### PR TITLE
Add JSDoc/TSDoc to all exported symbols

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -11,10 +11,15 @@ import {
 } from './constants.js';
 import { AISecSDKException, ErrorType } from './errors.js';
 
+/** Options for initializing the global scan API configuration. */
 export interface InitOptions {
+  /** AIRS API key. Falls back to `PANW_AI_SEC_API_KEY` env var. */
   apiKey?: string;
+  /** Pre-obtained bearer token. Falls back to `PANW_AI_SEC_API_TOKEN` env var. */
   apiToken?: string;
+  /** AIRS API endpoint URL. Falls back to `PANW_AI_SEC_API_ENDPOINT` env var. */
   apiEndpoint?: string;
+  /** Max retry attempts (0–5). Defaults to 5. */
   numRetries?: number;
 }
 
@@ -97,8 +102,14 @@ class Configuration {
   }
 }
 
+/** Global singleton holding scan API configuration. */
 export const globalConfiguration = new Configuration();
 
+/**
+ * Initialize the global scan API configuration. Must be called before using {@link Scanner}.
+ * @param opts - Configuration options. Reads env vars as fallbacks.
+ * @throws {AISecSDKException} If neither apiKey nor apiToken is provided.
+ */
 export function init(opts: InitOptions = {}): void {
   globalConfiguration.init(opts);
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,17 +1,32 @@
 // src/errors.ts — mirrors Python SDK exceptions.py
 
+/** Classification of SDK errors by origin. */
 export enum ErrorType {
+  /** 5xx response from the AIRS API. */
   SERVER_SIDE_ERROR = 'AISEC_SERVER_SIDE_ERROR',
+  /** 4xx response or network failure. */
   CLIENT_SIDE_ERROR = 'AISEC_CLIENT_SIDE_ERROR',
+  /** Invalid user-supplied input (bad UUID, oversized content, etc.). */
   USER_REQUEST_PAYLOAD_ERROR = 'AISEC_USER_REQUEST_PAYLOAD_ERROR',
+  /** Required configuration value is missing. */
   MISSING_VARIABLE = 'AISEC_MISSING_VARIABLE',
+  /** Internal SDK error. */
   AISEC_SDK_ERROR = 'AISEC_SDK_ERROR',
+  /** OAuth2 token fetch failure. */
   OAUTH_ERROR = 'AISEC_OAUTH_ERROR',
 }
 
+/**
+ * Base exception for all AIRS SDK errors.
+ * The `errorType` field classifies the error origin.
+ */
 export class AISecSDKException extends Error {
   public readonly errorType?: ErrorType;
 
+  /**
+   * @param message - Human-readable error description.
+   * @param errorType - Classification of the error.
+   */
   constructor(message: string, errorType?: ErrorType) {
     super(errorType ? `${errorType}:${message}` : message);
     this.name = 'AISecSDKException';

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -12,15 +12,23 @@ import { AISecSDKException, ErrorType } from './errors.js';
 import { executeWithRetry } from './http-retry.js';
 import { generatePayloadHash } from './utils.js';
 
+/** Options for a scan API HTTP request. */
 export interface HttpRequestOptions {
+  /** HTTP method. */
   method: 'GET' | 'POST';
+  /** API path (appended to the configured endpoint). */
   path: string;
+  /** Request body (JSON-serialized). */
   body?: unknown;
+  /** URL query parameters. */
   params?: Record<string, string>;
 }
 
+/** Typed HTTP response wrapper. */
 export interface HttpResponse<T = unknown> {
+  /** HTTP status code. */
   status: number;
+  /** Parsed response body. */
   data: T;
 }
 

--- a/src/http-retry.ts
+++ b/src/http-retry.ts
@@ -3,22 +3,45 @@
 import { HTTP_FORCE_RETRY_STATUS_CODES } from './constants.js';
 import { AISecSDKException, ErrorType } from './errors.js';
 
+/**
+ * Sleep for the given number of milliseconds.
+ * @param ms - Milliseconds to wait.
+ */
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Calculate exponential backoff delay for the given attempt.
+ * @param attempt - Zero-based attempt number.
+ * @returns Delay in milliseconds.
+ */
 export function backoffDelay(attempt: number): number {
   return Math.pow(2, attempt) * 1000;
 }
 
+/**
+ * Check if an HTTP status code should trigger a retry.
+ * @param status - HTTP status code.
+ */
 export function isRetryableStatus(status: number): boolean {
   return HTTP_FORCE_RETRY_STATUS_CODES.includes(status);
 }
 
+/**
+ * Classify an HTTP status code as server-side or client-side error.
+ * @param status - HTTP status code.
+ */
 export function classifyErrorType(status: number): ErrorType {
   return status >= 500 ? ErrorType.SERVER_SIDE_ERROR : ErrorType.CLIENT_SIDE_ERROR;
 }
 
+/**
+ * Extract a human-readable error message from an API error response body.
+ * Tries `error_message`, `message`, and `error.message` fields in order.
+ * @param body - Raw response body string.
+ * @param status - HTTP status code for fallback message.
+ */
 export function extractErrorMessage(body: string, status: number): string {
   try {
     const parsed = JSON.parse(body) as Record<string, unknown>;
@@ -33,12 +56,22 @@ export function extractErrorMessage(body: string, status: number): string {
   }
 }
 
+/** Options for {@link executeWithRetry}. */
 export interface RetryOptions {
+  /** Maximum number of retry attempts. */
   maxRetries: number;
+  /** Function that performs the HTTP request for each attempt. */
   execute: (attempt: number) => Promise<Response>;
+  /** Optional callback for handling special failure cases (e.g. 401 token refresh). Return true to retry without consuming the retry budget. */
   onRetryableFailure?: (response: Response, attempt: number) => Promise<boolean>;
 }
 
+/**
+ * Execute an HTTP request with exponential backoff retry.
+ * @param opts - Retry configuration and request function.
+ * @returns Successful HTTP Response.
+ * @throws {AISecSDKException} After exhausting retries or on non-retryable errors.
+ */
 export async function executeWithRetry(opts: RetryOptions): Promise<Response> {
   const { maxRetries, execute, onRetryableFailure } = opts;
   let lastError: Error | undefined;

--- a/src/management/client.ts
+++ b/src/management/client.ts
@@ -12,15 +12,26 @@ import { OAuthClient } from './oauth-client.js';
 import { ProfilesClient } from './profiles.js';
 import { TopicsClient } from './topics.js';
 
+/** Options for constructing a {@link ManagementClient}. */
 export interface ManagementClientOptions {
+  /** OAuth2 client ID. Falls back to `PANW_MGMT_CLIENT_ID` env var. */
   clientId?: string;
+  /** OAuth2 client secret. Falls back to `PANW_MGMT_CLIENT_SECRET` env var. */
   clientSecret?: string;
+  /** Tenant Service Group ID. Falls back to `PANW_MGMT_TSG_ID` env var. */
   tsgId?: string;
+  /** Management API endpoint URL. Falls back to `PANW_MGMT_ENDPOINT` env var. */
   apiEndpoint?: string;
+  /** OAuth2 token endpoint URL. Falls back to `PANW_MGMT_TOKEN_ENDPOINT` env var. */
   tokenEndpoint?: string;
+  /** Max retry attempts (0–5). Defaults to 5. */
   numRetries?: number;
 }
 
+/**
+ * Client for AIRS management API operations (profiles and topics CRUD).
+ * Authenticates via OAuth2 client_credentials flow.
+ */
 export class ManagementClient {
   public readonly profiles: ProfilesClient;
   public readonly topics: TopicsClient;

--- a/src/management/management-http-client.ts
+++ b/src/management/management-http-client.ts
@@ -2,6 +2,7 @@ import { USER_AGENT } from '../constants.js';
 import { executeWithRetry } from '../http-retry.js';
 import type { OAuthClient } from './oauth-client.js';
 
+/** @internal Options for a management API HTTP request. */
 export interface MgmtHttpRequestOptions {
   method: 'GET' | 'POST' | 'PUT' | 'DELETE';
   baseUrl: string;
@@ -12,6 +13,7 @@ export interface MgmtHttpRequestOptions {
   numRetries: number;
 }
 
+/** @internal Typed management API HTTP response. */
 export interface MgmtHttpResponse<T = unknown> {
   status: number;
   data: T;

--- a/src/management/oauth-client.ts
+++ b/src/management/oauth-client.ts
@@ -2,15 +2,24 @@ import { DEFAULT_TOKEN_ENDPOINT } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { OAuthTokenResponseSchema } from '../models/oauth-token.js';
 
+/** Options for constructing an {@link OAuthClient}. */
 export interface OAuthClientOptions {
+  /** OAuth2 client ID. */
   clientId: string;
+  /** OAuth2 client secret. */
   clientSecret: string;
+  /** Tenant Service Group ID. */
   tsgId: string;
+  /** OAuth2 token endpoint URL. Defaults to Palo Alto Networks auth endpoint. */
   tokenEndpoint?: string;
 }
 
 const TOKEN_BUFFER_MS = 30_000; // refresh 30s before expiry
 
+/**
+ * OAuth2 client_credentials token manager.
+ * Caches tokens, refreshes before expiry, and deduplicates concurrent requests.
+ */
 export class OAuthClient {
   public readonly tokenEndpoint: string;
   private readonly clientId: string;
@@ -28,6 +37,10 @@ export class OAuthClient {
     this.tokenEndpoint = opts.tokenEndpoint ?? DEFAULT_TOKEN_ENDPOINT;
   }
 
+  /**
+   * Get a valid access token, refreshing if needed.
+   * @returns Bearer access token string.
+   */
   async getToken(): Promise<string> {
     if (this.accessToken && Date.now() < this.expiresAt - TOKEN_BUFFER_MS) {
       return this.accessToken;
@@ -44,6 +57,7 @@ export class OAuthClient {
     return this.pendingFetch;
   }
 
+  /** Clear the cached token, forcing a fresh fetch on next call. */
   clearToken(): void {
     this.accessToken = null;
     this.expiresAt = 0;

--- a/src/management/profiles.ts
+++ b/src/management/profiles.ts
@@ -10,11 +10,15 @@ import type {
   DeleteProfileResponse,
 } from '../models/mgmt-security-profile.js';
 
+/** Pagination parameters for list operations. */
 export interface PaginationOptions {
+  /** Starting offset. Defaults to 0. */
   offset?: number;
+  /** Max items to return. Defaults to 100. */
   limit?: number;
 }
 
+/** @internal */
 export interface ProfilesClientOptions {
   baseUrl: string;
   oauthClient: OAuthClient;
@@ -22,6 +26,7 @@ export interface ProfilesClientOptions {
   numRetries: number;
 }
 
+/** Client for AIRS security profile CRUD operations. */
 export class ProfilesClient {
   private readonly baseUrl: string;
   private readonly oauthClient: OAuthClient;
@@ -35,6 +40,11 @@ export class ProfilesClient {
     this.numRetries = opts.numRetries;
   }
 
+  /**
+   * Create a new security profile.
+   * @param request - Profile configuration.
+   * @returns The created security profile.
+   */
   async create(request: CreateSecurityProfileRequest): Promise<SecurityProfile> {
     const res = await managementHttpRequest<SecurityProfile>({
       method: 'POST',
@@ -47,6 +57,11 @@ export class ProfilesClient {
     return res.data;
   }
 
+  /**
+   * List security profiles for the TSG.
+   * @param opts - Pagination options.
+   * @returns Paginated list of security profiles.
+   */
   async list(opts?: PaginationOptions): Promise<SecurityProfileListResponse> {
     const params: Record<string, string> = {
       offset: String(opts?.offset ?? 0),
@@ -64,6 +79,12 @@ export class ProfilesClient {
     return res.data;
   }
 
+  /**
+   * Update an existing security profile.
+   * @param profileId - UUID of the profile to update.
+   * @param request - Updated profile configuration.
+   * @returns The updated security profile.
+   */
   async update(profileId: string, request: CreateSecurityProfileRequest): Promise<SecurityProfile> {
     if (!isValidUuid(profileId)) {
       throw new AISecSDKException(
@@ -83,6 +104,11 @@ export class ProfilesClient {
     return res.data;
   }
 
+  /**
+   * Delete a security profile.
+   * @param profileId - UUID of the profile to delete.
+   * @returns Deletion confirmation message.
+   */
   async delete(profileId: string): Promise<DeleteProfileResponse> {
     if (!isValidUuid(profileId)) {
       throw new AISecSDKException(

--- a/src/management/topics.ts
+++ b/src/management/topics.ts
@@ -11,6 +11,7 @@ import type {
 } from '../models/mgmt-custom-topic.js';
 import type { PaginationOptions } from './profiles.js';
 
+/** @internal */
 export interface TopicsClientOptions {
   baseUrl: string;
   oauthClient: OAuthClient;
@@ -18,6 +19,7 @@ export interface TopicsClientOptions {
   numRetries: number;
 }
 
+/** Client for AIRS custom topic CRUD operations. */
 export class TopicsClient {
   private readonly baseUrl: string;
   private readonly oauthClient: OAuthClient;
@@ -31,6 +33,11 @@ export class TopicsClient {
     this.numRetries = opts.numRetries;
   }
 
+  /**
+   * Create a new custom topic.
+   * @param request - Topic definition with name, description, and examples.
+   * @returns The created custom topic.
+   */
   async create(request: CreateCustomTopicRequest): Promise<CustomTopic> {
     const res = await managementHttpRequest<CustomTopic>({
       method: 'POST',
@@ -43,6 +50,11 @@ export class TopicsClient {
     return res.data;
   }
 
+  /**
+   * List custom topics for the TSG.
+   * @param opts - Pagination options.
+   * @returns Paginated list of custom topics.
+   */
   async list(opts?: PaginationOptions): Promise<CustomTopicListResponse> {
     const params: Record<string, string> = {
       offset: String(opts?.offset ?? 0),
@@ -60,6 +72,12 @@ export class TopicsClient {
     return res.data;
   }
 
+  /**
+   * Update an existing custom topic.
+   * @param topicId - UUID of the topic to update.
+   * @param request - Updated topic definition.
+   * @returns The updated custom topic.
+   */
   async update(topicId: string, request: CreateCustomTopicRequest): Promise<CustomTopic> {
     if (!isValidUuid(topicId)) {
       throw new AISecSDKException(
@@ -79,6 +97,11 @@ export class TopicsClient {
     return res.data;
   }
 
+  /**
+   * Delete a custom topic. Fails if topic is referenced by a profile.
+   * @param topicId - UUID of the topic to delete.
+   * @returns Deletion confirmation message.
+   */
   async delete(topicId: string): Promise<DeleteTopicResponse> {
     if (!isValidUuid(topicId)) {
       throw new AISecSDKException(
@@ -97,6 +120,11 @@ export class TopicsClient {
     return res.data;
   }
 
+  /**
+   * Force-delete a custom topic, removing it from any referencing profiles.
+   * @param topicId - UUID of the topic to force-delete.
+   * @returns Deletion confirmation message.
+   */
   async forceDelete(topicId: string): Promise<DeleteTopicResponse> {
     if (!isValidUuid(topicId)) {
       throw new AISecSDKException(

--- a/src/models/ai-profile.ts
+++ b/src/models/ai-profile.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { MAX_AI_PROFILE_NAME_LENGTH } from '../constants.js';
 
+/** Zod schema for AI security profile identifier. Requires profile_id or profile_name. */
 export const AiProfileSchema = z
   .object({
     profile_id: z.string().uuid().optional(),
@@ -10,4 +11,5 @@ export const AiProfileSchema = z
     message: 'Either profile_id or profile_name must be provided',
   });
 
+/** AI security profile identifier. At least one of profile_id or profile_name required. */
 export type AiProfile = z.infer<typeof AiProfileSchema>;

--- a/src/models/async-scan.ts
+++ b/src/models/async-scan.ts
@@ -1,13 +1,16 @@
 import { z } from 'zod';
 import { ScanRequestSchema } from './scan-request.js';
 
+/** Zod schema for an async scan batch item. */
 export const AsyncScanObjectSchema = z.object({
   req_id: z.number().int(),
   scan_req: ScanRequestSchema,
 });
 
+/** Async scan batch item containing a request ID and scan request. */
 export type AsyncScanObject = z.infer<typeof AsyncScanObjectSchema>;
 
+/** Zod schema for the async scan API response. */
 export const AsyncScanResponseSchema = z.object({
   received: z.string(),
   scan_id: z.string(),
@@ -15,4 +18,5 @@ export const AsyncScanResponseSchema = z.object({
   source: z.string().optional(),
 });
 
+/** Async scan API response with scan ID for later querying. */
 export type AsyncScanResponse = z.infer<typeof AsyncScanResponseSchema>;

--- a/src/models/detection.ts
+++ b/src/models/detection.ts
@@ -2,13 +2,16 @@ import { z } from 'zod';
 import { DlpReportSchema } from './dlp-report.js';
 import { UrlfEntrySchema } from './urlf-report.js';
 
+/** Zod schema for detection service detail results (URLF and DLP reports). */
 export const DSDetailResultSchema = z.object({
   urlf_report: z.array(UrlfEntrySchema).optional(),
   dlp_report: DlpReportSchema.optional(),
 });
 
+/** Detection service detail results containing URLF and DLP reports. */
 export type DSDetailResult = z.infer<typeof DSDetailResultSchema>;
 
+/** Zod schema for detection service result metadata (score and confidence). */
 export const DSResultMetadataSchema = z
   .object({
     score: z.number().optional(),
@@ -16,8 +19,10 @@ export const DSResultMetadataSchema = z
   })
   .passthrough();
 
+/** Detection service result metadata with score and confidence. */
 export type DSResultMetadata = z.infer<typeof DSResultMetadataSchema>;
 
+/** Zod schema for an individual detection service result. */
 export const DetectionServiceResultSchema = z.object({
   data_type: z.string().optional(),
   detection_service: z.string().optional(),
@@ -27,4 +32,5 @@ export const DetectionServiceResultSchema = z.object({
   result_detail: DSDetailResultSchema.optional(),
 });
 
+/** Individual detection service result with verdict, action, and details. */
 export type DetectionServiceResult = z.infer<typeof DetectionServiceResultSchema>;

--- a/src/models/dlp-report.ts
+++ b/src/models/dlp-report.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+/** Zod schema for a DLP (Data Loss Prevention) report. */
 export const DlpReportSchema = z.object({
   dlp_report_id: z.string().optional(),
   dlp_profile_name: z.string().optional(),
@@ -9,4 +10,5 @@ export const DlpReportSchema = z.object({
   data_pattern_rule2_verdict: z.string().optional(),
 });
 
+/** DLP report with profile info and data pattern rule verdicts. */
 export type DlpReport = z.infer<typeof DlpReportSchema>;

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -1,25 +1,31 @@
 // src/models/enums.ts — typed enums for AIRS API verdict/action/category values
 
+/** Scan result verdict classification. */
 export const Verdict = {
   BENIGN: 'benign',
   MALICIOUS: 'malicious',
   UNKNOWN: 'unknown',
 } as const;
 
+/** Union type of all possible verdict values. */
 export type Verdict = (typeof Verdict)[keyof typeof Verdict];
 
+/** Enforcement action taken by AIRS. */
 export const Action = {
   ALLOW: 'allow',
   BLOCK: 'block',
   ALERT: 'alert',
 } as const;
 
+/** Union type of all possible action values. */
 export type Action = (typeof Action)[keyof typeof Action];
 
+/** Top-level scan result category. */
 export const Category = {
   BENIGN: 'benign',
   MALICIOUS: 'malicious',
   UNKNOWN: 'unknown',
 } as const;
 
+/** Union type of all possible category values. */
 export type Category = (typeof Category)[keyof typeof Category];

--- a/src/models/error-response.ts
+++ b/src/models/error-response.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+/** Zod schema for an AIRS API error response. */
 export const ErrorResponseSchema = z.object({
   status_code: z.number().optional(),
   message: z.string().optional(),
@@ -17,4 +18,5 @@ export const ErrorResponseSchema = z.object({
     .optional(),
 });
 
+/** AIRS API error response with optional retry-after guidance. */
 export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -1,13 +1,16 @@
 import { z } from 'zod';
 
+/** Zod schema for AI agent metadata. */
 export const AgentMetaSchema = z.object({
   agent_id: z.string().optional(),
   agent_version: z.string().optional(),
   agent_arn: z.string().optional(),
 });
 
+/** AI agent metadata (agent ID, version, ARN). */
 export type AgentMeta = z.infer<typeof AgentMetaSchema>;
 
+/** Zod schema for scan request metadata. */
 export const MetadataSchema = z.object({
   app_name: z.string().optional(),
   app_user: z.string().optional(),
@@ -16,4 +19,5 @@ export const MetadataSchema = z.object({
   agent_meta: AgentMetaSchema.optional(),
 });
 
+/** Application metadata attached to scan requests. */
 export type Metadata = z.infer<typeof MetadataSchema>;

--- a/src/models/mgmt-custom-topic.ts
+++ b/src/models/mgmt-custom-topic.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+/** Zod schema for an AIRS custom topic. */
 export const CustomTopicSchema = z
   .object({
     topic_id: z.string().optional(),
@@ -15,8 +16,10 @@ export const CustomTopicSchema = z
   })
   .passthrough();
 
+/** AIRS custom topic with name, description, examples, and audit metadata. */
 export type CustomTopic = z.infer<typeof CustomTopicSchema>;
 
+/** Zod schema for a custom topic create/update request. */
 export const CreateCustomTopicRequestSchema = z
   .object({
     topic_id: z.string().optional(),
@@ -32,8 +35,10 @@ export const CreateCustomTopicRequestSchema = z
   })
   .passthrough();
 
+/** Request body for creating or updating a custom topic. */
 export type CreateCustomTopicRequest = z.infer<typeof CreateCustomTopicRequestSchema>;
 
+/** Zod schema for a paginated custom topic list response. */
 export const CustomTopicListResponseSchema = z
   .object({
     custom_topics: z.array(CustomTopicSchema),
@@ -41,16 +46,20 @@ export const CustomTopicListResponseSchema = z
   })
   .passthrough();
 
+/** Paginated list of custom topics. */
 export type CustomTopicListResponse = z.infer<typeof CustomTopicListResponseSchema>;
 
+/** Zod schema for a topic deletion response. */
 export const DeleteTopicResponseSchema = z
   .object({
     message: z.string(),
   })
   .passthrough();
 
+/** Response from deleting a custom topic. */
 export type DeleteTopicResponse = z.infer<typeof DeleteTopicResponseSchema>;
 
+/** Zod schema for a topic deletion conflict (409). */
 export const DeleteTopicConflictSchema = z
   .object({
     message: z.string(),
@@ -66,4 +75,5 @@ export const DeleteTopicConflictSchema = z
   })
   .passthrough();
 
+/** Conflict response when deleting a topic referenced by profiles. */
 export type DeleteTopicConflict = z.infer<typeof DeleteTopicConflictSchema>;

--- a/src/models/mgmt-security-profile.ts
+++ b/src/models/mgmt-security-profile.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+/** Zod schema for DLP data profile configuration. */
 export const DlpDataProfileSchema = z
   .object({
     profile_name: z.string(),
@@ -7,8 +8,10 @@ export const DlpDataProfileSchema = z
   })
   .passthrough();
 
+/** DLP data profile configuration. */
 export type DlpDataProfile = z.infer<typeof DlpDataProfileSchema>;
 
+/** Zod schema for DLP configuration. */
 export const DlpSchema = z
   .object({
     dlp_status: z.string().optional(),
@@ -16,8 +19,10 @@ export const DlpSchema = z
   })
   .passthrough();
 
+/** DLP configuration with status and data profiles. */
 export type Dlp = z.infer<typeof DlpSchema>;
 
+/** Zod schema for data leak detection settings. */
 export const DataLeakDetectionSchema = z
   .object({
     'data-leak-detection-status': z.string().optional(),
@@ -25,8 +30,10 @@ export const DataLeakDetectionSchema = z
   })
   .passthrough();
 
+/** Data leak detection settings. */
 export type DataLeakDetection = z.infer<typeof DataLeakDetectionSchema>;
 
+/** Zod schema for application protection settings. */
 export const AppProtectionSchema = z
   .object({
     'prompt-injection': z.string().optional(),
@@ -34,24 +41,30 @@ export const AppProtectionSchema = z
   })
   .passthrough();
 
+/** Application protection settings (prompt injection, jailbreak detection). */
 export type AppProtection = z.infer<typeof AppProtectionSchema>;
 
+/** Zod schema for model protection settings. */
 export const ModelProtectionSchema = z
   .object({
     'model-denial-of-service': z.string().optional(),
   })
   .passthrough();
 
+/** Model protection settings (DoS protection). */
 export type ModelProtection = z.infer<typeof ModelProtectionSchema>;
 
+/** Zod schema for agent protection settings. */
 export const AgentProtectionSchema = z
   .object({
     'malicious-agent-activity': z.string().optional(),
   })
   .passthrough();
 
+/** Agent protection settings (malicious agent activity detection). */
 export type AgentProtection = z.infer<typeof AgentProtectionSchema>;
 
+/** Zod schema for latency configuration. */
 export const LatencySchema = z
   .object({
     status: z.string().optional(),
@@ -59,16 +72,20 @@ export const LatencySchema = z
   })
   .passthrough();
 
+/** Latency configuration for inline scanning. */
 export type Latency = z.infer<typeof LatencySchema>;
 
+/** Zod schema for model configuration. */
 export const ModelConfigurationSchema = z
   .object({
     latency: LatencySchema.optional(),
   })
   .passthrough();
 
+/** Model configuration including latency settings. */
 export type ModelConfiguration = z.infer<typeof ModelConfigurationSchema>;
 
+/** Zod schema for the security profile policy. */
 export const PolicySchema = z
   .object({
     'data-leak-detection': DataLeakDetectionSchema.optional(),
@@ -79,8 +96,10 @@ export const PolicySchema = z
   })
   .passthrough();
 
+/** Security profile policy containing all protection and configuration settings. */
 export type Policy = z.infer<typeof PolicySchema>;
 
+/** Zod schema for an AIRS security profile. */
 export const SecurityProfileSchema = z
   .object({
     profile_id: z.string().optional(),
@@ -94,8 +113,10 @@ export const SecurityProfileSchema = z
   })
   .passthrough();
 
+/** AIRS security profile with name, policy, and audit metadata. */
 export type SecurityProfile = z.infer<typeof SecurityProfileSchema>;
 
+/** Zod schema for a security profile create/update request. */
 export const CreateSecurityProfileRequestSchema = z
   .object({
     profile_id: z.string().optional(),
@@ -109,8 +130,10 @@ export const CreateSecurityProfileRequestSchema = z
   })
   .passthrough();
 
+/** Request body for creating or updating a security profile. */
 export type CreateSecurityProfileRequest = z.infer<typeof CreateSecurityProfileRequestSchema>;
 
+/** Zod schema for a paginated security profile list response. */
 export const SecurityProfileListResponseSchema = z
   .object({
     ai_profiles: z.array(SecurityProfileSchema),
@@ -118,16 +141,20 @@ export const SecurityProfileListResponseSchema = z
   })
   .passthrough();
 
+/** Paginated list of security profiles. */
 export type SecurityProfileListResponse = z.infer<typeof SecurityProfileListResponseSchema>;
 
+/** Zod schema for a profile deletion response. */
 export const DeleteProfileResponseSchema = z
   .object({
     message: z.string(),
   })
   .passthrough();
 
+/** Response from deleting a security profile. */
 export type DeleteProfileResponse = z.infer<typeof DeleteProfileResponseSchema>;
 
+/** Zod schema for a profile deletion conflict (409). */
 export const DeleteProfileConflictSchema = z
   .object({
     message: z.string(),
@@ -143,4 +170,5 @@ export const DeleteProfileConflictSchema = z
   })
   .passthrough();
 
+/** Conflict response when deleting a profile referenced by policies. */
 export type DeleteProfileConflict = z.infer<typeof DeleteProfileConflictSchema>;

--- a/src/models/oauth-token.ts
+++ b/src/models/oauth-token.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+/** Zod schema for an OAuth2 token response. */
 export const OAuthTokenResponseSchema = z.object({
   access_token: z.string(),
   token_type: z.string().optional(),
@@ -7,4 +8,5 @@ export const OAuthTokenResponseSchema = z.object({
   scope: z.string().optional(),
 });
 
+/** OAuth2 token response with access token and expiry. */
 export type OAuthTokenResponse = z.infer<typeof OAuthTokenResponseSchema>;

--- a/src/models/prompt-detected.ts
+++ b/src/models/prompt-detected.ts
@@ -1,11 +1,14 @@
 import { z } from 'zod';
 
+/** Zod schema for prompt detection detail data. */
 export const PromptDetectionDetailsSchema = z.object({
   topic_guardrails_details: z.record(z.unknown()).optional(),
 });
 
+/** Prompt detection detail data including topic guardrails. */
 export type PromptDetectionDetails = z.infer<typeof PromptDetectionDetailsSchema>;
 
+/** Zod schema for prompt-side detection flags. */
 export const PromptDetectedSchema = z.object({
   url_cats: z.boolean().optional(),
   dlp: z.boolean().optional(),
@@ -16,4 +19,5 @@ export const PromptDetectedSchema = z.object({
   topic_violation: z.boolean().optional(),
 });
 
+/** Flags indicating which detection types triggered on the prompt. */
 export type PromptDetected = z.infer<typeof PromptDetectedSchema>;

--- a/src/models/response-detected.ts
+++ b/src/models/response-detected.ts
@@ -1,11 +1,14 @@
 import { z } from 'zod';
 
+/** Zod schema for response detection detail data. */
 export const ResponseDetectionDetailsSchema = z.object({
   topic_guardrails_details: z.record(z.unknown()).optional(),
 });
 
+/** Response detection detail data including topic guardrails. */
 export type ResponseDetectionDetails = z.infer<typeof ResponseDetectionDetailsSchema>;
 
+/** Zod schema for response-side detection flags. */
 export const ResponseDetectedSchema = z.object({
   url_cats: z.boolean().optional(),
   dlp: z.boolean().optional(),
@@ -17,4 +20,5 @@ export const ResponseDetectedSchema = z.object({
   topic_violation: z.boolean().optional(),
 });
 
+/** Flags indicating which detection types triggered on the response. */
 export type ResponseDetected = z.infer<typeof ResponseDetectedSchema>;

--- a/src/models/scan-id-result.ts
+++ b/src/models/scan-id-result.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { ScanResponseSchema } from './scan-response.js';
 
+/** Zod schema for a scan ID query result. */
 export const ScanIdResultSchema = z.object({
   source: z.string().optional(),
   req_id: z.number().optional(),
@@ -9,4 +10,5 @@ export const ScanIdResultSchema = z.object({
   result: ScanResponseSchema.optional(),
 });
 
+/** Result of querying a scan by its scan ID, including status and full scan response. */
 export type ScanIdResult = z.infer<typeof ScanIdResultSchema>;

--- a/src/models/scan-request.ts
+++ b/src/models/scan-request.ts
@@ -4,6 +4,7 @@ import { AiProfileSchema } from './ai-profile.js';
 import { MetadataSchema } from './metadata.js';
 import { ToolEventSchema } from './tool-event.js';
 
+/** Zod schema for a single content item within a scan request. */
 export const ScanRequestContentsInnerSchema = z.object({
   prompt: z.string().optional(),
   response: z.string().optional(),
@@ -13,8 +14,10 @@ export const ScanRequestContentsInnerSchema = z.object({
   tool_event: ToolEventSchema.optional(),
 });
 
+/** Single content item within a scan request. */
 export type ScanRequestContentsInner = z.infer<typeof ScanRequestContentsInnerSchema>;
 
+/** Zod schema for a complete scan request payload. */
 export const ScanRequestSchema = z.object({
   tr_id: z.string().max(MAX_TRANSACTION_ID_STR_LENGTH).optional(),
   session_id: z.string().max(MAX_SESSION_ID_STR_LENGTH).optional(),
@@ -23,4 +26,5 @@ export const ScanRequestSchema = z.object({
   contents: z.array(ScanRequestContentsInnerSchema).min(1),
 });
 
+/** Complete scan request payload sent to the AIRS API. */
 export type ScanRequest = z.infer<typeof ScanRequestSchema>;

--- a/src/models/scan-response.ts
+++ b/src/models/scan-response.ts
@@ -3,13 +3,16 @@ import { PromptDetectedSchema, PromptDetectionDetailsSchema } from './prompt-det
 import { ResponseDetectedSchema, ResponseDetectionDetailsSchema } from './response-detected.js';
 import { ToolEventMetadataSchema } from './tool-event.js';
 
+/** Zod schema for masked data in scan results. */
 export const MaskedDataSchema = z.object({
   data: z.string().optional(),
   pattern_detections: z.array(z.record(z.unknown())).optional(),
 });
 
+/** Masked data containing redacted content and pattern detections. */
 export type MaskedData = z.infer<typeof MaskedDataSchema>;
 
+/** Zod schema for I/O detection flags. */
 export const IODetectedSchema = z
   .object({
     url_cats: z.boolean().optional(),
@@ -20,8 +23,10 @@ export const IODetectedSchema = z
   })
   .passthrough();
 
+/** Flags indicating which detection types triggered on input or output. */
 export type IODetected = z.infer<typeof IODetectedSchema>;
 
+/** Zod schema for the scan summary (verdict + action). */
 export const ScanSummarySchema = z
   .object({
     verdict: z.string().optional(),
@@ -29,8 +34,10 @@ export const ScanSummarySchema = z
   })
   .passthrough();
 
+/** Scan summary containing overall verdict and action. */
 export type ScanSummary = z.infer<typeof ScanSummarySchema>;
 
+/** Zod schema for tool/agent detection results. */
 export const ToolDetectedSchema = z.object({
   verdict: z.string().optional(),
   metadata: ToolEventMetadataSchema.optional(),
@@ -39,8 +46,10 @@ export const ToolDetectedSchema = z.object({
   output_detected: IODetectedSchema.optional(),
 });
 
+/** Detection results for tool/agent interactions. */
 export type ToolDetected = z.infer<typeof ToolDetectedSchema>;
 
+/** Zod schema for a complete scan response from the AIRS API. */
 export const ScanResponseSchema = z.object({
   source: z.string().optional(),
   report_id: z.string(),
@@ -62,4 +71,5 @@ export const ScanResponseSchema = z.object({
   completed_at: z.string().optional(),
 });
 
+/** Complete scan response with verdict, action, and detection details. */
 export type ScanResponse = z.infer<typeof ScanResponseSchema>;

--- a/src/models/threat-report.ts
+++ b/src/models/threat-report.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { DetectionServiceResultSchema } from './detection.js';
 
+/** Zod schema for a detailed threat scan report. */
 export const ThreatScanReportSchema = z.object({
   source: z.string().optional(),
   report_id: z.string().optional(),
@@ -11,4 +12,5 @@ export const ThreatScanReportSchema = z.object({
   detection_results: z.array(DetectionServiceResultSchema).optional(),
 });
 
+/** Detailed threat scan report with per-service detection results. */
 export type ThreatScanReport = z.infer<typeof ThreatScanReportSchema>;

--- a/src/models/tool-event.ts
+++ b/src/models/tool-event.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+/** Zod schema for tool/function call event metadata. */
 export const ToolEventMetadataSchema = z.object({
   ecosystem: z.string(),
   method: z.string(),
@@ -7,12 +8,15 @@ export const ToolEventMetadataSchema = z.object({
   tool_invoked: z.string().optional(),
 });
 
+/** Tool/function call event metadata (ecosystem, method, server, tool). */
 export type ToolEventMetadata = z.infer<typeof ToolEventMetadataSchema>;
 
+/** Zod schema for a tool/function call event with input and output. */
 export const ToolEventSchema = z.object({
   metadata: ToolEventMetadataSchema.optional(),
   input: z.string().optional(),
   output: z.string().optional(),
 });
 
+/** Tool/function call event with optional input and output strings. */
 export type ToolEvent = z.infer<typeof ToolEventSchema>;

--- a/src/models/urlf-report.ts
+++ b/src/models/urlf-report.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 
+/** Zod schema for a URL filtering report entry. */
 export const UrlfEntrySchema = z.object({
   url: z.string().optional(),
   risk_level: z.string().optional(),
   categories: z.array(z.string()).optional(),
 });
 
+/** URL filtering report entry with URL, risk level, and categories. */
 export type UrlfEntry = z.infer<typeof UrlfEntrySchema>;

--- a/src/scan/content.ts
+++ b/src/scan/content.ts
@@ -10,15 +10,26 @@ import { AISecSDKException, ErrorType } from '../errors.js';
 import type { ToolEvent } from '../models/tool-event.js';
 import type { ScanRequestContentsInner } from '../models/scan-request.js';
 
+/** Options for constructing a {@link Content} instance. At least one field is required. */
 export interface ContentOptions {
+  /** User prompt text. Max 2 MB. */
   prompt?: string;
+  /** AI model response text. Max 2 MB. */
   response?: string;
+  /** Conversation context. Max 100 MB. */
   context?: string;
+  /** Code prompt text. Max 2 MB. */
   codePrompt?: string;
+  /** Code response text. Max 2 MB. */
   codeResponse?: string;
+  /** Tool/function call event data. */
   toolEvent?: ToolEvent;
 }
 
+/**
+ * Represents content to be scanned by AIRS.
+ * Validates byte-length limits on construction and property assignment.
+ */
 export class Content {
   private _prompt?: string;
   private _response?: string;
@@ -121,6 +132,7 @@ export class Content {
     this._toolEvent = value;
   }
 
+  /** Total byte length of all text content fields. */
   get length(): number {
     let total = 0;
     if (this._prompt) total += Buffer.byteLength(this._prompt);
@@ -131,6 +143,7 @@ export class Content {
     return total;
   }
 
+  /** Serialize to the API request format. */
   toJSON(): ScanRequestContentsInner {
     const obj: ScanRequestContentsInner = {};
     if (this._prompt !== undefined) obj.prompt = this._prompt;
@@ -142,6 +155,10 @@ export class Content {
     return obj;
   }
 
+  /**
+   * Create a Content instance from an API response object.
+   * @param json - Scan request contents inner object.
+   */
   static fromJSON(json: ScanRequestContentsInner): Content {
     return new Content({
       prompt: json.prompt,
@@ -153,6 +170,10 @@ export class Content {
     });
   }
 
+  /**
+   * Load content from a JSON file.
+   * @param filePath - Path to JSON file containing scan request contents.
+   */
   static fromJSONFile(filePath: string): Content {
     const raw = readFileSync(filePath, 'utf-8');
     const parsed: ScanRequestContentsInner = JSON.parse(raw);

--- a/src/scan/scanner.ts
+++ b/src/scan/scanner.ts
@@ -23,13 +23,25 @@ import type { ScanIdResult } from '../models/scan-id-result.js';
 import type { ThreatScanReport } from '../models/threat-report.js';
 import { Content } from './content.js';
 
+/** Optional parameters for {@link Scanner.syncScan}. */
 export interface SyncScanOptions {
+  /** Transaction ID for tracing. Max 100 characters. */
   trId?: string;
+  /** Session ID for grouping related scans. Max 100 characters. */
   sessionId?: string;
+  /** Application metadata attached to the scan request. */
   metadata?: Metadata;
 }
 
+/** Client for AIRS scan operations (sync, async, and query). */
 export class Scanner {
+  /**
+   * Perform a synchronous content scan.
+   * @param aiProfile - AI security profile to scan against.
+   * @param content - Content to scan.
+   * @param opts - Optional transaction/session IDs and metadata.
+   * @returns Scan response with verdict, action, and detection details.
+   */
   async syncScan(
     aiProfile: AiProfile,
     content: Content,
@@ -64,6 +76,11 @@ export class Scanner {
     return res.data;
   }
 
+  /**
+   * Submit content for asynchronous scanning.
+   * @param scanObjects - Array of scan objects (1–5 items).
+   * @returns Response containing scan IDs for later querying.
+   */
   async asyncScan(scanObjects: AsyncScanObject[]): Promise<AsyncScanResponse> {
     if (scanObjects.length < 1) {
       throw new AISecSDKException(
@@ -86,6 +103,11 @@ export class Scanner {
     return res.data;
   }
 
+  /**
+   * Query scan results by scan IDs.
+   * @param scanIds - Array of scan UUIDs (1–5 items).
+   * @returns Array of scan results with status and response data.
+   */
   async queryByScanIds(scanIds: string[]): Promise<ScanIdResult[]> {
     if (scanIds.length < 1) {
       throw new AISecSDKException(
@@ -113,6 +135,11 @@ export class Scanner {
     return res.data;
   }
 
+  /**
+   * Query detailed threat reports by report IDs.
+   * @param reportIds - Array of report IDs (1–5 items).
+   * @returns Array of threat scan reports with detection details.
+   */
   async queryByReportIds(reportIds: string[]): Promise<ThreatScanReport[]> {
     if (reportIds.length < 1) {
       throw new AISecSDKException(


### PR DESCRIPTION
## Summary
- Add JSDoc/TSDoc to all 8 exported classes
- Add JSDoc to all 11+ exported interfaces with field descriptions
- Add JSDoc to all 20+ exported methods with `@param` and `@returns`
- Add JSDoc to all 30+ exported Zod schemas and inferred types
- Add JSDoc to enum const objects and types

Closes #5

## Test plan
- [x] All 172 tests pass (no behavioral changes)
- [x] Lint/format/typecheck pass
- [x] 97.39% coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)