### PR TITLE
Release v0.2.1

### DIFF
--- a/.changeset/0001-review-fixes.md
+++ b/.changeset/0001-review-fixes.md
@@ -1,0 +1,9 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+- Fix SDK_VERSION constant to match package.json version
+- Replace pnpm references with npm in documentation
+- Extract shared HTTP retry logic into reusable utility
+- Add typed enums for verdict, action, and category values (Verdict, Action, Category)
+- Add JSDoc/TSDoc to all exported symbols (classes, interfaces, methods, types, schemas)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript SDK for Palo Alto Networks AI Runtime Security",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.2.0';
+export const SDK_VERSION = '0.2.1';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
## Summary
Version bump to 0.2.1 incorporating all review fixes from 2026-03-07.

### Changes in this release
- **Bug fix:** SDK_VERSION constant now matches package.json (#2)
- **Docs:** Replace pnpm references with npm run (#3)
- **Enhancement:** Shared HTTP retry logic extracted to utility (#4)
- **Enhancement:** Typed enums for verdict/action/category (#6)
- **Docs:** JSDoc/TSDoc on all 60+ exported symbols (#5)

### Stats
- 172 tests passing, 97.39% coverage
- 0 lint/format/typecheck issues
- 0 npm audit vulnerabilities

## Test plan
- [x] All 172 tests pass
- [x] Lint/format/typecheck pass
- [x] Coverage ≥97%
- [x] SDK_VERSION matches package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)