### PR TITLE
Fix SDK_VERSION constant to match package.json 0.2.0

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.1.2';
+export const SDK_VERSION = '0.2.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/test/http-client.spec.ts
+++ b/test/http-client.spec.ts
@@ -2,6 +2,18 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { httpRequest } from '../src/http-client.js';
 import { globalConfiguration, init } from '../src/configuration.js';
 import { AISecSDKException } from '../src/errors.js';
+import { SDK_VERSION, USER_AGENT } from '../src/constants.js';
+import pkg from '../package.json' with { type: 'json' };
+
+describe('SDK_VERSION', () => {
+  it('matches package.json version', () => {
+    expect(SDK_VERSION).toBe(pkg.version);
+  });
+
+  it('is embedded in USER_AGENT string', () => {
+    expect(USER_AGENT).toContain(SDK_VERSION);
+  });
+});
 
 describe('httpRequest', () => {
   const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary
- Fix `SDK_VERSION` in `src/constants.ts` from `'0.1.2'` to `'0.2.0'` to match `package.json`
- Add tests verifying SDK_VERSION matches package.json and is embedded in USER_AGENT

Closes #2

## Test plan
- [x] New test: `SDK_VERSION matches package.json version`
- [x] New test: `SDK_VERSION is embedded in USER_AGENT string`
- [x] All 143 tests pass
- [x] Lint/format/typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)