### PR TITLE
Add Model Security service client

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -65,3 +65,25 @@ export const MGMT_PROFILES_TSG_PATH = '/v1/mgmt/profiles/tsg';
 export const MGMT_TOPIC_PATH = '/v1/mgmt/topic';
 export const MGMT_TOPICS_TSG_PATH = '/v1/mgmt/topics/tsg';
 export const MGMT_TOPIC_FORCE_PATH = '/v1/mgmt/topic/force';
+
+// Model Security API defaults
+export const DEFAULT_MODEL_SEC_DATA_ENDPOINT = 'https://api.sase.paloaltonetworks.com/aims/data';
+export const DEFAULT_MODEL_SEC_MGMT_ENDPOINT = 'https://api.sase.paloaltonetworks.com/aims/mgmt';
+
+// Model Security env vars
+export const MODEL_SEC_CLIENT_ID = 'PANW_MODEL_SEC_CLIENT_ID';
+export const MODEL_SEC_CLIENT_SECRET = 'PANW_MODEL_SEC_CLIENT_SECRET';
+export const MODEL_SEC_TSG_ID = 'PANW_MODEL_SEC_TSG_ID';
+export const MODEL_SEC_DATA_ENDPOINT = 'PANW_MODEL_SEC_DATA_ENDPOINT';
+export const MODEL_SEC_MGMT_ENDPOINT = 'PANW_MODEL_SEC_MGMT_ENDPOINT';
+export const MODEL_SEC_TOKEN_ENDPOINT = 'PANW_MODEL_SEC_TOKEN_ENDPOINT';
+
+// API paths — model security data plane
+export const MODEL_SEC_SCANS_PATH = '/v1/scans';
+export const MODEL_SEC_EVALUATIONS_PATH = '/v1/evaluations';
+export const MODEL_SEC_VIOLATIONS_PATH = '/v1/violations';
+
+// API paths — model security management
+export const MODEL_SEC_SECURITY_GROUPS_PATH = '/v1/security-groups';
+export const MODEL_SEC_SECURITY_RULES_PATH = '/v1/security-rules';
+export const MODEL_SEC_PYPI_AUTH_PATH = '/v1/pypi/authenticate';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { AISecSDKException, ErrorType } from './errors.js';
 export * from './models/index.js';
 export * from './constants.js';
 export * from './management/index.js';
+export * from './model-security/index.js';

--- a/src/model-security/client.ts
+++ b/src/model-security/client.ts
@@ -1,0 +1,140 @@
+import {
+  DEFAULT_MODEL_SEC_DATA_ENDPOINT,
+  DEFAULT_MODEL_SEC_MGMT_ENDPOINT,
+  MODEL_SEC_CLIENT_ID,
+  MODEL_SEC_CLIENT_SECRET,
+  MODEL_SEC_TSG_ID,
+  MODEL_SEC_DATA_ENDPOINT,
+  MODEL_SEC_MGMT_ENDPOINT,
+  MODEL_SEC_TOKEN_ENDPOINT,
+  MGMT_CLIENT_ID,
+  MGMT_CLIENT_SECRET,
+  MGMT_TSG_ID,
+  MGMT_TOKEN_ENDPOINT,
+  MAX_NUMBER_OF_RETRIES,
+  MODEL_SEC_PYPI_AUTH_PATH,
+} from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { OAuthClient } from '../management/oauth-client.js';
+import { managementHttpRequest } from '../management/management-http-client.js';
+import { ModelSecurityScansClient } from './scans-client.js';
+import { ModelSecurityGroupsClient } from './security-groups-client.js';
+import { ModelSecurityRulesClient } from './security-rules-client.js';
+import type { PyPIAuthResponse } from '../models/model-security.js';
+
+/** Options for constructing a {@link ModelSecurityClient}. */
+export interface ModelSecurityClientOptions {
+  /** OAuth2 client ID. Falls back to `PANW_MODEL_SEC_CLIENT_ID`, then `PANW_MGMT_CLIENT_ID`. */
+  clientId?: string;
+  /** OAuth2 client secret. Falls back to `PANW_MODEL_SEC_CLIENT_SECRET`, then `PANW_MGMT_CLIENT_SECRET`. */
+  clientSecret?: string;
+  /** Tenant Service Group ID. Falls back to `PANW_MODEL_SEC_TSG_ID`, then `PANW_MGMT_TSG_ID`. */
+  tsgId?: string;
+  /** Data plane endpoint URL. Falls back to `PANW_MODEL_SEC_DATA_ENDPOINT`. */
+  dataEndpoint?: string;
+  /** Management plane endpoint URL. Falls back to `PANW_MODEL_SEC_MGMT_ENDPOINT`. */
+  mgmtEndpoint?: string;
+  /** OAuth2 token endpoint URL. Falls back to `PANW_MODEL_SEC_TOKEN_ENDPOINT`, then `PANW_MGMT_TOKEN_ENDPOINT`. */
+  tokenEndpoint?: string;
+  /** Max retry attempts (0-5). Defaults to 5. */
+  numRetries?: number;
+}
+
+/**
+ * Client for AIRS Model Security API operations.
+ * Uses two base URLs: data plane for scans, management plane for security groups/rules.
+ * Authenticates via OAuth2 client_credentials flow (shared token for both planes).
+ */
+export class ModelSecurityClient {
+  /** Data plane scan operations. */
+  public readonly scans: ModelSecurityScansClient;
+  /** Management plane security group operations. */
+  public readonly securityGroups: ModelSecurityGroupsClient;
+  /** Management plane security rule operations (read-only). */
+  public readonly securityRules: ModelSecurityRulesClient;
+
+  private readonly mgmtEndpoint: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: ModelSecurityClientOptions = {}) {
+    const clientId =
+      opts.clientId ?? process.env[MODEL_SEC_CLIENT_ID] ?? process.env[MGMT_CLIENT_ID];
+    const clientSecret =
+      opts.clientSecret ?? process.env[MODEL_SEC_CLIENT_SECRET] ?? process.env[MGMT_CLIENT_SECRET];
+    const tsgId = opts.tsgId ?? process.env[MODEL_SEC_TSG_ID] ?? process.env[MGMT_TSG_ID];
+    const dataEndpoint =
+      opts.dataEndpoint ?? process.env[MODEL_SEC_DATA_ENDPOINT] ?? DEFAULT_MODEL_SEC_DATA_ENDPOINT;
+    const mgmtEndpoint =
+      opts.mgmtEndpoint ?? process.env[MODEL_SEC_MGMT_ENDPOINT] ?? DEFAULT_MODEL_SEC_MGMT_ENDPOINT;
+    const tokenEndpoint =
+      opts.tokenEndpoint ??
+      process.env[MODEL_SEC_TOKEN_ENDPOINT] ??
+      process.env[MGMT_TOKEN_ENDPOINT];
+    const numRetries = Math.min(
+      Math.max(opts.numRetries ?? MAX_NUMBER_OF_RETRIES, 0),
+      MAX_NUMBER_OF_RETRIES,
+    );
+
+    if (!clientId) {
+      throw new AISecSDKException(
+        'clientId is required (option or PANW_MODEL_SEC_CLIENT_ID / PANW_MGMT_CLIENT_ID env var)',
+        ErrorType.MISSING_VARIABLE,
+      );
+    }
+    if (!clientSecret) {
+      throw new AISecSDKException(
+        'clientSecret is required (option or PANW_MODEL_SEC_CLIENT_SECRET / PANW_MGMT_CLIENT_SECRET env var)',
+        ErrorType.MISSING_VARIABLE,
+      );
+    }
+    if (!tsgId) {
+      throw new AISecSDKException(
+        'tsgId is required (option or PANW_MODEL_SEC_TSG_ID / PANW_MGMT_TSG_ID env var)',
+        ErrorType.MISSING_VARIABLE,
+      );
+    }
+
+    this.oauthClient = new OAuthClient({
+      clientId,
+      clientSecret,
+      tsgId,
+      tokenEndpoint,
+    });
+    this.mgmtEndpoint = mgmtEndpoint;
+    this.numRetries = numRetries;
+
+    this.scans = new ModelSecurityScansClient({
+      baseUrl: dataEndpoint,
+      oauthClient: this.oauthClient,
+      numRetries,
+    });
+
+    this.securityGroups = new ModelSecurityGroupsClient({
+      baseUrl: mgmtEndpoint,
+      oauthClient: this.oauthClient,
+      numRetries,
+    });
+
+    this.securityRules = new ModelSecurityRulesClient({
+      baseUrl: mgmtEndpoint,
+      oauthClient: this.oauthClient,
+      numRetries,
+    });
+  }
+
+  /**
+   * Get PyPI authentication credentials for Google Artifact Registry.
+   * @returns PyPI auth response with URL and expiration.
+   */
+  async getPyPIAuth(): Promise<PyPIAuthResponse> {
+    const res = await managementHttpRequest<PyPIAuthResponse>({
+      method: 'GET',
+      baseUrl: this.mgmtEndpoint,
+      path: MODEL_SEC_PYPI_AUTH_PATH,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/model-security/index.ts
+++ b/src/model-security/index.ts
@@ -1,0 +1,9 @@
+export { ModelSecurityClient, type ModelSecurityClientOptions } from './client.js';
+export {
+  ModelSecurityScansClient,
+  type ModelSecurityListOptions,
+  type ModelSecurityScanListOptions,
+  type ModelSecurityFileListOptions,
+} from './scans-client.js';
+export { ModelSecurityGroupsClient } from './security-groups-client.js';
+export { ModelSecurityRulesClient } from './security-rules-client.js';

--- a/src/model-security/scans-client.ts
+++ b/src/model-security/scans-client.ts
@@ -1,0 +1,394 @@
+import {
+  MODEL_SEC_SCANS_PATH,
+  MODEL_SEC_EVALUATIONS_PATH,
+  MODEL_SEC_VIOLATIONS_PATH,
+} from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { isValidUuid } from '../utils.js';
+import { managementHttpRequest } from '../management/management-http-client.js';
+import type { OAuthClient } from '../management/oauth-client.js';
+import type {
+  ScanCreateRequest,
+  ScanBaseResponse,
+  ScanList,
+  RuleEvaluationList,
+  RuleEvaluationResponse,
+  FileList,
+  LabelsCreateRequest,
+  LabelsResponse,
+  ViolationList,
+  ViolationResponse,
+  LabelKeyList,
+  LabelValueList,
+} from '../models/model-security.js';
+
+/** Pagination and filter options for model security list operations. */
+export interface ModelSecurityListOptions {
+  /** Number of items to skip. */
+  skip?: number;
+  /** Maximum number of items to return. */
+  limit?: number;
+  /** Field name to sort by. */
+  sort_by?: string;
+  /** Sort direction: 'asc' or 'desc'. */
+  sort_direction?: string;
+  /** Search query string. */
+  search?: string;
+}
+
+/** Extended list options for scan listing with additional filters. */
+export interface ModelSecurityScanListOptions extends ModelSecurityListOptions {
+  /** Filter by evaluation outcome. */
+  eval_outcome?: string;
+  /** Filter by source type. */
+  source_type?: string;
+  /** Filter by scan origin. */
+  scan_origin?: string;
+}
+
+/** List options for file listing with file-specific filters. */
+export interface ModelSecurityFileListOptions extends ModelSecurityListOptions {
+  /** Filter by file type. */
+  type?: string;
+  /** Filter by file result. */
+  result?: string;
+}
+
+/** @internal */
+export interface ModelSecurityScansClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+/** Build query params from list options. */
+function buildListParams(opts?: ModelSecurityListOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
+  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}
+
+/** Client for Model Security data plane scan operations. */
+export class ModelSecurityScansClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: ModelSecurityScansClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * Create a new model security scan.
+   * @param request - Scan creation request body.
+   * @returns The created scan response.
+   */
+  async create(request: ScanCreateRequest): Promise<ScanBaseResponse> {
+    const res = await managementHttpRequest<ScanBaseResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: MODEL_SEC_SCANS_PATH,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * List model security scans with optional filters.
+   * @param opts - Pagination and filter options.
+   * @returns Paginated list of scans.
+   */
+  async list(opts?: ModelSecurityScanListOptions): Promise<ScanList> {
+    const params = buildListParams(opts);
+    if (opts?.eval_outcome !== undefined) params.eval_outcome = opts.eval_outcome;
+    if (opts?.source_type !== undefined) params.source_type = opts.source_type;
+    if (opts?.scan_origin !== undefined) params.scan_origin = opts.scan_origin;
+
+    const res = await managementHttpRequest<ScanList>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: MODEL_SEC_SCANS_PATH,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get a single scan by UUID.
+   * @param uuid - Scan UUID.
+   * @returns The scan response.
+   */
+  async get(uuid: string): Promise<ScanBaseResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid scan uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<ScanBaseResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SCANS_PATH}/${uuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get rule evaluations for a scan.
+   * @param scanUuid - Scan UUID.
+   * @param opts - Pagination options.
+   * @returns Paginated list of rule evaluations.
+   */
+  async getEvaluations(
+    scanUuid: string,
+    opts?: ModelSecurityListOptions,
+  ): Promise<RuleEvaluationList> {
+    if (!isValidUuid(scanUuid)) {
+      throw new AISecSDKException(
+        `Invalid scan uuid: ${scanUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<RuleEvaluationList>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/evaluations`,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get files for a scan.
+   * @param scanUuid - Scan UUID.
+   * @param opts - Pagination and file filter options.
+   * @returns Paginated list of files.
+   */
+  async getFiles(scanUuid: string, opts?: ModelSecurityFileListOptions): Promise<FileList> {
+    if (!isValidUuid(scanUuid)) {
+      throw new AISecSDKException(
+        `Invalid scan uuid: ${scanUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const params = buildListParams(opts);
+    if (opts?.type !== undefined) params.type = opts.type;
+    if (opts?.result !== undefined) params.result = opts.result;
+
+    const res = await managementHttpRequest<FileList>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/files`,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Add labels to a scan (merge with existing).
+   * @param scanUuid - Scan UUID.
+   * @param request - Labels to add.
+   * @returns Labels response.
+   */
+  async addLabels(scanUuid: string, request: LabelsCreateRequest): Promise<LabelsResponse> {
+    if (!isValidUuid(scanUuid)) {
+      throw new AISecSDKException(
+        `Invalid scan uuid: ${scanUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<LabelsResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/labels`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Set labels on a scan (replace all existing).
+   * @param scanUuid - Scan UUID.
+   * @param request - Labels to set.
+   * @returns Labels response.
+   */
+  async setLabels(scanUuid: string, request: LabelsCreateRequest): Promise<LabelsResponse> {
+    if (!isValidUuid(scanUuid)) {
+      throw new AISecSDKException(
+        `Invalid scan uuid: ${scanUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<LabelsResponse>({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/labels`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Delete labels from a scan by key.
+   * @param scanUuid - Scan UUID.
+   * @param keys - Label keys to delete.
+   */
+  async deleteLabels(scanUuid: string, keys: string[]): Promise<void> {
+    if (!isValidUuid(scanUuid)) {
+      throw new AISecSDKException(
+        `Invalid scan uuid: ${scanUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    // Build keys as repeated query params: ?keys=key1&keys=key2
+    // managementHttpRequest uses URLSearchParams.set which only supports single values,
+    // so we manually build the query string portion
+    const url = new URL(`https://placeholder${MODEL_SEC_SCANS_PATH}/${scanUuid}/labels`);
+    for (const key of keys) {
+      url.searchParams.append('keys', key);
+    }
+    // Extract just the query string and append to path
+    const queryString = url.searchParams.toString();
+    const pathWithQuery = `${MODEL_SEC_SCANS_PATH}/${scanUuid}/labels${queryString ? `?${queryString}` : ''}`;
+
+    await managementHttpRequest<void>({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: pathWithQuery,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Get rule violations for a scan.
+   * @param scanUuid - Scan UUID.
+   * @param opts - Pagination options.
+   * @returns Paginated list of violations.
+   */
+  async getViolations(scanUuid: string, opts?: ModelSecurityListOptions): Promise<ViolationList> {
+    if (!isValidUuid(scanUuid)) {
+      throw new AISecSDKException(
+        `Invalid scan uuid: ${scanUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<ViolationList>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/rule-violations`,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get distinct label keys across all scans.
+   * @param opts - Pagination options.
+   * @returns Paginated list of label keys.
+   */
+  async getLabelKeys(opts?: ModelSecurityListOptions): Promise<LabelKeyList> {
+    const res = await managementHttpRequest<LabelKeyList>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SCANS_PATH}/label-keys`,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get distinct values for a label key.
+   * @param key - Label key to get values for.
+   * @param opts - Pagination options.
+   * @returns Paginated list of label values.
+   */
+  async getLabelValues(key: string, opts?: ModelSecurityListOptions): Promise<LabelValueList> {
+    const res = await managementHttpRequest<LabelValueList>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SCANS_PATH}/label-keys/${encodeURIComponent(key)}/values`,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get a single rule evaluation by UUID.
+   * @param uuid - Evaluation UUID.
+   * @returns The rule evaluation response.
+   */
+  async getEvaluation(uuid: string): Promise<RuleEvaluationResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid evaluation uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<RuleEvaluationResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_EVALUATIONS_PATH}/${uuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get a single violation by UUID.
+   * @param uuid - Violation UUID.
+   * @returns The violation response.
+   */
+  async getViolation(uuid: string): Promise<ViolationResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid violation uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<ViolationResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_VIOLATIONS_PATH}/${uuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/model-security/security-groups-client.ts
+++ b/src/model-security/security-groups-client.ts
@@ -1,0 +1,249 @@
+import { MODEL_SEC_SECURITY_GROUPS_PATH } from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { isValidUuid } from '../utils.js';
+import { managementHttpRequest } from '../management/management-http-client.js';
+import type { OAuthClient } from '../management/oauth-client.js';
+import type { ModelSecurityListOptions } from './scans-client.js';
+import type {
+  ModelSecurityGroupCreateRequest,
+  ModelSecurityGroupResponse,
+  ModelSecurityGroupUpdateRequest,
+  ListModelSecurityGroupsResponse,
+  ModelSecurityRuleInstanceResponse,
+  ModelSecurityRuleInstanceUpdateRequest,
+  ListModelSecurityRuleInstancesResponse,
+} from '../models/model-security.js';
+
+/** @internal */
+export interface ModelSecurityGroupsClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+/** Build query params from list options. */
+function buildListParams(opts?: ModelSecurityListOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
+  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}
+
+/** Client for Model Security management plane security group operations. */
+export class ModelSecurityGroupsClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: ModelSecurityGroupsClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * Create a new security group.
+   * @param request - Security group creation request.
+   * @returns The created security group.
+   */
+  async create(request: ModelSecurityGroupCreateRequest): Promise<ModelSecurityGroupResponse> {
+    const res = await managementHttpRequest<ModelSecurityGroupResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: MODEL_SEC_SECURITY_GROUPS_PATH,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * List security groups with optional filters.
+   * @param opts - Pagination and filter options.
+   * @returns Paginated list of security groups.
+   */
+  async list(opts?: ModelSecurityListOptions): Promise<ListModelSecurityGroupsResponse> {
+    const res = await managementHttpRequest<ListModelSecurityGroupsResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: MODEL_SEC_SECURITY_GROUPS_PATH,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get a single security group by UUID.
+   * @param uuid - Security group UUID.
+   * @returns The security group.
+   */
+  async get(uuid: string): Promise<ModelSecurityGroupResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid security group uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<ModelSecurityGroupResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${uuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Update an existing security group.
+   * @param uuid - Security group UUID.
+   * @param request - Updated security group fields.
+   * @returns The updated security group.
+   */
+  async update(
+    uuid: string,
+    request: ModelSecurityGroupUpdateRequest,
+  ): Promise<ModelSecurityGroupResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid security group uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<ModelSecurityGroupResponse>({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${uuid}`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Delete a security group.
+   * @param uuid - Security group UUID.
+   */
+  async delete(uuid: string): Promise<void> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid security group uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    await managementHttpRequest<void>({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${uuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * List rule instances for a security group.
+   * @param securityGroupUuid - Security group UUID.
+   * @param opts - Pagination options.
+   * @returns Paginated list of rule instances.
+   */
+  async listRuleInstances(
+    securityGroupUuid: string,
+    opts?: ModelSecurityListOptions,
+  ): Promise<ListModelSecurityRuleInstancesResponse> {
+    if (!isValidUuid(securityGroupUuid)) {
+      throw new AISecSDKException(
+        `Invalid security group uuid: ${securityGroupUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<ListModelSecurityRuleInstancesResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${securityGroupUuid}/rule-instances`,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get a single rule instance within a security group.
+   * @param securityGroupUuid - Security group UUID.
+   * @param ruleInstanceUuid - Rule instance UUID.
+   * @returns The rule instance.
+   */
+  async getRuleInstance(
+    securityGroupUuid: string,
+    ruleInstanceUuid: string,
+  ): Promise<ModelSecurityRuleInstanceResponse> {
+    if (!isValidUuid(securityGroupUuid)) {
+      throw new AISecSDKException(
+        `Invalid security group uuid: ${securityGroupUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+    if (!isValidUuid(ruleInstanceUuid)) {
+      throw new AISecSDKException(
+        `Invalid rule instance uuid: ${ruleInstanceUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<ModelSecurityRuleInstanceResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${securityGroupUuid}/rule-instances/${ruleInstanceUuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Update a rule instance within a security group.
+   * @param securityGroupUuid - Security group UUID.
+   * @param ruleInstanceUuid - Rule instance UUID.
+   * @param request - Updated rule instance fields.
+   * @returns The updated rule instance.
+   */
+  async updateRuleInstance(
+    securityGroupUuid: string,
+    ruleInstanceUuid: string,
+    request: ModelSecurityRuleInstanceUpdateRequest,
+  ): Promise<ModelSecurityRuleInstanceResponse> {
+    if (!isValidUuid(securityGroupUuid)) {
+      throw new AISecSDKException(
+        `Invalid security group uuid: ${securityGroupUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+    if (!isValidUuid(ruleInstanceUuid)) {
+      throw new AISecSDKException(
+        `Invalid rule instance uuid: ${ruleInstanceUuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<ModelSecurityRuleInstanceResponse>({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${securityGroupUuid}/rule-instances/${ruleInstanceUuid}`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/model-security/security-rules-client.ts
+++ b/src/model-security/security-rules-client.ts
@@ -1,0 +1,81 @@
+import { MODEL_SEC_SECURITY_RULES_PATH } from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { isValidUuid } from '../utils.js';
+import { managementHttpRequest } from '../management/management-http-client.js';
+import type { OAuthClient } from '../management/oauth-client.js';
+import type { ModelSecurityListOptions } from './scans-client.js';
+import type {
+  ListModelSecurityRulesResponse,
+  ModelSecurityRuleResponse,
+} from '../models/model-security.js';
+
+/** @internal */
+export interface ModelSecurityRulesClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+/** Build query params from list options. */
+function buildListParams(opts?: ModelSecurityListOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
+  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}
+
+/** Client for Model Security management plane security rule operations (read-only). */
+export class ModelSecurityRulesClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: ModelSecurityRulesClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List available security rules.
+   * @param opts - Pagination options.
+   * @returns Paginated list of security rules.
+   */
+  async list(opts?: ModelSecurityListOptions): Promise<ListModelSecurityRulesResponse> {
+    const res = await managementHttpRequest<ListModelSecurityRulesResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: MODEL_SEC_SECURITY_RULES_PATH,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get a single security rule by UUID.
+   * @param uuid - Security rule UUID.
+   * @returns The security rule.
+   */
+  async get(uuid: string): Promise<ModelSecurityRuleResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid security rule uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<ModelSecurityRuleResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_SECURITY_RULES_PATH}/${uuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -87,3 +87,5 @@ export {
   DeleteTopicConflictSchema,
   type DeleteTopicConflict,
 } from './mgmt-custom-topic.js';
+export * from './model-security-enums.js';
+export * from './model-security.js';

--- a/src/models/model-security-enums.ts
+++ b/src/models/model-security-enums.ts
@@ -1,0 +1,218 @@
+// src/models/model-security-enums.ts — typed enums for AIRS Model Security API values
+
+/** Error codes returned by the Model Security scan service. */
+export const ErrorCodes = {
+  UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+  SCAN_ERROR: 'SCAN_ERROR',
+  INVALID_RESPONSE: 'INVALID_RESPONSE',
+  ACCESS_DENIED: 'ACCESS_DENIED',
+  MISSING_CREDENTIALS: 'MISSING_CREDENTIALS',
+  NO_SUCH_KEY: 'NO_SUCH_KEY',
+  NO_SUCH_BUCKET: 'NO_SUCH_BUCKET',
+  INVALID_BUCKET_NAME: 'INVALID_BUCKET_NAME',
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
+  INVALID_OBJECT_STATE: 'INVALID_OBJECT_STATE',
+  UNKNOWN_REMOTE_SERVICE_ERROR: 'UNKNOWN_REMOTE_SERVICE_ERROR',
+  UNSUPPORTED_REMOTE_STORAGE: 'UNSUPPORTED_REMOTE_STORAGE',
+  MISSING_ARTIFACTS: 'MISSING_ARTIFACTS',
+  WORKER_ERROR: 'WORKER_ERROR',
+  POLICY_EVAL_ERROR: 'POLICY_EVAL_ERROR',
+} as const;
+
+/** Union type of all possible error code values. */
+export type ErrorCodes = (typeof ErrorCodes)[keyof typeof ErrorCodes];
+
+/** Evaluation outcome for a model security scan. */
+export const EvalOutcome = {
+  PENDING: 'PENDING',
+  ALLOWED: 'ALLOWED',
+  BLOCKED: 'BLOCKED',
+  ERROR: 'ERROR',
+} as const;
+
+/** Union type of all possible evaluation outcome values. */
+export type EvalOutcome = (typeof EvalOutcome)[keyof typeof EvalOutcome];
+
+/** Results of individual file scanning. */
+export const FileScanResult = {
+  SKIPPED: 'SKIPPED',
+  SUCCESS: 'SUCCESS',
+  ERROR: 'ERROR',
+  FAILED: 'FAILED',
+} as const;
+
+/** Union type of all possible file scan result values. */
+export type FileScanResult = (typeof FileScanResult)[keyof typeof FileScanResult];
+
+/** File type in the scanned model tree. */
+export const FileType = {
+  DIRECTORY: 'DIRECTORY',
+  FILE: 'FILE',
+} as const;
+
+/** Union type of all possible file type values. */
+export type FileType = (typeof FileType)[keyof typeof FileType];
+
+/** Status of a model file scan. */
+export const ModelScanStatus = {
+  SCANNED: 'SCANNED',
+  SKIPPED: 'SKIPPED',
+  ERROR: 'ERROR',
+} as const;
+
+/** Union type of all possible model scan status values. */
+export type ModelScanStatus = (typeof ModelScanStatus)[keyof typeof ModelScanStatus];
+
+/** Results of rule evaluation. */
+export const RuleEvaluationResult = {
+  PASSED: 'PASSED',
+  FAILED: 'FAILED',
+  ERROR: 'ERROR',
+} as const;
+
+/** Union type of all possible rule evaluation result values. */
+export type RuleEvaluationResult = (typeof RuleEvaluationResult)[keyof typeof RuleEvaluationResult];
+
+/** Rule evaluation states. */
+export const RuleState = {
+  DISABLED: 'DISABLED',
+  ALLOWING: 'ALLOWING',
+  BLOCKING: 'BLOCKING',
+} as const;
+
+/** Union type of all possible rule state values. */
+export type RuleState = (typeof RuleState)[keyof typeof RuleState];
+
+/** Origin of the model security scan. */
+export const ScanOrigin = {
+  MODEL_SECURITY_SDK: 'MODEL_SECURITY_SDK',
+  HUGGING_FACE: 'HUGGING_FACE',
+} as const;
+
+/** Union type of all possible scan origin values. */
+export type ScanOrigin = (typeof ScanOrigin)[keyof typeof ScanOrigin];
+
+/** Fields available for date-based sorting. */
+export const SortByDateField = {
+  CREATED_AT: 'created_at',
+  UPDATED_AT: 'updated_at',
+} as const;
+
+/** Union type of all possible sort-by-date field values. */
+export type SortByDateField = (typeof SortByDateField)[keyof typeof SortByDateField];
+
+/** Fields available for file-based sorting. */
+export const SortByFileField = {
+  PATH: 'path',
+  TYPE: 'type',
+} as const;
+
+/** Union type of all possible sort-by-file field values. */
+export type SortByFileField = (typeof SortByFileField)[keyof typeof SortByFileField];
+
+/** Sort direction for list queries. */
+export const SortDirection = {
+  ASC: 'asc',
+  DESC: 'desc',
+} as const;
+
+/** Union type of all possible sort direction values. */
+export type SortDirection = (typeof SortDirection)[keyof typeof SortDirection];
+
+/** Source type for model origin. */
+export const SourceType = {
+  LOCAL: 'LOCAL',
+  HUGGING_FACE: 'HUGGING_FACE',
+  S3: 'S3',
+  GCS: 'GCS',
+  AZURE: 'AZURE',
+  ARTIFACTORY: 'ARTIFACTORY',
+  GITLAB: 'GITLAB',
+  ALL: 'ALL',
+} as const;
+
+/** Union type of all possible source type values. */
+export type SourceType = (typeof SourceType)[keyof typeof SourceType];
+
+/**
+ * Threat category codes for model scan issues.
+ * Should be in sync with modelscan-pai issue codes.
+ */
+export const ThreatCategory = {
+  PAIT_ARV_100: 'PAIT-ARV-100',
+  PAIT_GGUF_100: 'PAIT-GGUF-100',
+  PAIT_GGUF_101: 'PAIT-GGUF-101',
+  PAIT_KERAS_100: 'PAIT-KERAS-100',
+  PAIT_KERAS_101: 'PAIT-KERAS-101',
+  PAIT_KERAS_102: 'PAIT-KERAS-102',
+  PAIT_JOBLIB_100: 'PAIT-JOBLIB-100',
+  PAIT_JOBLIB_101: 'PAIT-JOBLIB-101',
+  PAIT_PKL_100: 'PAIT-PKL-100',
+  PAIT_PKL_101: 'PAIT-PKL-101',
+  PAIT_PYTCH_100: 'PAIT-PYTCH-100',
+  PAIT_PYTCH_101: 'PAIT-PYTCH-101',
+  PAIT_EXDIR_100: 'PAIT-EXDIR-100',
+  PAIT_EXDIR_101: 'PAIT-EXDIR-101',
+  PAIT_ONNX_200: 'PAIT-ONNX-200',
+  PAIT_TF_200: 'PAIT-TF-200',
+  PAIT_LMAFL_300: 'PAIT-LMAFL-300',
+  PAIT_LITERT_300: 'PAIT-LITERT-300',
+  PAIT_LITERT_301: 'PAIT-LITERT-301',
+  PAIT_LITERT_302: 'PAIT-LITERT-302',
+  PAIT_KERAS_300: 'PAIT-KERAS-300',
+  PAIT_KERAS_301: 'PAIT-KERAS-301',
+  PAIT_TCHST_300: 'PAIT-TCHST-300',
+  PAIT_TCHST_301: 'PAIT-TCHST-301',
+  PAIT_TF_300: 'PAIT-TF-300',
+  PAIT_TF_301: 'PAIT-TF-301',
+  PAIT_TF_302: 'PAIT-TF-302',
+  PAIT_TMT_300: 'PAIT-TMT-300',
+  PAIT_TMT_301: 'PAIT-TMT-301',
+  UNAPPROVED_FORMATS: 'UNAPPROVED_FORMATS',
+} as const;
+
+/** Union type of all possible threat category values. */
+export type ThreatCategory = (typeof ThreatCategory)[keyof typeof ThreatCategory];
+
+/** Security group states. */
+export const ModelSecurityGroupState = {
+  PENDING: 'PENDING',
+  ACTIVE: 'ACTIVE',
+} as const;
+
+/** Union type of all possible model security group state values. */
+export type ModelSecurityGroupState =
+  (typeof ModelSecurityGroupState)[keyof typeof ModelSecurityGroupState];
+
+/** Rule types for different scanning approaches. */
+export const RuleType = {
+  METADATA: 'METADATA',
+  ARTIFACT: 'ARTIFACT',
+} as const;
+
+/** Union type of all possible rule type values. */
+export type RuleType = (typeof RuleType)[keyof typeof RuleType];
+
+/** Editable field types used by rule structure for UI rendering. */
+export const RuleEditableFieldType = {
+  SELECT: 'SELECT',
+  LIST: 'LIST',
+} as const;
+
+/** Union type of all possible rule editable field type values. */
+export type RuleEditableFieldType =
+  (typeof RuleEditableFieldType)[keyof typeof RuleEditableFieldType];
+
+/** Allowed keys for rule field values configuration. */
+export const RuleFieldValueKey = {
+  APPROVED_FORMATS: 'approved_formats',
+  APPROVED_LOCATIONS: 'approved_locations',
+  APPROVED_LICENSES: 'approved_licenses',
+  DENY_ORGS: 'deny_orgs',
+  DENIED_ORG_MODELS: 'denied_org_models',
+  APPROVED_ORG_MODELS: 'approved_org_models',
+} as const;
+
+/** Union type of all possible rule field value key values. */
+export type RuleFieldValueKey = (typeof RuleFieldValueKey)[keyof typeof RuleFieldValueKey];

--- a/src/models/model-security.ts
+++ b/src/models/model-security.ts
@@ -1,0 +1,526 @@
+// src/models/model-security.ts — Zod schemas + types for AIRS Model Security API
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Shared / utility schemas
+// ---------------------------------------------------------------------------
+
+/** Zod schema for model security pagination metadata. */
+export const ModelSecurityPaginationSchema = z
+  .object({
+    total_items: z.number().int().nullable().optional(),
+  })
+  .passthrough();
+
+/** Pagination metadata for model security list responses. */
+export type ModelSecurityPagination = z.infer<typeof ModelSecurityPaginationSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Labels
+// ---------------------------------------------------------------------------
+
+/** Zod schema for a single label key-value pair. */
+export const LabelSchema = z.object({
+  key: z.string(),
+  value: z.string(),
+});
+
+/** A single label key-value pair. */
+export type Label = z.infer<typeof LabelSchema>;
+
+/** Zod schema for creating/setting labels on a scan. */
+export const LabelsCreateRequestSchema = z.object({
+  labels: z.array(LabelSchema),
+});
+
+/** Request body for creating or setting scan labels. */
+export type LabelsCreateRequest = z.infer<typeof LabelsCreateRequestSchema>;
+
+/** Zod schema for labels response (empty body on success). */
+export const LabelsResponseSchema = z.object({}).passthrough();
+
+/** Response from label create/set operations. */
+export type LabelsResponse = z.infer<typeof LabelsResponseSchema>;
+
+/** Zod schema for a paginated list of label keys. */
+export const LabelKeyListSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    keys: z.array(z.string()),
+  })
+  .passthrough();
+
+/** Paginated list of distinct label keys. */
+export type LabelKeyList = z.infer<typeof LabelKeyListSchema>;
+
+/** Zod schema for a paginated list of label values. */
+export const LabelValueListSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    values: z.array(z.string()),
+  })
+  .passthrough();
+
+/** Paginated list of distinct label values. */
+export type LabelValueList = z.infer<typeof LabelValueListSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Eval summary
+// ---------------------------------------------------------------------------
+
+/** Zod schema for evaluation summary counts. */
+export const EvalSummarySchema = z
+  .object({
+    rules_failed: z.number().int().optional().default(0),
+    rules_passed: z.number().int().optional().default(0),
+    total_rules: z.number().int().optional().default(0),
+  })
+  .passthrough();
+
+/** Summary of rule evaluation pass/fail counts. */
+export type EvalSummary = z.infer<typeof EvalSummarySchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Model scan issues & file scan data
+// ---------------------------------------------------------------------------
+
+/** Zod schema for a single issue detected during model scanning. */
+export const ModelScanIssueSchema = z
+  .object({
+    description: z.string(),
+    source: z.string(),
+    threat: z.string().nullable().optional(),
+    module: z.string().nullable().optional(),
+    operator: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+/** A single issue detected during model file scanning. */
+export type ModelScanIssue = z.infer<typeof ModelScanIssueSchema>;
+
+/** Zod schema for per-file scan data within a scan request. */
+export const FileScanDataSchema = z
+  .object({
+    file_path: z.string(),
+    modelscan_status: z.string(),
+    blob_id: z.string(),
+    error_message: z.string().nullable().optional(),
+    formats: z.array(z.string()).nullable().optional(),
+    issues_detected: z.array(ModelScanIssueSchema).nullable().optional(),
+  })
+  .passthrough();
+
+/** Per-file scan data included in a scan creation request. */
+export type FileScanData = z.infer<typeof FileScanDataSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Scan details (nested in create request)
+// ---------------------------------------------------------------------------
+
+/** Zod schema for detailed scan results submitted with a scan creation. */
+export const ScanDetailsSchema = z.object({
+  scanner_version: z.string(),
+  time_started: z.string(),
+  files: z.array(FileScanDataSchema),
+  total_files_scanned: z.number().int(),
+  total_files_skipped: z.number().int(),
+  model_formats: z.array(z.string()),
+  model_size_bytes: z.number().int(),
+  scan_duration_ms: z.number().int(),
+  error_code: z.string().nullable().optional(),
+  error_message: z.string().nullable().optional(),
+});
+
+/** Detailed scan results submitted with a scan creation request. */
+export type ScanDetails = z.infer<typeof ScanDetailsSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Scan create request
+// ---------------------------------------------------------------------------
+
+/** Zod schema for creating a new model security scan. */
+export const ScanCreateRequestSchema = z.object({
+  model_uri: z.string(),
+  security_group_uuid: z.string(),
+  scan_origin: z.string(),
+  allow_patterns: z.array(z.string()).nullable().optional(),
+  ignore_patterns: z.array(z.string()).nullable().optional(),
+  labels: z.array(LabelSchema).nullable().optional(),
+  model_author: z.string().nullable().optional(),
+  model_name: z.string().nullable().optional(),
+  model_version: z.string().nullable().optional(),
+  scan_details: ScanDetailsSchema.nullable().optional(),
+});
+
+/** Request body for creating a new model security scan. */
+export type ScanCreateRequest = z.infer<typeof ScanCreateRequestSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Scan base response
+// ---------------------------------------------------------------------------
+
+/** Zod schema for the base scan response returned by the API. */
+export const ScanBaseResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    model_uri: z.string(),
+    owner: z.string(),
+    scan_origin: z.string(),
+    security_group_uuid: z.string(),
+    security_group_name: z.string(),
+    model_version_uuid: z.string(),
+    eval_outcome: z.string(),
+    source_type: z.string(),
+    created_by: z.string().nullable().optional(),
+    enabled_rule_count_snapshot: z.number().int().nullable().optional(),
+    error_code: z.string().nullable().optional(),
+    error_message: z.string().nullable().optional(),
+    eval_summary: EvalSummarySchema.nullable().optional(),
+    labels: z.array(LabelSchema).optional(),
+    model_formats: z.array(z.string()).nullable().optional(),
+    scanner_version: z.string().nullable().optional(),
+    time_started: z.string().nullable().optional(),
+    total_files_scanned: z.number().int().nullable().optional(),
+    total_files_skipped: z.number().int().nullable().optional(),
+  })
+  .passthrough();
+
+/** Base scan response from the Model Security API. */
+export type ScanBaseResponse = z.infer<typeof ScanBaseResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Scan list
+// ---------------------------------------------------------------------------
+
+/** Zod schema for a paginated list of scans. */
+export const ScanListSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    scans: z.array(ScanBaseResponseSchema),
+  })
+  .passthrough();
+
+/** Paginated list of model security scans. */
+export type ScanList = z.infer<typeof ScanListSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — File response
+// ---------------------------------------------------------------------------
+
+/** Zod schema for a file entry in the scanned model tree. */
+export const FileResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    path: z.string(),
+    parent_path: z.string(),
+    type: z.string(),
+    result: z.string(),
+    model_version_uuid: z.string(),
+    blob_id: z.string().nullable().optional(),
+    formats: z.array(z.string()).nullable().optional(),
+    scan_uuid: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+/** A file entry in the scanned model tree. */
+export type FileResponse = z.infer<typeof FileResponseSchema>;
+
+/** Zod schema for a paginated list of files. */
+export const FileListSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    files: z.array(FileResponseSchema),
+  })
+  .passthrough();
+
+/** Paginated list of scanned model files. */
+export type FileList = z.infer<typeof FileListSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Rule evaluation response
+// ---------------------------------------------------------------------------
+
+/** Zod schema for a single rule evaluation result. */
+export const RuleEvaluationResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    result: z.string(),
+    violation_count: z.number().int(),
+    rule_instance_uuid: z.string(),
+    scan_uuid: z.string(),
+    rule_name: z.string(),
+    rule_description: z.string(),
+    rule_instance_state: z.string(),
+  })
+  .passthrough();
+
+/** A single rule evaluation result for a scan. */
+export type RuleEvaluationResponse = z.infer<typeof RuleEvaluationResponseSchema>;
+
+/** Zod schema for a paginated list of rule evaluations. */
+export const RuleEvaluationListSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    evaluations: z.array(RuleEvaluationResponseSchema),
+  })
+  .passthrough();
+
+/** Paginated list of rule evaluations. */
+export type RuleEvaluationList = z.infer<typeof RuleEvaluationListSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Violation response
+// ---------------------------------------------------------------------------
+
+/** Zod schema for a single violation response. */
+export const ViolationResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    description: z.string(),
+    rule_instance_uuid: z.string(),
+    rule_name: z.string(),
+    rule_description: z.string(),
+    rule_instance_state: z.string(),
+    file: z.string().nullable().optional(),
+    hash: z.string().nullable().optional(),
+    module: z.string().nullable().optional(),
+    operator: z.string().nullable().optional(),
+    threat: z.string().nullable().optional(),
+    threat_description: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+/** A single violation with detailed rule information. */
+export type ViolationResponse = z.infer<typeof ViolationResponseSchema>;
+
+/** Zod schema for a paginated list of violations. */
+export const ViolationListSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    violations: z.array(ViolationResponseSchema),
+  })
+  .passthrough();
+
+/** Paginated list of rule violations. */
+export type ViolationList = z.infer<typeof ViolationListSchema>;
+
+// ---------------------------------------------------------------------------
+// Management — Rule editable field & remediation
+// ---------------------------------------------------------------------------
+
+/** Zod schema for a dropdown option on a rule editable field. */
+export const RuleEditableFieldDropdownSchema = z
+  .object({
+    value: z.string(),
+    label: z.string(),
+  })
+  .passthrough();
+
+/** A dropdown option for a rule editable field. */
+export type RuleEditableFieldDropdown = z.infer<typeof RuleEditableFieldDropdownSchema>;
+
+/** Zod schema for a rule editable field definition. */
+export const RuleEditableFieldSchema = z
+  .object({
+    attribute_name: z.string(),
+    type: z.string(),
+    display_name: z.string(),
+    display_type: z.string(),
+    description: z.string().nullable().optional(),
+    dropdown_values: z.array(RuleEditableFieldDropdownSchema).nullable().optional(),
+  })
+  .passthrough();
+
+/** A rule editable field definition for UI rendering. */
+export type RuleEditableField = z.infer<typeof RuleEditableFieldSchema>;
+
+/** Zod schema for rule remediation steps. */
+export const RuleRemediationSchema = z
+  .object({
+    description: z.string(),
+    steps: z.array(z.string()),
+    url: z.string(),
+  })
+  .passthrough();
+
+/** Remediation steps for a security rule. */
+export type RuleRemediation = z.infer<typeof RuleRemediationSchema>;
+
+// ---------------------------------------------------------------------------
+// Management — Rule configuration (used in group creation)
+// ---------------------------------------------------------------------------
+
+/** Zod schema for rule configuration during security group creation. */
+export const RuleConfigurationSchema = z
+  .object({
+    field_values: z.record(z.unknown()).optional(),
+    state: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+/** Configuration for customizing a rule during security group creation. */
+export type RuleConfiguration = z.infer<typeof RuleConfigurationSchema>;
+
+// ---------------------------------------------------------------------------
+// Management — Model security rule response
+// ---------------------------------------------------------------------------
+
+/** Zod schema for a model security rule definition. */
+export const ModelSecurityRuleResponseSchema = z
+  .object({
+    uuid: z.string(),
+    name: z.string(),
+    description: z.string(),
+    rule_type: z.string(),
+    compatible_sources: z.array(z.string()),
+    default_state: z.string(),
+    remediation: RuleRemediationSchema,
+    editable_fields: z.array(RuleEditableFieldSchema),
+    constant_values: z.record(z.unknown()),
+    default_values: z.record(z.unknown()),
+  })
+  .passthrough();
+
+/** A model security rule definition. */
+export type ModelSecurityRuleResponse = z.infer<typeof ModelSecurityRuleResponseSchema>;
+
+/** Zod schema for a paginated list of security rules. */
+export const ListModelSecurityRulesResponseSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    rules: z.array(ModelSecurityRuleResponseSchema),
+  })
+  .passthrough();
+
+/** Paginated list of model security rules. */
+export type ListModelSecurityRulesResponse = z.infer<typeof ListModelSecurityRulesResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Management — Rule instance
+// ---------------------------------------------------------------------------
+
+/** Zod schema for a model security rule instance response. */
+export const ModelSecurityRuleInstanceResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    security_group_uuid: z.string(),
+    security_rule_uuid: z.string(),
+    state: z.string(),
+    rule: ModelSecurityRuleResponseSchema,
+    field_values: z.record(z.unknown()).optional(),
+  })
+  .passthrough();
+
+/** An instantiated rule that gets evaluated against scans. */
+export type ModelSecurityRuleInstanceResponse = z.infer<
+  typeof ModelSecurityRuleInstanceResponseSchema
+>;
+
+/** Zod schema for updating a rule instance. */
+export const ModelSecurityRuleInstanceUpdateRequestSchema = z.object({
+  security_group_uuid: z.string(),
+  state: z.string().nullable().optional(),
+  field_values: z.record(z.unknown()).nullable().optional(),
+});
+
+/** Request body for updating a rule instance. */
+export type ModelSecurityRuleInstanceUpdateRequest = z.infer<
+  typeof ModelSecurityRuleInstanceUpdateRequestSchema
+>;
+
+/** Zod schema for a paginated list of rule instances. */
+export const ListModelSecurityRuleInstancesResponseSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    rule_instances: z.array(ModelSecurityRuleInstanceResponseSchema),
+  })
+  .passthrough();
+
+/** Paginated list of model security rule instances. */
+export type ListModelSecurityRuleInstancesResponse = z.infer<
+  typeof ListModelSecurityRuleInstancesResponseSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Management — Security group
+// ---------------------------------------------------------------------------
+
+/** Zod schema for creating a model security group. */
+export const ModelSecurityGroupCreateRequestSchema = z.object({
+  name: z.string(),
+  source_type: z.string(),
+  description: z.string().optional().default(''),
+  rule_configurations: z.record(RuleConfigurationSchema).optional(),
+});
+
+/** Request body for creating a new model security group. */
+export type ModelSecurityGroupCreateRequest = z.infer<typeof ModelSecurityGroupCreateRequestSchema>;
+
+/** Zod schema for a model security group response. */
+export const ModelSecurityGroupResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    name: z.string(),
+    description: z.string(),
+    source_type: z.string(),
+    state: z.string(),
+    is_tombstone: z.boolean(),
+  })
+  .passthrough();
+
+/** A model security group with its configuration and state. */
+export type ModelSecurityGroupResponse = z.infer<typeof ModelSecurityGroupResponseSchema>;
+
+/** Zod schema for updating a model security group. */
+export const ModelSecurityGroupUpdateRequestSchema = z.object({
+  name: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
+});
+
+/** Request body for updating a model security group. */
+export type ModelSecurityGroupUpdateRequest = z.infer<typeof ModelSecurityGroupUpdateRequestSchema>;
+
+/** Zod schema for a paginated list of security groups. */
+export const ListModelSecurityGroupsResponseSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    security_groups: z.array(ModelSecurityGroupResponseSchema),
+  })
+  .passthrough();
+
+/** Paginated list of model security groups. */
+export type ListModelSecurityGroupsResponse = z.infer<typeof ListModelSecurityGroupsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Management — PyPI auth
+// ---------------------------------------------------------------------------
+
+/** Zod schema for PyPI authentication response. */
+export const PyPIAuthResponseSchema = z
+  .object({
+    url: z.string(),
+    expires_at: z.string(),
+  })
+  .passthrough();
+
+/** PyPI authentication response with Google Artifact Registry URL. */
+export type PyPIAuthResponse = z.infer<typeof PyPIAuthResponseSchema>;

--- a/test/model-security/client.spec.ts
+++ b/test/model-security/client.spec.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { ModelSecurityClient } from '../../src/model-security/client.js';
+import { ModelSecurityScansClient } from '../../src/model-security/scans-client.js';
+import { ModelSecurityGroupsClient } from '../../src/model-security/security-groups-client.js';
+import { ModelSecurityRulesClient } from '../../src/model-security/security-rules-client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+describe('ModelSecurityClient', () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    globalThis.fetch = originalFetch;
+  });
+
+  it('constructs with explicit options', () => {
+    const client = new ModelSecurityClient({
+      clientId: 'cid',
+      clientSecret: 'csec',
+      tsgId: '999',
+    });
+    expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
+    expect(client.securityGroups).toBeInstanceOf(ModelSecurityGroupsClient);
+    expect(client.securityRules).toBeInstanceOf(ModelSecurityRulesClient);
+  });
+
+  it('reads credentials from MODEL_SEC env vars', () => {
+    process.env.PANW_MODEL_SEC_CLIENT_ID = 'env-cid';
+    process.env.PANW_MODEL_SEC_CLIENT_SECRET = 'env-csec';
+    process.env.PANW_MODEL_SEC_TSG_ID = 'env-tsg';
+
+    const client = new ModelSecurityClient();
+    expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
+  });
+
+  it('falls back to MGMT env vars', () => {
+    process.env.PANW_MGMT_CLIENT_ID = 'mgmt-cid';
+    process.env.PANW_MGMT_CLIENT_SECRET = 'mgmt-csec';
+    process.env.PANW_MGMT_TSG_ID = 'mgmt-tsg';
+
+    const client = new ModelSecurityClient();
+    expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
+  });
+
+  it('MODEL_SEC env vars take precedence over MGMT', () => {
+    process.env.PANW_MODEL_SEC_CLIENT_ID = 'msec-cid';
+    process.env.PANW_MODEL_SEC_CLIENT_SECRET = 'msec-csec';
+    process.env.PANW_MODEL_SEC_TSG_ID = 'msec-tsg';
+    process.env.PANW_MGMT_CLIENT_ID = 'mgmt-cid';
+    process.env.PANW_MGMT_CLIENT_SECRET = 'mgmt-csec';
+    process.env.PANW_MGMT_TSG_ID = 'mgmt-tsg';
+
+    // Should not throw — uses MODEL_SEC vars
+    const client = new ModelSecurityClient();
+    expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
+  });
+
+  it('explicit opts override env vars', () => {
+    process.env.PANW_MODEL_SEC_CLIENT_ID = 'env-cid';
+    process.env.PANW_MODEL_SEC_CLIENT_SECRET = 'env-csec';
+    process.env.PANW_MODEL_SEC_TSG_ID = 'env-tsg';
+
+    const client = new ModelSecurityClient({
+      clientId: 'override',
+      clientSecret: 'override-sec',
+      tsgId: 'override-tsg',
+    });
+    expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
+  });
+
+  it('throws when clientId missing', () => {
+    expect(
+      () =>
+        new ModelSecurityClient({
+          clientSecret: 'sec',
+          tsgId: '1',
+        }),
+    ).toThrow(AISecSDKException);
+  });
+
+  it('throws when clientSecret missing', () => {
+    expect(
+      () =>
+        new ModelSecurityClient({
+          clientId: 'cid',
+          tsgId: '1',
+        }),
+    ).toThrow(AISecSDKException);
+  });
+
+  it('throws when tsgId missing', () => {
+    expect(
+      () =>
+        new ModelSecurityClient({
+          clientId: 'cid',
+          clientSecret: 'sec',
+        }),
+    ).toThrow(AISecSDKException);
+  });
+
+  it('accepts custom endpoints', () => {
+    const client = new ModelSecurityClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+      dataEndpoint: 'https://data.example.com',
+      mgmtEndpoint: 'https://mgmt.example.com',
+      tokenEndpoint: 'https://auth.example.com/token',
+    });
+    expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
+  });
+
+  it('reads endpoints from env vars', () => {
+    process.env.PANW_MODEL_SEC_CLIENT_ID = 'cid';
+    process.env.PANW_MODEL_SEC_CLIENT_SECRET = 'sec';
+    process.env.PANW_MODEL_SEC_TSG_ID = '1';
+    process.env.PANW_MODEL_SEC_DATA_ENDPOINT = 'https://data.env.com';
+    process.env.PANW_MODEL_SEC_MGMT_ENDPOINT = 'https://mgmt.env.com';
+    process.env.PANW_MODEL_SEC_TOKEN_ENDPOINT = 'https://auth.env.com/token';
+
+    const client = new ModelSecurityClient();
+    expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
+  });
+
+  it('clamps numRetries to valid range', () => {
+    const client = new ModelSecurityClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+      numRetries: 10,
+    });
+    expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
+  });
+
+  it('clamps negative numRetries to 0', () => {
+    const client = new ModelSecurityClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+      numRetries: -1,
+    });
+    expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
+  });
+
+  it('defaults numRetries to 5', () => {
+    const client = new ModelSecurityClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+    });
+    expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
+  });
+
+  describe('getPyPIAuth', () => {
+    it('GETs /v1/pypi/authenticate', async () => {
+      const pypiResp = { url: 'https://artifact.example.com', expires_at: '2025-01-01T00:00:00Z' };
+      const tokenResp = { access_token: 'tok', token_type: 'bearer', expires_in: 3600 };
+      globalThis.fetch = vi
+        .fn()
+        // First call: OAuthClient.getToken() fetches a token
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(tokenResp),
+          text: () => Promise.resolve(JSON.stringify(tokenResp)),
+        })
+        // Second call: actual API request
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify(pypiResp)),
+        });
+
+      const client = new ModelSecurityClient({
+        clientId: 'cid',
+        clientSecret: 'sec',
+        tsgId: '1',
+        numRetries: 0,
+      });
+
+      const result = await client.getPyPIAuth();
+      expect(result.url).toBe('https://artifact.example.com');
+
+      // Second call is the actual API request
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain('/v1/pypi/authenticate');
+    });
+  });
+});

--- a/test/model-security/scans-client.spec.ts
+++ b/test/model-security/scans-client.spec.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ModelSecurityScansClient } from '../../src/model-security/scans-client.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+const now = '2025-01-01T00:00:00Z';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+const baseScan = {
+  uuid: validUuid,
+  tsg_id: '123',
+  created_at: now,
+  updated_at: now,
+  model_uri: 'hf://org/model',
+  owner: 'user@test.com',
+  scan_origin: 'MODEL_SECURITY_SDK',
+  security_group_uuid: validUuid,
+  security_group_name: 'default',
+  model_version_uuid: validUuid,
+  eval_outcome: 'ALLOWED',
+  source_type: 'HUGGING_FACE',
+};
+
+describe('ModelSecurityScansClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: ModelSecurityScansClient;
+
+  beforeEach(() => {
+    client = new ModelSecurityScansClient({
+      baseUrl: 'https://data.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // -----------------------------------------------------------------------
+  // create
+  // -----------------------------------------------------------------------
+  describe('create', () => {
+    it('POSTs to /v1/scans', async () => {
+      mockFetch(baseScan, 201);
+      const result = await client.create({
+        model_uri: 'hf://org/model',
+        security_group_uuid: validUuid,
+        scan_origin: 'MODEL_SECURITY_SDK',
+      });
+
+      expect(result.uuid).toBe(validUuid);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://data.example.com/v1/scans');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // list
+  // -----------------------------------------------------------------------
+  describe('list', () => {
+    it('GETs /v1/scans', async () => {
+      mockFetch({ pagination: { total_items: 1 }, scans: [baseScan] });
+      const result = await client.list();
+
+      expect(result.scans).toHaveLength(1);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/scans');
+    });
+
+    it('passes pagination params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, scans: [] });
+      await client.list({ skip: 10, limit: 5 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('skip=10');
+      expect(url).toContain('limit=5');
+    });
+
+    it('passes filter params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, scans: [] });
+      await client.list({
+        eval_outcome: 'ALLOWED',
+        source_type: 'HUGGING_FACE',
+        scan_origin: 'MODEL_SECURITY_SDK',
+      });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('eval_outcome=ALLOWED');
+      expect(url).toContain('source_type=HUGGING_FACE');
+      expect(url).toContain('scan_origin=MODEL_SECURITY_SDK');
+    });
+
+    it('passes sort params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, scans: [] });
+      await client.list({ sort_by: 'created_at', sort_direction: 'desc' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('sort_by=created_at');
+      expect(url).toContain('sort_direction=desc');
+    });
+
+    it('passes search param', async () => {
+      mockFetch({ pagination: { total_items: 0 }, scans: [] });
+      await client.list({ search: 'model-name' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('search=model-name');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // get
+  // -----------------------------------------------------------------------
+  describe('get', () => {
+    it('GETs /v1/scans/:uuid', async () => {
+      mockFetch(baseScan);
+      const result = await client.get(validUuid);
+
+      expect(result.uuid).toBe(validUuid);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/scans/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.get('bad-uuid')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getEvaluations
+  // -----------------------------------------------------------------------
+  describe('getEvaluations', () => {
+    it('GETs /v1/scans/:uuid/evaluations', async () => {
+      mockFetch({ pagination: { total_items: 0 }, evaluations: [] });
+      const result = await client.getEvaluations(validUuid);
+
+      expect(result.evaluations).toHaveLength(0);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/scans/${validUuid}/evaluations`);
+    });
+
+    it('passes pagination params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, evaluations: [] });
+      await client.getEvaluations(validUuid, { skip: 0, limit: 10 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('limit=10');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getEvaluations('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getFiles
+  // -----------------------------------------------------------------------
+  describe('getFiles', () => {
+    it('GETs /v1/scans/:uuid/files', async () => {
+      mockFetch({ pagination: { total_items: 0 }, files: [] });
+      const result = await client.getFiles(validUuid);
+
+      expect(result.files).toHaveLength(0);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/scans/${validUuid}/files`);
+    });
+
+    it('passes file filter params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, files: [] });
+      await client.getFiles(validUuid, { type: 'FILE', result: 'SUCCESS' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('type=FILE');
+      expect(url).toContain('result=SUCCESS');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getFiles('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // addLabels
+  // -----------------------------------------------------------------------
+  describe('addLabels', () => {
+    it('POSTs to /v1/scans/:uuid/labels', async () => {
+      mockFetch({});
+      await client.addLabels(validUuid, { labels: [{ key: 'env', value: 'prod' }] });
+
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/scans/${validUuid}/labels`);
+      expect(init.method).toBe('POST');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.addLabels('bad', { labels: [{ key: 'a', value: 'b' }] })).rejects.toThrow(
+        AISecSDKException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // setLabels
+  // -----------------------------------------------------------------------
+  describe('setLabels', () => {
+    it('PUTs to /v1/scans/:uuid/labels', async () => {
+      mockFetch({});
+      await client.setLabels(validUuid, { labels: [{ key: 'env', value: 'staging' }] });
+
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/scans/${validUuid}/labels`);
+      expect(init.method).toBe('PUT');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.setLabels('bad', { labels: [{ key: 'a', value: 'b' }] })).rejects.toThrow(
+        AISecSDKException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // deleteLabels
+  // -----------------------------------------------------------------------
+  describe('deleteLabels', () => {
+    it('DELETEs /v1/scans/:uuid/labels with keys query params', async () => {
+      mockFetch(undefined);
+      await client.deleteLabels(validUuid, ['env', 'team']);
+
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/scans/${validUuid}/labels`);
+      expect(url).toContain('keys=env');
+      expect(url).toContain('keys=team');
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('handles empty keys array', async () => {
+      mockFetch(undefined);
+      await client.deleteLabels(validUuid, []);
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/scans/${validUuid}/labels`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.deleteLabels('bad', ['env'])).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getViolations
+  // -----------------------------------------------------------------------
+  describe('getViolations', () => {
+    it('GETs /v1/scans/:uuid/rule-violations', async () => {
+      mockFetch({ pagination: { total_items: 0 }, violations: [] });
+      const result = await client.getViolations(validUuid);
+
+      expect(result.violations).toHaveLength(0);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/scans/${validUuid}/rule-violations`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getViolations('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getLabelKeys
+  // -----------------------------------------------------------------------
+  describe('getLabelKeys', () => {
+    it('GETs /v1/scans/label-keys', async () => {
+      mockFetch({ pagination: { total_items: 2 }, keys: ['env', 'team'] });
+      const result = await client.getLabelKeys();
+
+      expect(result.keys).toEqual(['env', 'team']);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/scans/label-keys');
+    });
+
+    it('passes pagination params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, keys: [] });
+      await client.getLabelKeys({ limit: 50 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('limit=50');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getLabelValues
+  // -----------------------------------------------------------------------
+  describe('getLabelValues', () => {
+    it('GETs /v1/scans/label-keys/:key/values', async () => {
+      mockFetch({ pagination: { total_items: 1 }, values: ['prod'] });
+      const result = await client.getLabelValues('env');
+
+      expect(result.values).toEqual(['prod']);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/scans/label-keys/env/values');
+    });
+
+    it('encodes special characters in key', async () => {
+      mockFetch({ pagination: { total_items: 0 }, values: [] });
+      await client.getLabelValues('my key');
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/scans/label-keys/my%20key/values');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getEvaluation
+  // -----------------------------------------------------------------------
+  describe('getEvaluation', () => {
+    it('GETs /v1/evaluations/:uuid', async () => {
+      const evalResp = {
+        uuid: validUuid,
+        tsg_id: '123',
+        created_at: now,
+        updated_at: now,
+        result: 'PASSED',
+        violation_count: 0,
+        rule_instance_uuid: validUuid,
+        scan_uuid: validUuid,
+        rule_name: 'rule-1',
+        rule_description: 'desc',
+        rule_instance_state: 'BLOCKING',
+      };
+      mockFetch(evalResp);
+      const result = await client.getEvaluation(validUuid);
+
+      expect(result.result).toBe('PASSED');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/evaluations/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getEvaluation('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getViolation
+  // -----------------------------------------------------------------------
+  describe('getViolation', () => {
+    it('GETs /v1/violations/:uuid', async () => {
+      const violation = {
+        uuid: validUuid,
+        tsg_id: '123',
+        created_at: now,
+        updated_at: now,
+        description: 'Malicious op',
+        rule_instance_uuid: validUuid,
+        rule_name: 'r',
+        rule_description: 'rd',
+        rule_instance_state: 'BLOCKING',
+      };
+      mockFetch(violation);
+      const result = await client.getViolation(validUuid);
+
+      expect(result.description).toBe('Malicious op');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/violations/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getViolation('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+});

--- a/test/model-security/security-groups-client.spec.ts
+++ b/test/model-security/security-groups-client.spec.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ModelSecurityGroupsClient } from '../../src/model-security/security-groups-client.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+const validUuid2 = '660e8400-e29b-41d4-a716-446655440000';
+const now = '2025-01-01T00:00:00Z';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+const sampleGroup = {
+  uuid: validUuid,
+  tsg_id: '123',
+  created_at: now,
+  updated_at: now,
+  name: 'default',
+  description: '',
+  source_type: 'HUGGING_FACE',
+  state: 'ACTIVE',
+  is_tombstone: false,
+};
+
+const baseRule = {
+  uuid: validUuid,
+  name: 'rule-1',
+  description: 'Test rule',
+  rule_type: 'ARTIFACT',
+  compatible_sources: ['HUGGING_FACE'],
+  default_state: 'BLOCKING',
+  remediation: { description: 'Fix', steps: ['s1'], url: 'https://example.com' },
+  editable_fields: [],
+  constant_values: {},
+  default_values: {},
+};
+
+const sampleRuleInstance = {
+  uuid: validUuid2,
+  tsg_id: '123',
+  created_at: now,
+  updated_at: now,
+  security_group_uuid: validUuid,
+  security_rule_uuid: validUuid,
+  state: 'BLOCKING',
+  rule: baseRule,
+};
+
+describe('ModelSecurityGroupsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: ModelSecurityGroupsClient;
+
+  beforeEach(() => {
+    client = new ModelSecurityGroupsClient({
+      baseUrl: 'https://mgmt.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('create', () => {
+    it('POSTs to /v1/security-groups', async () => {
+      mockFetch(sampleGroup, 201);
+      const result = await client.create({ name: 'default', source_type: 'HUGGING_FACE' });
+
+      expect(result.name).toBe('default');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://mgmt.example.com/v1/security-groups');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  describe('list', () => {
+    it('GETs /v1/security-groups', async () => {
+      mockFetch({ pagination: { total_items: 1 }, security_groups: [sampleGroup] });
+      const result = await client.list();
+
+      expect(result.security_groups).toHaveLength(1);
+    });
+
+    it('passes pagination params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, security_groups: [] });
+      await client.list({ skip: 5, limit: 10 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('skip=5');
+      expect(url).toContain('limit=10');
+    });
+  });
+
+  describe('get', () => {
+    it('GETs /v1/security-groups/:uuid', async () => {
+      mockFetch(sampleGroup);
+      const result = await client.get(validUuid);
+
+      expect(result.uuid).toBe(validUuid);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/security-groups/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.get('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('update', () => {
+    it('PUTs to /v1/security-groups/:uuid', async () => {
+      mockFetch({ ...sampleGroup, name: 'updated' });
+      const result = await client.update(validUuid, { name: 'updated' });
+
+      expect(result.name).toBe('updated');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/security-groups/${validUuid}`);
+      expect(init.method).toBe('PUT');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.update('bad', { name: 'x' })).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('delete', () => {
+    it('DELETEs /v1/security-groups/:uuid', async () => {
+      mockFetch(undefined);
+      await client.delete(validUuid);
+
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/security-groups/${validUuid}`);
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.delete('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('listRuleInstances', () => {
+    it('GETs /v1/security-groups/:uuid/rule-instances', async () => {
+      mockFetch({ pagination: { total_items: 1 }, rule_instances: [sampleRuleInstance] });
+      const result = await client.listRuleInstances(validUuid);
+
+      expect(result.rule_instances).toHaveLength(1);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/security-groups/${validUuid}/rule-instances`);
+    });
+
+    it('passes pagination params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, rule_instances: [] });
+      await client.listRuleInstances(validUuid, { limit: 20 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('limit=20');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.listRuleInstances('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getRuleInstance', () => {
+    it('GETs /v1/security-groups/:sgUuid/rule-instances/:riUuid', async () => {
+      mockFetch(sampleRuleInstance);
+      const result = await client.getRuleInstance(validUuid, validUuid2);
+
+      expect(result.state).toBe('BLOCKING');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/security-groups/${validUuid}/rule-instances/${validUuid2}`);
+    });
+
+    it('rejects invalid security group UUID', async () => {
+      await expect(client.getRuleInstance('bad', validUuid2)).rejects.toThrow(AISecSDKException);
+    });
+
+    it('rejects invalid rule instance UUID', async () => {
+      await expect(client.getRuleInstance(validUuid, 'bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('updateRuleInstance', () => {
+    it('PUTs to /v1/security-groups/:sgUuid/rule-instances/:riUuid', async () => {
+      mockFetch({ ...sampleRuleInstance, state: 'ALLOWING' });
+      const result = await client.updateRuleInstance(validUuid, validUuid2, {
+        security_group_uuid: validUuid,
+        state: 'ALLOWING',
+      });
+
+      expect(result.state).toBe('ALLOWING');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/security-groups/${validUuid}/rule-instances/${validUuid2}`);
+      expect(init.method).toBe('PUT');
+    });
+
+    it('rejects invalid security group UUID', async () => {
+      await expect(
+        client.updateRuleInstance('bad', validUuid2, {
+          security_group_uuid: validUuid,
+        }),
+      ).rejects.toThrow(AISecSDKException);
+    });
+
+    it('rejects invalid rule instance UUID', async () => {
+      await expect(
+        client.updateRuleInstance(validUuid, 'bad', {
+          security_group_uuid: validUuid,
+        }),
+      ).rejects.toThrow(AISecSDKException);
+    });
+  });
+});

--- a/test/model-security/security-rules-client.spec.ts
+++ b/test/model-security/security-rules-client.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ModelSecurityRulesClient } from '../../src/model-security/security-rules-client.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+const sampleRule = {
+  uuid: validUuid,
+  name: 'rule-1',
+  description: 'Test rule',
+  rule_type: 'ARTIFACT',
+  compatible_sources: ['HUGGING_FACE'],
+  default_state: 'BLOCKING',
+  remediation: { description: 'Fix', steps: ['s1'], url: 'https://example.com' },
+  editable_fields: [],
+  constant_values: {},
+  default_values: {},
+};
+
+describe('ModelSecurityRulesClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: ModelSecurityRulesClient;
+
+  beforeEach(() => {
+    client = new ModelSecurityRulesClient({
+      baseUrl: 'https://mgmt.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('list', () => {
+    it('GETs /v1/security-rules', async () => {
+      mockFetch({ pagination: { total_items: 1 }, rules: [sampleRule] });
+      const result = await client.list();
+
+      expect(result.rules).toHaveLength(1);
+      expect(result.rules[0].name).toBe('rule-1');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://mgmt.example.com/v1/security-rules');
+    });
+
+    it('passes pagination params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, rules: [] });
+      await client.list({ skip: 0, limit: 25, sort_by: 'created_at', sort_direction: 'asc' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('limit=25');
+      expect(url).toContain('sort_by=created_at');
+      expect(url).toContain('sort_direction=asc');
+    });
+
+    it('passes search param', async () => {
+      mockFetch({ pagination: { total_items: 0 }, rules: [] });
+      await client.list({ search: 'pickle' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('search=pickle');
+    });
+  });
+
+  describe('get', () => {
+    it('GETs /v1/security-rules/:uuid', async () => {
+      mockFetch(sampleRule);
+      const result = await client.get(validUuid);
+
+      expect(result.name).toBe('rule-1');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/security-rules/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.get('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+});

--- a/test/models/model-security-enums.spec.ts
+++ b/test/models/model-security-enums.spec.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ErrorCodes,
+  EvalOutcome,
+  FileScanResult,
+  FileType,
+  ModelScanStatus,
+  RuleEvaluationResult,
+  RuleState,
+  ScanOrigin,
+  SortByDateField,
+  SortByFileField,
+  SortDirection,
+  SourceType,
+  ThreatCategory,
+  ModelSecurityGroupState,
+  RuleType,
+  RuleEditableFieldType,
+  RuleFieldValueKey,
+} from '../../src/models/model-security-enums.js';
+
+describe('ErrorCodes', () => {
+  it('has expected values', () => {
+    expect(ErrorCodes.UNKNOWN_ERROR).toBe('UNKNOWN_ERROR');
+    expect(ErrorCodes.SCAN_ERROR).toBe('SCAN_ERROR');
+    expect(ErrorCodes.WORKER_ERROR).toBe('WORKER_ERROR');
+    expect(ErrorCodes.POLICY_EVAL_ERROR).toBe('POLICY_EVAL_ERROR');
+  });
+
+  it('has exactly 16 values', () => {
+    expect(Object.keys(ErrorCodes)).toHaveLength(16);
+  });
+
+  it('values are assignable to ErrorCodes type', () => {
+    const e: ErrorCodes = ErrorCodes.ACCESS_DENIED;
+    expect(e).toBe('ACCESS_DENIED');
+  });
+});
+
+describe('EvalOutcome', () => {
+  it('has expected values', () => {
+    expect(EvalOutcome.PENDING).toBe('PENDING');
+    expect(EvalOutcome.ALLOWED).toBe('ALLOWED');
+    expect(EvalOutcome.BLOCKED).toBe('BLOCKED');
+    expect(EvalOutcome.ERROR).toBe('ERROR');
+  });
+
+  it('has exactly 4 values', () => {
+    expect(Object.keys(EvalOutcome)).toHaveLength(4);
+  });
+});
+
+describe('FileScanResult', () => {
+  it('has expected values', () => {
+    expect(FileScanResult.SKIPPED).toBe('SKIPPED');
+    expect(FileScanResult.SUCCESS).toBe('SUCCESS');
+    expect(FileScanResult.ERROR).toBe('ERROR');
+    expect(FileScanResult.FAILED).toBe('FAILED');
+  });
+
+  it('has exactly 4 values', () => {
+    expect(Object.keys(FileScanResult)).toHaveLength(4);
+  });
+});
+
+describe('FileType', () => {
+  it('has expected values', () => {
+    expect(FileType.DIRECTORY).toBe('DIRECTORY');
+    expect(FileType.FILE).toBe('FILE');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(FileType)).toHaveLength(2);
+  });
+});
+
+describe('ModelScanStatus', () => {
+  it('has expected values', () => {
+    expect(ModelScanStatus.SCANNED).toBe('SCANNED');
+    expect(ModelScanStatus.SKIPPED).toBe('SKIPPED');
+    expect(ModelScanStatus.ERROR).toBe('ERROR');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(ModelScanStatus)).toHaveLength(3);
+  });
+});
+
+describe('RuleEvaluationResult', () => {
+  it('has expected values', () => {
+    expect(RuleEvaluationResult.PASSED).toBe('PASSED');
+    expect(RuleEvaluationResult.FAILED).toBe('FAILED');
+    expect(RuleEvaluationResult.ERROR).toBe('ERROR');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(RuleEvaluationResult)).toHaveLength(3);
+  });
+});
+
+describe('RuleState', () => {
+  it('has expected values', () => {
+    expect(RuleState.DISABLED).toBe('DISABLED');
+    expect(RuleState.ALLOWING).toBe('ALLOWING');
+    expect(RuleState.BLOCKING).toBe('BLOCKING');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(RuleState)).toHaveLength(3);
+  });
+});
+
+describe('ScanOrigin', () => {
+  it('has expected values', () => {
+    expect(ScanOrigin.MODEL_SECURITY_SDK).toBe('MODEL_SECURITY_SDK');
+    expect(ScanOrigin.HUGGING_FACE).toBe('HUGGING_FACE');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(ScanOrigin)).toHaveLength(2);
+  });
+});
+
+describe('SortByDateField', () => {
+  it('has expected values', () => {
+    expect(SortByDateField.CREATED_AT).toBe('created_at');
+    expect(SortByDateField.UPDATED_AT).toBe('updated_at');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(SortByDateField)).toHaveLength(2);
+  });
+});
+
+describe('SortByFileField', () => {
+  it('has expected values', () => {
+    expect(SortByFileField.PATH).toBe('path');
+    expect(SortByFileField.TYPE).toBe('type');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(SortByFileField)).toHaveLength(2);
+  });
+});
+
+describe('SortDirection', () => {
+  it('has expected values', () => {
+    expect(SortDirection.ASC).toBe('asc');
+    expect(SortDirection.DESC).toBe('desc');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(SortDirection)).toHaveLength(2);
+  });
+});
+
+describe('SourceType', () => {
+  it('has expected values', () => {
+    expect(SourceType.LOCAL).toBe('LOCAL');
+    expect(SourceType.HUGGING_FACE).toBe('HUGGING_FACE');
+    expect(SourceType.S3).toBe('S3');
+    expect(SourceType.GCS).toBe('GCS');
+    expect(SourceType.AZURE).toBe('AZURE');
+    expect(SourceType.ARTIFACTORY).toBe('ARTIFACTORY');
+    expect(SourceType.GITLAB).toBe('GITLAB');
+    expect(SourceType.ALL).toBe('ALL');
+  });
+
+  it('has exactly 8 values', () => {
+    expect(Object.keys(SourceType)).toHaveLength(8);
+  });
+});
+
+describe('ThreatCategory', () => {
+  it('has expected values', () => {
+    expect(ThreatCategory.PAIT_ARV_100).toBe('PAIT-ARV-100');
+    expect(ThreatCategory.PAIT_PKL_100).toBe('PAIT-PKL-100');
+    expect(ThreatCategory.UNAPPROVED_FORMATS).toBe('UNAPPROVED_FORMATS');
+  });
+
+  it('has exactly 30 values', () => {
+    expect(Object.keys(ThreatCategory)).toHaveLength(30);
+  });
+});
+
+describe('ModelSecurityGroupState', () => {
+  it('has expected values', () => {
+    expect(ModelSecurityGroupState.PENDING).toBe('PENDING');
+    expect(ModelSecurityGroupState.ACTIVE).toBe('ACTIVE');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(ModelSecurityGroupState)).toHaveLength(2);
+  });
+});
+
+describe('RuleType', () => {
+  it('has expected values', () => {
+    expect(RuleType.METADATA).toBe('METADATA');
+    expect(RuleType.ARTIFACT).toBe('ARTIFACT');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(RuleType)).toHaveLength(2);
+  });
+});
+
+describe('RuleEditableFieldType', () => {
+  it('has expected values', () => {
+    expect(RuleEditableFieldType.SELECT).toBe('SELECT');
+    expect(RuleEditableFieldType.LIST).toBe('LIST');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(RuleEditableFieldType)).toHaveLength(2);
+  });
+});
+
+describe('RuleFieldValueKey', () => {
+  it('has expected values', () => {
+    expect(RuleFieldValueKey.APPROVED_FORMATS).toBe('approved_formats');
+    expect(RuleFieldValueKey.APPROVED_LOCATIONS).toBe('approved_locations');
+    expect(RuleFieldValueKey.APPROVED_LICENSES).toBe('approved_licenses');
+    expect(RuleFieldValueKey.DENY_ORGS).toBe('deny_orgs');
+    expect(RuleFieldValueKey.DENIED_ORG_MODELS).toBe('denied_org_models');
+    expect(RuleFieldValueKey.APPROVED_ORG_MODELS).toBe('approved_org_models');
+  });
+
+  it('has exactly 6 values', () => {
+    expect(Object.keys(RuleFieldValueKey)).toHaveLength(6);
+  });
+});

--- a/test/models/model-security.spec.ts
+++ b/test/models/model-security.spec.ts
@@ -1,0 +1,536 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ModelSecurityPaginationSchema,
+  LabelSchema,
+  LabelsCreateRequestSchema,
+  LabelsResponseSchema,
+  LabelKeyListSchema,
+  LabelValueListSchema,
+  EvalSummarySchema,
+  ModelScanIssueSchema,
+  FileScanDataSchema,
+  ScanDetailsSchema,
+  ScanCreateRequestSchema,
+  ScanBaseResponseSchema,
+  ScanListSchema,
+  FileResponseSchema,
+  FileListSchema,
+  RuleEvaluationResponseSchema,
+  RuleEvaluationListSchema,
+  ViolationResponseSchema,
+  ViolationListSchema,
+  RuleEditableFieldDropdownSchema,
+  RuleEditableFieldSchema,
+  RuleRemediationSchema,
+  RuleConfigurationSchema,
+  ModelSecurityRuleResponseSchema,
+  ListModelSecurityRulesResponseSchema,
+  ModelSecurityRuleInstanceResponseSchema,
+  ModelSecurityRuleInstanceUpdateRequestSchema,
+  ListModelSecurityRuleInstancesResponseSchema,
+  ModelSecurityGroupCreateRequestSchema,
+  ModelSecurityGroupResponseSchema,
+  ModelSecurityGroupUpdateRequestSchema,
+  ListModelSecurityGroupsResponseSchema,
+  PyPIAuthResponseSchema,
+} from '../../src/models/model-security.js';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+const now = '2025-01-01T00:00:00Z';
+
+const baseScan = {
+  uuid: validUuid,
+  tsg_id: '123',
+  created_at: now,
+  updated_at: now,
+  model_uri: 'hf://org/model',
+  owner: 'user@test.com',
+  scan_origin: 'MODEL_SECURITY_SDK',
+  security_group_uuid: validUuid,
+  security_group_name: 'default',
+  model_version_uuid: validUuid,
+  eval_outcome: 'ALLOWED',
+  source_type: 'HUGGING_FACE',
+};
+
+const baseRule = {
+  uuid: validUuid,
+  name: 'rule-1',
+  description: 'Test rule',
+  rule_type: 'ARTIFACT',
+  compatible_sources: ['HUGGING_FACE'],
+  default_state: 'BLOCKING',
+  remediation: { description: 'Fix it', steps: ['step1'], url: 'https://example.com' },
+  editable_fields: [],
+  constant_values: {},
+  default_values: {},
+};
+
+// ---------------------------------------------------------------------------
+// DataPlane schemas
+// ---------------------------------------------------------------------------
+
+describe('ModelSecurityPaginationSchema', () => {
+  it('parses valid pagination', () => {
+    expect(ModelSecurityPaginationSchema.parse({ total_items: 42 })).toEqual({ total_items: 42 });
+  });
+
+  it('accepts null total_items', () => {
+    expect(ModelSecurityPaginationSchema.parse({ total_items: null })).toEqual({
+      total_items: null,
+    });
+  });
+
+  it('accepts missing total_items', () => {
+    expect(ModelSecurityPaginationSchema.parse({})).toEqual({});
+  });
+
+  it('passes through unknown fields', () => {
+    const res = ModelSecurityPaginationSchema.parse({ total_items: 1, extra: true });
+    expect((res as Record<string, unknown>).extra).toBe(true);
+  });
+});
+
+describe('LabelSchema', () => {
+  it('parses valid label', () => {
+    expect(LabelSchema.parse({ key: 'env', value: 'prod' })).toEqual({
+      key: 'env',
+      value: 'prod',
+    });
+  });
+
+  it('rejects missing key', () => {
+    expect(() => LabelSchema.parse({ value: 'v' })).toThrow();
+  });
+});
+
+describe('LabelsCreateRequestSchema', () => {
+  it('parses valid request', () => {
+    const req = { labels: [{ key: 'a', value: 'b' }] };
+    expect(LabelsCreateRequestSchema.parse(req).labels).toHaveLength(1);
+  });
+
+  it('accepts empty labels array', () => {
+    expect(LabelsCreateRequestSchema.parse({ labels: [] }).labels).toHaveLength(0);
+  });
+});
+
+describe('LabelsResponseSchema', () => {
+  it('parses empty object', () => {
+    expect(LabelsResponseSchema.parse({})).toEqual({});
+  });
+
+  it('passes through extra fields', () => {
+    const res = LabelsResponseSchema.parse({ message: 'ok' });
+    expect((res as Record<string, unknown>).message).toBe('ok');
+  });
+});
+
+describe('LabelKeyListSchema', () => {
+  it('parses valid list', () => {
+    const data = { pagination: { total_items: 2 }, keys: ['env', 'team'] };
+    const parsed = LabelKeyListSchema.parse(data);
+    expect(parsed.keys).toEqual(['env', 'team']);
+    expect(parsed.pagination.total_items).toBe(2);
+  });
+});
+
+describe('LabelValueListSchema', () => {
+  it('parses valid list', () => {
+    const data = { pagination: { total_items: 1 }, values: ['prod'] };
+    expect(LabelValueListSchema.parse(data).values).toEqual(['prod']);
+  });
+});
+
+describe('EvalSummarySchema', () => {
+  it('parses with defaults', () => {
+    const parsed = EvalSummarySchema.parse({});
+    expect(parsed.rules_failed).toBe(0);
+    expect(parsed.rules_passed).toBe(0);
+    expect(parsed.total_rules).toBe(0);
+  });
+
+  it('parses explicit values', () => {
+    const parsed = EvalSummarySchema.parse({
+      rules_failed: 1,
+      rules_passed: 9,
+      total_rules: 10,
+    });
+    expect(parsed.total_rules).toBe(10);
+  });
+});
+
+describe('ModelScanIssueSchema', () => {
+  it('parses valid issue', () => {
+    const issue = { description: 'Bad op', source: 'pickle' };
+    expect(ModelScanIssueSchema.parse(issue).description).toBe('Bad op');
+  });
+
+  it('accepts optional fields as null', () => {
+    const issue = {
+      description: 'd',
+      source: 's',
+      threat: null,
+      module: null,
+      operator: null,
+    };
+    expect(ModelScanIssueSchema.parse(issue).threat).toBeNull();
+  });
+});
+
+describe('FileScanDataSchema', () => {
+  it('parses valid file scan data', () => {
+    const data = {
+      file_path: 'model.pkl',
+      modelscan_status: 'SCANNED',
+      blob_id: 'abc123',
+    };
+    expect(FileScanDataSchema.parse(data).file_path).toBe('model.pkl');
+  });
+});
+
+describe('ScanDetailsSchema', () => {
+  it('parses valid scan details', () => {
+    const details = {
+      scanner_version: '1.0.0',
+      time_started: now,
+      files: [],
+      total_files_scanned: 5,
+      total_files_skipped: 1,
+      model_formats: ['pickle'],
+      model_size_bytes: 1024,
+      scan_duration_ms: 500,
+    };
+    expect(ScanDetailsSchema.parse(details).scanner_version).toBe('1.0.0');
+  });
+});
+
+describe('ScanCreateRequestSchema', () => {
+  it('parses minimal request', () => {
+    const req = {
+      model_uri: 'hf://org/model',
+      security_group_uuid: validUuid,
+      scan_origin: 'MODEL_SECURITY_SDK',
+    };
+    expect(ScanCreateRequestSchema.parse(req).model_uri).toBe('hf://org/model');
+  });
+
+  it('parses full request with optionals', () => {
+    const req = {
+      model_uri: 'hf://org/model',
+      security_group_uuid: validUuid,
+      scan_origin: 'MODEL_SECURITY_SDK',
+      allow_patterns: ['*.pkl'],
+      ignore_patterns: ['*.tmp'],
+      labels: [{ key: 'env', value: 'prod' }],
+      model_author: 'author',
+      model_name: 'model',
+      model_version: '1.0',
+    };
+    const parsed = ScanCreateRequestSchema.parse(req);
+    expect(parsed.labels).toHaveLength(1);
+    expect(parsed.model_author).toBe('author');
+  });
+});
+
+describe('ScanBaseResponseSchema', () => {
+  it('parses valid scan response', () => {
+    const parsed = ScanBaseResponseSchema.parse(baseScan);
+    expect(parsed.uuid).toBe(validUuid);
+    expect(parsed.eval_outcome).toBe('ALLOWED');
+  });
+
+  it('accepts optional fields', () => {
+    const full = {
+      ...baseScan,
+      eval_summary: { rules_failed: 0, rules_passed: 5, total_rules: 5 },
+      labels: [{ key: 'env', value: 'test' }],
+      scanner_version: '1.0.0',
+    };
+    const parsed = ScanBaseResponseSchema.parse(full);
+    expect(parsed.eval_summary?.total_rules).toBe(5);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = ScanBaseResponseSchema.parse({ ...baseScan, future_field: true });
+    expect((res as Record<string, unknown>).future_field).toBe(true);
+  });
+});
+
+describe('ScanListSchema', () => {
+  it('parses valid list', () => {
+    const data = { pagination: { total_items: 1 }, scans: [baseScan] };
+    const parsed = ScanListSchema.parse(data);
+    expect(parsed.scans).toHaveLength(1);
+    expect(parsed.pagination.total_items).toBe(1);
+  });
+});
+
+describe('FileResponseSchema', () => {
+  it('parses valid file response', () => {
+    const file = {
+      uuid: validUuid,
+      tsg_id: '123',
+      created_at: now,
+      updated_at: now,
+      path: '/model.pkl',
+      parent_path: '/',
+      type: 'FILE',
+      result: 'SUCCESS',
+      model_version_uuid: validUuid,
+    };
+    expect(FileResponseSchema.parse(file).path).toBe('/model.pkl');
+  });
+});
+
+describe('FileListSchema', () => {
+  it('parses valid file list', () => {
+    const data = {
+      pagination: { total_items: 0 },
+      files: [],
+    };
+    expect(FileListSchema.parse(data).files).toHaveLength(0);
+  });
+});
+
+describe('RuleEvaluationResponseSchema', () => {
+  it('parses valid evaluation', () => {
+    const eval_ = {
+      uuid: validUuid,
+      tsg_id: '123',
+      created_at: now,
+      updated_at: now,
+      result: 'PASSED',
+      violation_count: 0,
+      rule_instance_uuid: validUuid,
+      scan_uuid: validUuid,
+      rule_name: 'rule-1',
+      rule_description: 'desc',
+      rule_instance_state: 'BLOCKING',
+    };
+    expect(RuleEvaluationResponseSchema.parse(eval_).result).toBe('PASSED');
+  });
+});
+
+describe('RuleEvaluationListSchema', () => {
+  it('parses empty list', () => {
+    const data = { pagination: { total_items: 0 }, evaluations: [] };
+    expect(RuleEvaluationListSchema.parse(data).evaluations).toHaveLength(0);
+  });
+});
+
+describe('ViolationResponseSchema', () => {
+  it('parses valid violation', () => {
+    const v = {
+      uuid: validUuid,
+      tsg_id: '123',
+      created_at: now,
+      updated_at: now,
+      description: 'Malicious op found',
+      rule_instance_uuid: validUuid,
+      rule_name: 'rule-1',
+      rule_description: 'desc',
+      rule_instance_state: 'BLOCKING',
+    };
+    expect(ViolationResponseSchema.parse(v).description).toBe('Malicious op found');
+  });
+
+  it('accepts optional threat fields', () => {
+    const v = {
+      uuid: validUuid,
+      tsg_id: '123',
+      created_at: now,
+      updated_at: now,
+      description: 'd',
+      rule_instance_uuid: validUuid,
+      rule_name: 'r',
+      rule_description: 'rd',
+      rule_instance_state: 'BLOCKING',
+      file: 'model.pkl',
+      hash: 'abc',
+      threat: 'PAIT-PKL-100',
+      threat_description: 'Pickle exploit',
+    };
+    const parsed = ViolationResponseSchema.parse(v);
+    expect(parsed.threat).toBe('PAIT-PKL-100');
+  });
+});
+
+describe('ViolationListSchema', () => {
+  it('parses empty list', () => {
+    const data = { pagination: { total_items: 0 }, violations: [] };
+    expect(ViolationListSchema.parse(data).violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Management schemas
+// ---------------------------------------------------------------------------
+
+describe('RuleEditableFieldDropdownSchema', () => {
+  it('parses valid dropdown', () => {
+    const d = { value: 'v1', label: 'Label 1' };
+    expect(RuleEditableFieldDropdownSchema.parse(d).value).toBe('v1');
+  });
+});
+
+describe('RuleEditableFieldSchema', () => {
+  it('parses valid field', () => {
+    const f = {
+      attribute_name: 'approved_formats',
+      type: 'LIST',
+      display_name: 'Approved Formats',
+      display_type: 'LIST',
+    };
+    expect(RuleEditableFieldSchema.parse(f).attribute_name).toBe('approved_formats');
+  });
+});
+
+describe('RuleRemediationSchema', () => {
+  it('parses valid remediation', () => {
+    const r = { description: 'Fix', steps: ['s1', 's2'], url: 'https://example.com' };
+    expect(RuleRemediationSchema.parse(r).steps).toHaveLength(2);
+  });
+});
+
+describe('RuleConfigurationSchema', () => {
+  it('parses with state and field_values', () => {
+    const c = { state: 'BLOCKING', field_values: { approved_formats: ['pickle'] } };
+    expect(RuleConfigurationSchema.parse(c).state).toBe('BLOCKING');
+  });
+
+  it('parses minimal config', () => {
+    expect(RuleConfigurationSchema.parse({})).toBeDefined();
+  });
+});
+
+describe('ModelSecurityRuleResponseSchema', () => {
+  it('parses valid rule', () => {
+    const parsed = ModelSecurityRuleResponseSchema.parse(baseRule);
+    expect(parsed.name).toBe('rule-1');
+    expect(parsed.compatible_sources).toContain('HUGGING_FACE');
+  });
+});
+
+describe('ListModelSecurityRulesResponseSchema', () => {
+  it('parses valid list', () => {
+    const data = { pagination: { total_items: 1 }, rules: [baseRule] };
+    expect(ListModelSecurityRulesResponseSchema.parse(data).rules).toHaveLength(1);
+  });
+});
+
+describe('ModelSecurityRuleInstanceResponseSchema', () => {
+  it('parses valid instance', () => {
+    const inst = {
+      uuid: validUuid,
+      tsg_id: '123',
+      created_at: now,
+      updated_at: now,
+      security_group_uuid: validUuid,
+      security_rule_uuid: validUuid,
+      state: 'BLOCKING',
+      rule: baseRule,
+    };
+    expect(ModelSecurityRuleInstanceResponseSchema.parse(inst).state).toBe('BLOCKING');
+  });
+});
+
+describe('ModelSecurityRuleInstanceUpdateRequestSchema', () => {
+  it('parses valid update', () => {
+    const req = {
+      security_group_uuid: validUuid,
+      state: 'ALLOWING',
+      field_values: { approved_formats: ['onnx'] },
+    };
+    expect(ModelSecurityRuleInstanceUpdateRequestSchema.parse(req).state).toBe('ALLOWING');
+  });
+
+  it('parses minimal update', () => {
+    const req = { security_group_uuid: validUuid };
+    expect(ModelSecurityRuleInstanceUpdateRequestSchema.parse(req).security_group_uuid).toBe(
+      validUuid,
+    );
+  });
+});
+
+describe('ListModelSecurityRuleInstancesResponseSchema', () => {
+  it('parses empty list', () => {
+    const data = { pagination: { total_items: 0 }, rule_instances: [] };
+    expect(ListModelSecurityRuleInstancesResponseSchema.parse(data).rule_instances).toHaveLength(0);
+  });
+});
+
+describe('ModelSecurityGroupCreateRequestSchema', () => {
+  it('parses minimal request', () => {
+    const req = { name: 'test-group', source_type: 'HUGGING_FACE' };
+    const parsed = ModelSecurityGroupCreateRequestSchema.parse(req);
+    expect(parsed.name).toBe('test-group');
+    expect(parsed.description).toBe('');
+  });
+
+  it('parses full request', () => {
+    const req = {
+      name: 'test-group',
+      source_type: 'HUGGING_FACE',
+      description: 'My group',
+      rule_configurations: {
+        [validUuid]: { state: 'BLOCKING', field_values: {} },
+      },
+    };
+    const parsed = ModelSecurityGroupCreateRequestSchema.parse(req);
+    expect(parsed.description).toBe('My group');
+  });
+});
+
+describe('ModelSecurityGroupResponseSchema', () => {
+  it('parses valid group', () => {
+    const group = {
+      uuid: validUuid,
+      tsg_id: '123',
+      created_at: now,
+      updated_at: now,
+      name: 'default',
+      description: '',
+      source_type: 'HUGGING_FACE',
+      state: 'ACTIVE',
+      is_tombstone: false,
+    };
+    expect(ModelSecurityGroupResponseSchema.parse(group).name).toBe('default');
+  });
+});
+
+describe('ModelSecurityGroupUpdateRequestSchema', () => {
+  it('parses name update', () => {
+    expect(ModelSecurityGroupUpdateRequestSchema.parse({ name: 'new' }).name).toBe('new');
+  });
+
+  it('parses empty update', () => {
+    expect(ModelSecurityGroupUpdateRequestSchema.parse({})).toBeDefined();
+  });
+});
+
+describe('ListModelSecurityGroupsResponseSchema', () => {
+  it('parses empty list', () => {
+    const data = { pagination: { total_items: 0 }, security_groups: [] };
+    expect(ListModelSecurityGroupsResponseSchema.parse(data).security_groups).toHaveLength(0);
+  });
+});
+
+describe('PyPIAuthResponseSchema', () => {
+  it('parses valid response', () => {
+    const data = { url: 'https://artifact.example.com', expires_at: now };
+    const parsed = PyPIAuthResponseSchema.parse(data);
+    expect(parsed.url).toBe('https://artifact.example.com');
+    expect(parsed.expires_at).toBe(now);
+  });
+
+  it('passes through extra fields', () => {
+    const data = { url: 'https://x.com', expires_at: now, extra: 'field' };
+    const parsed = PyPIAuthResponseSchema.parse(data);
+    expect((parsed as Record<string, unknown>).extra).toBe('field');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds complete Model Security service client (AIRS Model Security Data Plane + Management Plane APIs)
- 17 typed enum const objects for API values (EvalOutcome, SourceType, ThreatCategory, etc.)
- 33 Zod schemas + TypeScript types for all data/management plane models
- `ModelSecurityClient` facade with dual endpoints (data plane for scans, mgmt plane for security groups/rules)
- `ModelSecurityScansClient`: 13 methods (create, list, get, evaluations, files, labels CRUD, violations, label keys/values)
- `ModelSecurityGroupsClient`: 8 methods (CRUD + rule instance management)
- `ModelSecurityRulesClient`: 2 read-only methods (list, get)
- `getPyPIAuth()` for Google Artifact Registry authentication
- Env var fallback chain: `PANW_MODEL_SEC_*` -> `PANW_MGMT_*`
- 153 new tests (325 total), all passing

Closes #7

## Test plan
- [x] 35 enum tests covering all 17 const objects
- [x] 50 Zod schema tests for valid/invalid parsing across all 33 schemas
- [x] 14 ModelSecurityClient constructor tests (env vars, fallbacks, missing fields, endpoints)
- [x] 31 ModelSecurityScansClient method tests
- [x] 18 ModelSecurityGroupsClient method tests
- [x] 5 ModelSecurityRulesClient method tests
- [x] All UUID validation rejection tests
- [x] typecheck, lint, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)