### PR TITLE
Add typed enums for verdict, action, and category

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -222,6 +222,33 @@ interface DeleteTopicConflict {
 
 ---
 
+## Enums
+
+Typed const objects for AIRS API verdict, action, and category values.
+
+```ts
+import { Verdict, Action, Category } from '@cdot65/prisma-airs-sdk';
+
+// Verdict — scan result classification
+Verdict.BENIGN; // 'benign'
+Verdict.MALICIOUS; // 'malicious'
+Verdict.UNKNOWN; // 'unknown'
+
+// Action — enforcement action taken
+Action.ALLOW; // 'allow'
+Action.BLOCK; // 'block'
+Action.ALERT; // 'alert'
+
+// Category — top-level scan category
+Category.BENIGN; // 'benign'
+Category.MALICIOUS; // 'malicious'
+Category.UNKNOWN; // 'unknown'
+```
+
+Types are also exported: `Verdict`, `Action`, `Category` (union of literal string values).
+
+---
+
 ## Error Types
 
 ```ts

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -1,0 +1,25 @@
+// src/models/enums.ts — typed enums for AIRS API verdict/action/category values
+
+export const Verdict = {
+  BENIGN: 'benign',
+  MALICIOUS: 'malicious',
+  UNKNOWN: 'unknown',
+} as const;
+
+export type Verdict = (typeof Verdict)[keyof typeof Verdict];
+
+export const Action = {
+  ALLOW: 'allow',
+  BLOCK: 'block',
+  ALERT: 'alert',
+} as const;
+
+export type Action = (typeof Action)[keyof typeof Action];
+
+export const Category = {
+  BENIGN: 'benign',
+  MALICIOUS: 'malicious',
+  UNKNOWN: 'unknown',
+} as const;
+
+export type Category = (typeof Category)[keyof typeof Category];

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,3 +1,9 @@
+export { Verdict, Action, Category } from './enums.js';
+export type {
+  Verdict as VerdictType,
+  Action as ActionType,
+  Category as CategoryType,
+} from './enums.js';
 export { AiProfileSchema, type AiProfile } from './ai-profile.js';
 export { AgentMetaSchema, type AgentMeta, MetadataSchema, type Metadata } from './metadata.js';
 export {

--- a/test/models/enums.spec.ts
+++ b/test/models/enums.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { Verdict, Action, Category } from '../../src/models/enums.js';
+
+describe('Verdict', () => {
+  it('has expected values', () => {
+    expect(Verdict.BENIGN).toBe('benign');
+    expect(Verdict.MALICIOUS).toBe('malicious');
+    expect(Verdict.UNKNOWN).toBe('unknown');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(Verdict)).toHaveLength(3);
+  });
+
+  it('values are assignable to Verdict type', () => {
+    const v: Verdict = Verdict.BENIGN;
+    expect(v).toBe('benign');
+  });
+});
+
+describe('Action', () => {
+  it('has expected values', () => {
+    expect(Action.ALLOW).toBe('allow');
+    expect(Action.BLOCK).toBe('block');
+    expect(Action.ALERT).toBe('alert');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(Action)).toHaveLength(3);
+  });
+
+  it('values are assignable to Action type', () => {
+    const a: Action = Action.BLOCK;
+    expect(a).toBe('block');
+  });
+});
+
+describe('Category', () => {
+  it('has expected values', () => {
+    expect(Category.BENIGN).toBe('benign');
+    expect(Category.MALICIOUS).toBe('malicious');
+    expect(Category.UNKNOWN).toBe('unknown');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(Category)).toHaveLength(3);
+  });
+
+  it('values are assignable to Category type', () => {
+    const c: Category = Category.MALICIOUS;
+    expect(c).toBe('malicious');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `Verdict`, `Action`, `Category` const objects with literal string types
- Export from models barrel and main SDK export
- Update API reference docs with enum documentation

Closes #6

## Test plan
- [x] 9 new tests for enum values, counts, and type assignability
- [x] All 172 tests pass
- [x] Lint/format/typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)