### PR TITLE
Extract shared HTTP retry logic into utility

### DIFF
--- a/docs/sdk-overview.md
+++ b/docs/sdk-overview.md
@@ -89,6 +89,7 @@ src/
 ├── constants.ts              # endpoints, env var names, limits, paths
 ├── errors.ts                 # AISecSDKException + ErrorType enum
 ├── http-client.ts            # scan API fetch wrapper (API key/token auth)
+├── http-retry.ts             # shared retry logic (exponential backoff)
 ├── utils.ts                  # UUID validation, HMAC payload hash
 ├── scan/
 │   ├── scanner.ts            # Scanner class (syncScan, asyncScan, query*)

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -7,9 +7,9 @@ import {
   BEARER,
   PAYLOAD_HASH,
   USER_AGENT,
-  HTTP_FORCE_RETRY_STATUS_CODES,
 } from './constants.js';
 import { AISecSDKException, ErrorType } from './errors.js';
+import { executeWithRetry } from './http-retry.js';
 import { generatePayloadHash } from './utils.js';
 
 export interface HttpRequestOptions {
@@ -41,10 +41,6 @@ function buildHeaders(): Record<string, string> {
   return headers;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export async function httpRequest<T>(opts: HttpRequestOptions): Promise<HttpResponse<T>> {
   if (!globalConfiguration.initialized) {
     throw new AISecSDKException(
@@ -66,60 +62,21 @@ export async function httpRequest<T>(opts: HttpRequestOptions): Promise<HttpResp
   let bodyStr: string | undefined;
   if (opts.body !== undefined) {
     bodyStr = JSON.stringify(opts.body);
-    // Add payload hash if api key is present
     if (globalConfiguration.apiKey) {
       headers[PAYLOAD_HASH] = generatePayloadHash(bodyStr, globalConfiguration.apiKey);
     }
   }
 
-  const maxRetries = globalConfiguration.numRetries;
-  let lastError: Error | undefined;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const response = await fetch(url.toString(), {
+  const response = await executeWithRetry({
+    maxRetries: globalConfiguration.numRetries,
+    execute: () =>
+      fetch(url.toString(), {
         method: opts.method,
         headers,
         body: bodyStr,
-      });
+      }),
+  });
 
-      if (response.ok) {
-        const data = (await response.json()) as T;
-        return { status: response.status, data };
-      }
-
-      // Check if retryable
-      if (HTTP_FORCE_RETRY_STATUS_CODES.includes(response.status) && attempt < maxRetries) {
-        await sleep(Math.pow(2, attempt) * 1000);
-        continue;
-      }
-
-      // Non-retryable error
-      let errorMessage: string;
-      try {
-        const errorBody = await response.json();
-        errorMessage =
-          ((errorBody as Record<string, unknown>).message as string) ??
-          ((errorBody as Record<string, Record<string, unknown>>).error?.message as string) ??
-          `API error ${response.status}`;
-      } catch {
-        errorMessage = `API error ${response.status}`;
-      }
-
-      const errorType =
-        response.status >= 500 ? ErrorType.SERVER_SIDE_ERROR : ErrorType.CLIENT_SIDE_ERROR;
-      throw new AISecSDKException(errorMessage, errorType);
-    } catch (err) {
-      if (err instanceof AISecSDKException) {
-        throw err;
-      }
-      lastError = err as Error;
-      if (attempt < maxRetries) {
-        await sleep(Math.pow(2, attempt) * 1000);
-        continue;
-      }
-    }
-  }
-
-  throw new AISecSDKException(lastError?.message ?? 'Network error', ErrorType.CLIENT_SIDE_ERROR);
+  const data = (await response.json()) as T;
+  return { status: response.status, data };
 }

--- a/src/http-retry.ts
+++ b/src/http-retry.ts
@@ -1,0 +1,90 @@
+// src/http-retry.ts — shared retry logic for HTTP clients
+
+import { HTTP_FORCE_RETRY_STATUS_CODES } from './constants.js';
+import { AISecSDKException, ErrorType } from './errors.js';
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function backoffDelay(attempt: number): number {
+  return Math.pow(2, attempt) * 1000;
+}
+
+export function isRetryableStatus(status: number): boolean {
+  return HTTP_FORCE_RETRY_STATUS_CODES.includes(status);
+}
+
+export function classifyErrorType(status: number): ErrorType {
+  return status >= 500 ? ErrorType.SERVER_SIDE_ERROR : ErrorType.CLIENT_SIDE_ERROR;
+}
+
+export function extractErrorMessage(body: string, status: number): string {
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    return (
+      (parsed.error_message as string) ??
+      (parsed.message as string) ??
+      ((parsed.error as Record<string, unknown> | undefined)?.message as string) ??
+      `API error ${status}`
+    );
+  } catch {
+    return body ? `API error ${status}: ${body}` : `API error ${status}`;
+  }
+}
+
+export interface RetryOptions {
+  maxRetries: number;
+  execute: (attempt: number) => Promise<Response>;
+  onRetryableFailure?: (response: Response, attempt: number) => Promise<boolean>;
+}
+
+export async function executeWithRetry(opts: RetryOptions): Promise<Response> {
+  const { maxRetries, execute, onRetryableFailure } = opts;
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let response: Response;
+    try {
+      response = await execute(attempt);
+    } catch (err) {
+      if (err instanceof AISecSDKException) throw err;
+      lastError = err as Error;
+      if (attempt < maxRetries) {
+        await sleep(backoffDelay(attempt));
+        continue;
+      }
+      throw new AISecSDKException(
+        lastError.message ?? 'Network error',
+        ErrorType.CLIENT_SIDE_ERROR,
+      );
+    }
+
+    if (response.ok) return response;
+
+    // Let caller handle special status codes (e.g. 401 token refresh)
+    // When handled, decrement attempt so it doesn't count against retry budget
+    if (onRetryableFailure) {
+      const handled = await onRetryableFailure(response, attempt);
+      if (handled) {
+        attempt--;
+        continue;
+      }
+    }
+
+    if (isRetryableStatus(response.status) && attempt < maxRetries) {
+      await sleep(backoffDelay(attempt));
+      continue;
+    }
+
+    // Non-retryable error
+    const errorText = await response.text();
+    const errorMessage = extractErrorMessage(errorText, response.status);
+    throw new AISecSDKException(errorMessage, classifyErrorType(response.status));
+  }
+
+  throw new AISecSDKException(
+    lastError?.message ?? 'Max retries exceeded',
+    ErrorType.CLIENT_SIDE_ERROR,
+  );
+}

--- a/src/management/management-http-client.ts
+++ b/src/management/management-http-client.ts
@@ -1,5 +1,5 @@
-import { USER_AGENT, HTTP_FORCE_RETRY_STATUS_CODES } from '../constants.js';
-import { AISecSDKException, ErrorType } from '../errors.js';
+import { USER_AGENT } from '../constants.js';
+import { executeWithRetry } from '../http-retry.js';
 import type { OAuthClient } from './oauth-client.js';
 
 export interface MgmtHttpRequestOptions {
@@ -17,96 +17,49 @@ export interface MgmtHttpResponse<T = unknown> {
   data: T;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function extractError(body: string, status: number): string {
-  try {
-    const parsed = JSON.parse(body) as Record<string, unknown>;
-    return (
-      (parsed.error_message as string) ??
-      (parsed.message as string) ??
-      `API error ${status}: ${body}`
-    );
-  } catch {
-    return body ? `API error ${status}: ${body}` : `API error ${status}`;
-  }
-}
-
 export async function managementHttpRequest<T>(
   opts: MgmtHttpRequestOptions,
 ): Promise<MgmtHttpResponse<T>> {
   const { method, baseUrl, path, body, params, oauthClient, numRetries } = opts;
   let hadTokenRefresh = false;
 
-  for (let attempt = 0; attempt <= numRetries; attempt++) {
-    const token = await oauthClient.getToken();
-    const stripped = baseUrl.replace(/\/+$/, '');
-    const url = new URL(`${stripped}${path}`);
+  const response = await executeWithRetry({
+    maxRetries: numRetries,
+    execute: async () => {
+      const token = await oauthClient.getToken();
+      const stripped = baseUrl.replace(/\/+$/, '');
+      const url = new URL(`${stripped}${path}`);
 
-    if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        url.searchParams.set(key, value);
+      if (params) {
+        for (const [key, value] of Object.entries(params)) {
+          url.searchParams.set(key, value);
+        }
       }
-    }
 
-    const headers: Record<string, string> = {
-      Authorization: `Bearer ${token}`,
-      'User-Agent': USER_AGENT,
-    };
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        'User-Agent': USER_AGENT,
+      };
 
-    let bodyStr: string | undefined;
-    if (body !== undefined) {
-      headers['Content-Type'] = 'application/json';
-      bodyStr = JSON.stringify(body);
-    }
-
-    let response: Response;
-    try {
-      response = await fetch(url.toString(), {
-        method,
-        headers,
-        body: bodyStr,
-      });
-    } catch (err) {
-      if (attempt < numRetries) {
-        await sleep(Math.pow(2, attempt) * 1000);
-        continue;
+      let bodyStr: string | undefined;
+      if (body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+        bodyStr = JSON.stringify(body);
       }
-      throw new AISecSDKException(
-        (err as Error).message ?? 'Network error',
-        ErrorType.CLIENT_SIDE_ERROR,
-      );
-    }
 
-    if (response.ok) {
-      const text = await response.text();
-      const data = text ? (JSON.parse(text) as T) : ({} as T);
-      return { status: response.status, data };
-    }
+      return fetch(url.toString(), { method, headers, body: bodyStr });
+    },
+    onRetryableFailure: async (response) => {
+      if (response.status === 401 && !hadTokenRefresh) {
+        hadTokenRefresh = true;
+        oauthClient.clearToken();
+        return true;
+      }
+      return false;
+    },
+  });
 
-    // 401: clear token and retry once (doesn't count against retry budget)
-    if (response.status === 401 && !hadTokenRefresh) {
-      hadTokenRefresh = true;
-      oauthClient.clearToken();
-      attempt--;
-      continue;
-    }
-
-    // Retryable 5xx
-    if (HTTP_FORCE_RETRY_STATUS_CODES.includes(response.status) && attempt < numRetries) {
-      await sleep(Math.pow(2, attempt) * 1000);
-      continue;
-    }
-
-    // Non-retryable error
-    const errorText = await response.text();
-    const errorMessage = extractError(errorText, response.status);
-    const errorType =
-      response.status >= 500 ? ErrorType.SERVER_SIDE_ERROR : ErrorType.CLIENT_SIDE_ERROR;
-    throw new AISecSDKException(errorMessage, errorType);
-  }
-
-  throw new AISecSDKException('Max retries exceeded', ErrorType.CLIENT_SIDE_ERROR);
+  const text = await response.text();
+  const data = text ? (JSON.parse(text) as T) : ({} as T);
+  return { status: response.status, data };
 }

--- a/test/http-client.spec.ts
+++ b/test/http-client.spec.ts
@@ -90,7 +90,7 @@ describe('httpRequest', () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 400,
-      json: () => Promise.resolve({ message: 'Bad request' }),
+      text: () => Promise.resolve(JSON.stringify({ message: 'Bad request' })),
     });
 
     await expect(httpRequest({ method: 'GET', path: '/test' })).rejects.toThrow(AISecSDKException);

--- a/test/http-retry.spec.ts
+++ b/test/http-retry.spec.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  sleep,
+  backoffDelay,
+  isRetryableStatus,
+  classifyErrorType,
+  extractErrorMessage,
+  executeWithRetry,
+} from '../src/http-retry.js';
+import { AISecSDKException, ErrorType } from '../src/errors.js';
+
+describe('sleep', () => {
+  it('resolves after delay', async () => {
+    const start = Date.now();
+    await sleep(50);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(40);
+  });
+});
+
+describe('backoffDelay', () => {
+  it('returns exponential delays', () => {
+    expect(backoffDelay(0)).toBe(1000);
+    expect(backoffDelay(1)).toBe(2000);
+    expect(backoffDelay(2)).toBe(4000);
+    expect(backoffDelay(3)).toBe(8000);
+  });
+});
+
+describe('isRetryableStatus', () => {
+  it('returns true for 5xx retry codes', () => {
+    expect(isRetryableStatus(500)).toBe(true);
+    expect(isRetryableStatus(502)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+    expect(isRetryableStatus(504)).toBe(true);
+  });
+
+  it('returns false for non-retryable codes', () => {
+    expect(isRetryableStatus(400)).toBe(false);
+    expect(isRetryableStatus(401)).toBe(false);
+    expect(isRetryableStatus(404)).toBe(false);
+    expect(isRetryableStatus(200)).toBe(false);
+    expect(isRetryableStatus(501)).toBe(false);
+  });
+});
+
+describe('classifyErrorType', () => {
+  it('returns SERVER_SIDE_ERROR for 5xx', () => {
+    expect(classifyErrorType(500)).toBe(ErrorType.SERVER_SIDE_ERROR);
+    expect(classifyErrorType(503)).toBe(ErrorType.SERVER_SIDE_ERROR);
+  });
+
+  it('returns CLIENT_SIDE_ERROR for 4xx', () => {
+    expect(classifyErrorType(400)).toBe(ErrorType.CLIENT_SIDE_ERROR);
+    expect(classifyErrorType(404)).toBe(ErrorType.CLIENT_SIDE_ERROR);
+  });
+});
+
+describe('extractErrorMessage', () => {
+  it('extracts error_message field', () => {
+    expect(extractErrorMessage(JSON.stringify({ error_message: 'bad input' }), 400)).toBe(
+      'bad input',
+    );
+  });
+
+  it('falls back to message field', () => {
+    expect(extractErrorMessage(JSON.stringify({ message: 'not found' }), 404)).toBe('not found');
+  });
+
+  it('falls back to error.message field', () => {
+    expect(extractErrorMessage(JSON.stringify({ error: { message: 'nested error' } }), 500)).toBe(
+      'nested error',
+    );
+  });
+
+  it('falls back to generic message for unknown JSON', () => {
+    expect(extractErrorMessage(JSON.stringify({ code: 'UNKNOWN' }), 422)).toBe('API error 422');
+  });
+
+  it('handles non-JSON body', () => {
+    expect(extractErrorMessage('Bad Gateway', 502)).toBe('API error 502: Bad Gateway');
+  });
+
+  it('handles empty body', () => {
+    expect(extractErrorMessage('', 500)).toBe('API error 500');
+  });
+});
+
+describe('executeWithRetry', () => {
+  it('returns successful response', async () => {
+    const response = new Response(JSON.stringify({ ok: true }), { status: 200 });
+    const execute = vi.fn().mockResolvedValue(response);
+
+    const result = await executeWithRetry({ maxRetries: 0, execute });
+    expect(result).toBe(response);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on retryable status codes', async () => {
+    const failResponse = new Response('error', { status: 503 });
+    Object.defineProperty(failResponse, 'ok', { value: false });
+    const successResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce(failResponse)
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await executeWithRetry({ maxRetries: 1, execute });
+    expect(result).toBe(successResponse);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on network errors', async () => {
+    const successResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('connection reset'))
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await executeWithRetry({ maxRetries: 1, execute });
+    expect(result).toBe(successResponse);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting retries on network error', async () => {
+    const execute = vi.fn().mockRejectedValue(new Error('network down'));
+
+    await expect(executeWithRetry({ maxRetries: 0, execute })).rejects.toThrow(AISecSDKException);
+    await expect(executeWithRetry({ maxRetries: 0, execute })).rejects.toThrow(/network down/);
+  });
+
+  it('throws non-retryable errors immediately', async () => {
+    const response = new Response(JSON.stringify({ message: 'bad request' }), { status: 400 });
+    Object.defineProperty(response, 'ok', { value: false });
+
+    const execute = vi.fn().mockResolvedValue(response);
+
+    await expect(executeWithRetry({ maxRetries: 3, execute })).rejects.toThrow(AISecSDKException);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows AISecSDKException without wrapping', async () => {
+    const sdkError = new AISecSDKException('custom error', ErrorType.MISSING_VARIABLE);
+    const execute = vi.fn().mockRejectedValue(sdkError);
+
+    await expect(executeWithRetry({ maxRetries: 1, execute })).rejects.toBe(sdkError);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onRetryableFailure for custom handling', async () => {
+    const failResponse = new Response('', { status: 401 });
+    Object.defineProperty(failResponse, 'ok', { value: false });
+    const successResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce(failResponse)
+      .mockResolvedValueOnce(successResponse);
+
+    const onRetryableFailure = vi.fn().mockResolvedValue(true);
+
+    const result = await executeWithRetry({
+      maxRetries: 1,
+      execute,
+      onRetryableFailure,
+    });
+
+    expect(result).toBe(successResponse);
+    expect(onRetryableFailure).toHaveBeenCalledWith(failResponse, 0);
+  });
+
+  it('falls through when onRetryableFailure returns false', async () => {
+    const response = new Response(JSON.stringify({ message: 'unauthorized' }), { status: 401 });
+    Object.defineProperty(response, 'ok', { value: false });
+
+    const execute = vi.fn().mockResolvedValue(response);
+    const onRetryableFailure = vi.fn().mockResolvedValue(false);
+
+    await expect(executeWithRetry({ maxRetries: 0, execute, onRetryableFailure })).rejects.toThrow(
+      AISecSDKException,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `executeWithRetry()`, `sleep()`, `backoffDelay()`, `isRetryableStatus()`, `classifyErrorType()`, `extractErrorMessage()` into `src/http-retry.ts`
- Refactor `src/http-client.ts` to use shared retry (removed ~45 lines of duplication)
- Refactor `src/management/management-http-client.ts` to use shared retry
- 401 token refresh preserved via `onRetryableFailure` callback pattern
- Update docs project structure

Closes #4

## Test plan
- [x] 20 new tests for `http-retry.ts` utility
- [x] All 163 tests pass (no regressions)
- [x] 100% coverage on http-client.ts, 98.48% on http-retry.ts
- [x] Lint/format/typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)