### PR TITLE
Replace pnpm references with npm in docs

### DIFF
--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -239,7 +239,7 @@ try {
 cp .env.example .env
 
 # Run examples
-pnpm example:mgmt-auth
-pnpm example:mgmt-profiles
-pnpm example:mgmt-topics
+npm run example:mgmt-auth
+npm run example:mgmt-profiles
+npm run example:mgmt-topics
 ```

--- a/docs/sdk-overview.md
+++ b/docs/sdk-overview.md
@@ -120,10 +120,10 @@ npm run typecheck      # tsc --noEmit
 
 ```bash
 cp .env.example .env   # fill in credentials
-pnpm example:scan
-pnpm example:async-scan
-pnpm example:query
-pnpm example:mgmt-auth
-pnpm example:mgmt-profiles
-pnpm example:mgmt-topics
+npm run example:scan
+npm run example:async-scan
+npm run example:query
+npm run example:mgmt-auth
+npm run example:mgmt-profiles
+npm run example:mgmt-topics
 ```


### PR DESCRIPTION
## Summary
- Replace `pnpm` with `npm run` in `docs/sdk-overview.md` (6 references)
- Replace `pnpm` with `npm run` in `docs/management-api.md` (3 references)

Closes #3

## Test plan
- [x] No pnpm references remain in docs
- [x] All commands are correct `npm run` equivalents
- [x] All 143 tests pass
- [x] Lint/format/typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)