### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/.changeset/0002-model-security-service.md
+++ b/.changeset/0002-model-security-service.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Add Model Security service client for AIRS Model Security Data Plane and Management Plane APIs. Includes typed enums, Zod schemas, and full client coverage for scans, security groups, security rules, labels, evaluations, violations, and PyPI authentication.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "TypeScript SDK for Palo Alto Networks AI Runtime Security",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.2.1';
+export const SDK_VERSION = '0.3.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
## Summary
- Bump version from 0.2.1 to 0.3.0 for Model Security service release
- Update SDK_VERSION constant and package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)