### PR TITLE
Add Red Team service client

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -87,3 +87,34 @@ export const MODEL_SEC_VIOLATIONS_PATH = '/v1/violations';
 export const MODEL_SEC_SECURITY_GROUPS_PATH = '/v1/security-groups';
 export const MODEL_SEC_SECURITY_RULES_PATH = '/v1/security-rules';
 export const MODEL_SEC_PYPI_AUTH_PATH = '/v1/pypi/authenticate';
+
+// Red Team API defaults
+export const DEFAULT_RED_TEAM_DATA_ENDPOINT =
+  'https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane';
+export const DEFAULT_RED_TEAM_MGMT_ENDPOINT =
+  'https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane';
+
+// Red Team env vars
+export const RED_TEAM_CLIENT_ID = 'PANW_RED_TEAM_CLIENT_ID';
+export const RED_TEAM_CLIENT_SECRET = 'PANW_RED_TEAM_CLIENT_SECRET';
+export const RED_TEAM_TSG_ID = 'PANW_RED_TEAM_TSG_ID';
+export const RED_TEAM_DATA_ENDPOINT = 'PANW_RED_TEAM_DATA_ENDPOINT';
+export const RED_TEAM_MGMT_ENDPOINT = 'PANW_RED_TEAM_MGMT_ENDPOINT';
+export const RED_TEAM_TOKEN_ENDPOINT = 'PANW_RED_TEAM_TOKEN_ENDPOINT';
+
+// API paths — red team data plane
+export const RED_TEAM_SCAN_PATH = '/v1/scan';
+export const RED_TEAM_CATEGORIES_PATH = '/v1/categories';
+export const RED_TEAM_REPORT_STATIC_PATH = '/v1/report/static';
+export const RED_TEAM_REPORT_DYNAMIC_PATH = '/v1/report/dynamic';
+export const RED_TEAM_REPORT_PATH = '/v1/report';
+export const RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH = '/v1/custom-attacks';
+export const RED_TEAM_DASHBOARD_PATH = '/v1/dashboard';
+export const RED_TEAM_QUOTA_PATH = '/v1/metering/quota';
+export const RED_TEAM_ERROR_LOG_PATH = '/v1/error-log/job';
+export const RED_TEAM_SENTIMENT_PATH = '/v1/sentiment';
+
+// API paths — red team management plane
+export const RED_TEAM_TARGET_PATH = '/v1/target';
+export const RED_TEAM_CUSTOM_ATTACK_PATH = '/v1/custom-attack';
+export const RED_TEAM_MGMT_DASHBOARD_PATH = '/v1/dashboard/overview';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from './models/index.js';
 export * from './constants.js';
 export * from './management/index.js';
 export * from './model-security/index.js';
+export * from './red-team/index.js';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -89,3 +89,5 @@ export {
 } from './mgmt-custom-topic.js';
 export * from './model-security-enums.js';
 export * from './model-security.js';
+export * from './red-team-enums.js';
+export * from './red-team.js';

--- a/src/models/red-team-enums.ts
+++ b/src/models/red-team-enums.ts
@@ -1,0 +1,284 @@
+// src/models/red-team-enums.ts — typed enums for AIRS Red Teaming API values
+
+/** API endpoint accessibility type. */
+export const ApiEndpointType = {
+  PUBLIC: 'PUBLIC',
+  PRIVATE: 'PRIVATE',
+  NETWORK_BROKER: 'NETWORK_BROKER',
+} as const;
+export type ApiEndpointType = (typeof ApiEndpointType)[keyof typeof ApiEndpointType];
+
+/** Attack lifecycle status. */
+export const AttackStatus = {
+  INIT: 'INIT',
+  ATTACK: 'ATTACK',
+  DETECTION: 'DETECTION',
+  REPORT: 'REPORT',
+  COMPLETED: 'COMPLETED',
+  FAILED: 'FAILED',
+} as const;
+export type AttackStatus = (typeof AttackStatus)[keyof typeof AttackStatus];
+
+/** Attack type classification. */
+export const AttackType = {
+  NORMAL: 'NORMAL',
+  CUSTOM: 'CUSTOM',
+} as const;
+export type AttackType = (typeof AttackType)[keyof typeof AttackType];
+
+/** Authentication type for target connections. */
+export const AuthType = {
+  OAUTH: 'OAUTH',
+  ACCESS_TOKEN: 'ACCESS_TOKEN',
+} as const;
+export type AuthType = (typeof AuthType)[keyof typeof AuthType];
+
+/** Brand risk subcategories. */
+export const BrandSubCategory = {
+  COMPETITOR_ENDORSEMENTS: 'COMPETITOR_ENDORSEMENTS',
+  BRAND_TARNISHING_SELF_CRITICISM: 'BRAND_TARNISHING_SELF_CRITICISM',
+  DISCRIMINATING_CLAIMS: 'DISCRIMINATING_CLAIMS',
+  POLITICAL_ENDORSEMENTS: 'POLITICAL_ENDORSEMENTS',
+} as const;
+export type BrandSubCategory = (typeof BrandSubCategory)[keyof typeof BrandSubCategory];
+
+/** Compliance framework subcategories. */
+export const ComplianceSubCategory = {
+  OWASP: 'OWASP',
+  MITRE_ATLAS: 'MITRE_ATLAS',
+  NIST: 'NIST',
+  DASF_V2: 'DASF_V2',
+} as const;
+export type ComplianceSubCategory =
+  (typeof ComplianceSubCategory)[keyof typeof ComplianceSubCategory];
+
+/** Whether a scan counts toward quota. */
+export const CountedQuotaEnum = {
+  HELD: 'HELD',
+  COUNTED: 'COUNTED',
+  NOT_COUNTED: 'NOT_COUNTED',
+} as const;
+export type CountedQuotaEnum = (typeof CountedQuotaEnum)[keyof typeof CountedQuotaEnum];
+
+/** Date range filter for dashboard queries. */
+export const DateRangeFilter = {
+  LAST_7_DAYS: 'LAST_7_DAYS',
+  LAST_15_DAYS: 'LAST_15_DAYS',
+  LAST_30_DAYS: 'LAST_30_DAYS',
+  ALL: 'ALL',
+} as const;
+export type DateRangeFilter = (typeof DateRangeFilter)[keyof typeof DateRangeFilter];
+
+/** Error source for error log entries. */
+export const ErrorSource = {
+  TARGET: 'TARGET',
+  JOB: 'JOB',
+  SYSTEM: 'SYSTEM',
+  VALIDATION: 'VALIDATION',
+  TARGET_PROFILING: 'TARGET_PROFILING',
+} as const;
+export type ErrorSource = (typeof ErrorSource)[keyof typeof ErrorSource];
+
+/** Red Team error type classification (prefixed to avoid conflict with SDK ErrorType). */
+export const RedTeamErrorType = {
+  CONTENT_FILTER: 'CONTENT_FILTER',
+  RATE_LIMIT: 'RATE_LIMIT',
+  AUTHENTICATION: 'AUTHENTICATION',
+  NETWORK: 'NETWORK',
+  VALIDATION: 'VALIDATION',
+  NETWORK_CHANNEL: 'NETWORK_CHANNEL',
+  UNKNOWN: 'UNKNOWN',
+} as const;
+export type RedTeamErrorType = (typeof RedTeamErrorType)[keyof typeof RedTeamErrorType];
+
+/** Report download file format. */
+export const FileFormat = {
+  CSV: 'CSV',
+  JSON: 'JSON',
+  ALL: 'ALL',
+} as const;
+export type FileFormat = (typeof FileFormat)[keyof typeof FileFormat];
+
+/** Dynamic scan goal type. */
+export const GoalType = {
+  BASE: 'BASE',
+  TOOL_MISUSE: 'TOOL_MISUSE',
+  GOAL_MANIPULATION: 'GOAL_MANIPULATION',
+} as const;
+export type GoalType = (typeof GoalType)[keyof typeof GoalType];
+
+/** Goal type query parameter filter. */
+export const GoalTypeQueryParam = {
+  AGENT: 'AGENT',
+  HUMAN_AUGMENTED: 'HUMAN_AUGMENTED',
+} as const;
+export type GoalTypeQueryParam = (typeof GoalTypeQueryParam)[keyof typeof GoalTypeQueryParam];
+
+/** Guardrail action for runtime security policies. */
+export const GuardrailAction = {
+  ALLOW: 'ALLOW',
+  BLOCK: 'BLOCK',
+} as const;
+export type GuardrailAction = (typeof GuardrailAction)[keyof typeof GuardrailAction];
+
+/** Red team scan job status. */
+export const JobStatus = {
+  INIT: 'INIT',
+  QUEUED: 'QUEUED',
+  RUNNING: 'RUNNING',
+  COMPLETED: 'COMPLETED',
+  PARTIALLY_COMPLETE: 'PARTIALLY_COMPLETE',
+  FAILED: 'FAILED',
+  ABORTED: 'ABORTED',
+} as const;
+export type JobStatus = (typeof JobStatus)[keyof typeof JobStatus];
+
+/** Job status values available for filtering (excludes INIT). */
+export const JobStatusFilter = {
+  QUEUED: 'QUEUED',
+  RUNNING: 'RUNNING',
+  COMPLETED: 'COMPLETED',
+  PARTIALLY_COMPLETE: 'PARTIALLY_COMPLETE',
+  FAILED: 'FAILED',
+  ABORTED: 'ABORTED',
+} as const;
+export type JobStatusFilter = (typeof JobStatusFilter)[keyof typeof JobStatusFilter];
+
+/** Red team scan job type. */
+export const JobType = {
+  STATIC: 'STATIC',
+  DYNAMIC: 'DYNAMIC',
+  CUSTOM: 'CUSTOM',
+} as const;
+export type JobType = (typeof JobType)[keyof typeof JobType];
+
+/** Runtime security policy type. */
+export const PolicyType = {
+  PROMPT_INJECTION: 'PROMPT_INJECTION',
+  TOXIC_CONTENT: 'TOXIC_CONTENT',
+  CUSTOM_TOPIC_GUARDRAILS: 'CUSTOM_TOPIC_GUARDRAILS',
+  MALICIOUS_CODE_DETECTION: 'MALICIOUS_CODE_DETECTION',
+  MALICIOUS_URL_DETECTION: 'MALICIOUS_URL_DETECTION',
+  SENSITIVE_DATA_PROTECTION: 'SENSITIVE_DATA_PROTECTION',
+} as const;
+export type PolicyType = (typeof PolicyType)[keyof typeof PolicyType];
+
+/** Target profiling status. */
+export const ProfilingStatus = {
+  INIT: 'INIT',
+  QUEUED: 'QUEUED',
+  IN_PROGRESS: 'IN_PROGRESS',
+  COMPLETED: 'COMPLETED',
+  FAILED: 'FAILED',
+} as const;
+export type ProfilingStatus = (typeof ProfilingStatus)[keyof typeof ProfilingStatus];
+
+/** Red Team risk category (prefixed to avoid conflict with SDK Category). */
+export const RedTeamCategory = {
+  SECURITY: 'SECURITY',
+  SAFETY: 'SAFETY',
+  COMPLIANCE: 'COMPLIANCE',
+  BRAND: 'BRAND',
+} as const;
+export type RedTeamCategory = (typeof RedTeamCategory)[keyof typeof RedTeamCategory];
+
+/** Target response mode. */
+export const ResponseMode = {
+  REST: 'REST',
+  STREAMING: 'STREAMING',
+} as const;
+export type ResponseMode = (typeof ResponseMode)[keyof typeof ResponseMode];
+
+/** Risk rating levels. */
+export const RiskRating = {
+  LOW: 'LOW',
+  MEDIUM: 'MEDIUM',
+  HIGH: 'HIGH',
+  CRITICAL: 'CRITICAL',
+} as const;
+export type RiskRating = (typeof RiskRating)[keyof typeof RiskRating];
+
+/** Safety risk subcategories. */
+export const SafetySubCategory = {
+  BIAS: 'BIAS',
+  CBRN: 'CBRN',
+  CYBERCRIME: 'CYBERCRIME',
+  DRUGS: 'DRUGS',
+  HATE_TOXIC_ABUSE: 'HATE_TOXIC_ABUSE',
+  NON_VIOLENT_CRIMES: 'NON_VIOLENT_CRIMES',
+  POLITICAL: 'POLITICAL',
+  SELF_HARM: 'SELF_HARM',
+  SEXUAL: 'SEXUAL',
+  VIOLENT_CRIMES_WEAPONS: 'VIOLENT_CRIMES_WEAPONS',
+} as const;
+export type SafetySubCategory = (typeof SafetySubCategory)[keyof typeof SafetySubCategory];
+
+/** Security risk subcategories. */
+export const SecuritySubCategory = {
+  ADVERSARIAL_SUFFIX: 'ADVERSARIAL_SUFFIX',
+  EVASION: 'EVASION',
+  INDIRECT_PROMPT_INJECTION: 'INDIRECT_PROMPT_INJECTION',
+  JAILBREAK: 'JAILBREAK',
+  MULTI_TURN: 'MULTI_TURN',
+  PROMPT_INJECTION: 'PROMPT_INJECTION',
+  REMOTE_CODE_EXECUTION: 'REMOTE_CODE_EXECUTION',
+  SYSTEM_PROMPT_LEAK: 'SYSTEM_PROMPT_LEAK',
+  TOOL_LEAK: 'TOOL_LEAK',
+  MALWARE_GENERATION: 'MALWARE_GENERATION',
+} as const;
+export type SecuritySubCategory = (typeof SecuritySubCategory)[keyof typeof SecuritySubCategory];
+
+/** Severity filter levels. */
+export const SeverityFilter = {
+  LOW: 'LOW',
+  MEDIUM: 'MEDIUM',
+  HIGH: 'HIGH',
+  CRITICAL: 'CRITICAL',
+} as const;
+export type SeverityFilter = (typeof SeverityFilter)[keyof typeof SeverityFilter];
+
+/** Attack status query parameter filter. */
+export const StatusQueryParam = {
+  SUCCESSFUL: 'SUCCESSFUL',
+  FAILED: 'FAILED',
+} as const;
+export type StatusQueryParam = (typeof StatusQueryParam)[keyof typeof StatusQueryParam];
+
+/** Dynamic scan stream type. */
+export const StreamType = {
+  NORMAL: 'NORMAL',
+  ADVERSARIAL: 'ADVERSARIAL',
+} as const;
+export type StreamType = (typeof StreamType)[keyof typeof StreamType];
+
+/** Target connection provider type. */
+export const TargetConnectionType = {
+  DATABRICKS: 'DATABRICKS',
+  BEDROCK: 'BEDROCK',
+  OPENAI: 'OPENAI',
+  HUGGING_FACE: 'HUGGING_FACE',
+  CUSTOM: 'CUSTOM',
+  REST: 'REST',
+  STREAMING: 'STREAMING',
+} as const;
+export type TargetConnectionType = (typeof TargetConnectionType)[keyof typeof TargetConnectionType];
+
+/** Target lifecycle status. */
+export const TargetStatus = {
+  DRAFT: 'DRAFT',
+  VALIDATING: 'VALIDATING',
+  VALIDATED: 'VALIDATED',
+  ACTIVE: 'ACTIVE',
+  INACTIVE: 'INACTIVE',
+  FAILED: 'FAILED',
+  PENDING_AUTH: 'PENDING_AUTH',
+} as const;
+export type TargetStatus = (typeof TargetStatus)[keyof typeof TargetStatus];
+
+/** Target classification type. */
+export const TargetType = {
+  APPLICATION: 'APPLICATION',
+  AGENT: 'AGENT',
+  MODEL: 'MODEL',
+} as const;
+export type TargetType = (typeof TargetType)[keyof typeof TargetType];

--- a/src/models/red-team.ts
+++ b/src/models/red-team.ts
@@ -1,0 +1,1236 @@
+// src/models/red-team.ts — Zod schemas + types for AIRS Red Teaming API
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Shared / utility schemas
+// ---------------------------------------------------------------------------
+
+export const RedTeamPaginationSchema = z
+  .object({ total_items: z.number().int().nullable().optional() })
+  .passthrough();
+export type RedTeamPagination = z.infer<typeof RedTeamPaginationSchema>;
+
+export const CountByNameSchema = z.object({ name: z.string(), count: z.number().int() });
+export type CountByName = z.infer<typeof CountByNameSchema>;
+
+export const ValidationErrorSchema = z.object({
+  loc: z.array(z.union([z.string(), z.number()])),
+  msg: z.string(),
+  type: z.string(),
+});
+export type ValidationError = z.infer<typeof ValidationErrorSchema>;
+
+export const HTTPValidationErrorSchema = z
+  .object({ detail: z.array(ValidationErrorSchema).optional() })
+  .passthrough();
+export type HTTPValidationError = z.infer<typeof HTTPValidationErrorSchema>;
+
+// ---------------------------------------------------------------------------
+// Target context schemas (shared between data plane & management)
+// ---------------------------------------------------------------------------
+
+export const TargetBackgroundSchema = z
+  .object({
+    industry: z.unknown().optional(),
+    use_case: z.unknown().optional(),
+    competitors: z.unknown().optional(),
+  })
+  .passthrough();
+export type TargetBackground = z.infer<typeof TargetBackgroundSchema>;
+
+export const TargetAdditionalContextSchema = z
+  .object({
+    base_model: z.unknown().optional(),
+    core_architecture: z.unknown().optional(),
+    system_prompt: z.unknown().optional(),
+    languages_supported: z.unknown().optional(),
+    banned_keywords: z.unknown().optional(),
+    tools_accessible: z.unknown().optional(),
+  })
+  .passthrough();
+export type TargetAdditionalContext = z.infer<typeof TargetAdditionalContextSchema>;
+
+export const TargetMetadataSchema = z
+  .object({
+    multi_turn: z.boolean().optional(),
+    multi_turn_error_message: z.unknown().optional(),
+    rate_limit: z.unknown().optional(),
+    rate_limit_enabled: z.boolean().optional(),
+    rate_limit_error_code: z.unknown().optional(),
+    rate_limit_error_json: z.unknown().optional(),
+    rate_limit_error_message: z.unknown().optional(),
+    content_filter_enabled: z.boolean().optional(),
+    content_filter_error_code: z.unknown().optional(),
+    content_filter_error_json: z.unknown().optional(),
+    content_filter_error_message: z.unknown().optional(),
+    probe_message: z.string().optional(),
+    request_timeout: z.number().optional(),
+  })
+  .passthrough();
+export type TargetMetadata = z.infer<typeof TargetMetadataSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Job / Scan schemas
+// ---------------------------------------------------------------------------
+
+export const TargetJobRequestSchema = z.object({
+  uuid: z.string(),
+  version: z.number().int().nullable().optional(),
+});
+export type TargetJobRequest = z.infer<typeof TargetJobRequestSchema>;
+
+export const JobTimeRecordSchema = z
+  .object({
+    queued_at: z.string().nullable().optional(),
+    started_at: z.string().nullable().optional(),
+    completed_at: z.string().nullable().optional(),
+    time_taken: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type JobTimeRecord = z.infer<typeof JobTimeRecordSchema>;
+
+export const StaticJobMetadataSchema = z
+  .object({
+    categories: z.record(z.unknown()),
+    rate_limit_enabled: z.boolean().optional(),
+    rate_limit: z.number().int().nullable().optional(),
+    rate_limit_error_code: z.number().int().nullable().optional(),
+    rate_limit_error_message: z.string().nullable().optional(),
+    rate_limit_error_json: z.unknown().optional(),
+    content_filter_enabled: z.boolean().optional(),
+    content_filter_error_code: z.number().int().nullable().optional(),
+    content_filter_error_message: z.string().nullable().optional(),
+    content_filter_error_json: z.unknown().optional(),
+  })
+  .passthrough();
+export type StaticJobMetadata = z.infer<typeof StaticJobMetadataSchema>;
+
+export const DynamicJobMetadataSchema = z
+  .object({
+    rate_limit_enabled: z.boolean().optional(),
+    rate_limit: z.number().int().nullable().optional(),
+    rate_limit_error_code: z.number().int().nullable().optional(),
+    rate_limit_error_message: z.string().nullable().optional(),
+    rate_limit_error_json: z.unknown().optional(),
+    content_filter_enabled: z.boolean().optional(),
+    content_filter_error_code: z.number().int().nullable().optional(),
+    content_filter_error_message: z.string().nullable().optional(),
+    content_filter_error_json: z.unknown().optional(),
+    stream_breadth: z.number().int().optional(),
+    stream_depth: z.number().int().optional(),
+    max_tokens: z.number().int().optional(),
+    context_size: z.number().int().optional(),
+    attack_goals: z.array(z.unknown()).optional(),
+    base_model: z.string().nullable().optional(),
+    use_case: z.string().nullable().optional(),
+    system_prompt: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type DynamicJobMetadata = z.infer<typeof DynamicJobMetadataSchema>;
+
+export const CustomJobMetadataSchema = z
+  .object({
+    custom_prompt_sets: z.array(z.unknown()),
+    rate_limit_enabled: z.boolean().optional(),
+    rate_limit: z.number().int().nullable().optional(),
+    rate_limit_error_code: z.number().int().nullable().optional(),
+    rate_limit_error_message: z.string().nullable().optional(),
+    rate_limit_error_json: z.unknown().optional(),
+    content_filter_enabled: z.boolean().optional(),
+    content_filter_error_code: z.number().int().nullable().optional(),
+    content_filter_error_message: z.string().nullable().optional(),
+    content_filter_error_json: z.unknown().optional(),
+  })
+  .passthrough();
+export type CustomJobMetadata = z.infer<typeof CustomJobMetadataSchema>;
+
+export const JobCreateRequestSchema = z.object({
+  name: z.string(),
+  target: TargetJobRequestSchema,
+  job_type: z.string(),
+  job_metadata: z.union([
+    StaticJobMetadataSchema,
+    DynamicJobMetadataSchema,
+    CustomJobMetadataSchema,
+  ]),
+  version: z.number().int().nullable().optional(),
+  extra_info: z.record(z.unknown()).nullable().optional(),
+});
+export type JobCreateRequest = z.infer<typeof JobCreateRequestSchema>;
+
+export const StaticJobReportStatsSchema = z
+  .object({
+    output_completion_percentage: z.number(),
+    partial_report_unlocked: z.boolean().optional(),
+    partial_report_unlocked_at: z.string().nullable().optional(),
+    report_summary: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type StaticJobReportStats = z.infer<typeof StaticJobReportStatsSchema>;
+
+export const DynamicJobReportStatsSchema = z
+  .object({
+    total_goals: z.number().int().optional(),
+    total_streams: z.number().int().optional(),
+    total_threats: z.number().int().optional(),
+    goals_achieved: z.number().int().optional(),
+    report_summary: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type DynamicJobReportStats = z.infer<typeof DynamicJobReportStatsSchema>;
+
+export const TargetReferenceSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    name: z.string(),
+    description: z.string().nullable().optional(),
+    target_type: z.string().nullable().optional(),
+    connection_type: z.string().nullable().optional(),
+    api_endpoint_type: z.string().nullable().optional(),
+    response_mode: z.string().nullable().optional(),
+    session_supported: z.boolean().optional(),
+    extra_info: z.record(z.unknown()).nullable().optional(),
+    status: z.string(),
+    active: z.boolean(),
+    validated: z.boolean(),
+    version: z.number().int().nullable().optional(),
+    secret_version: z.string().nullable().optional(),
+    created_by_user_id: z.string().nullable().optional(),
+    updated_by_user_id: z.string().nullable().optional(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    target_metadata: TargetMetadataSchema.optional(),
+    target_background: TargetBackgroundSchema.nullable().optional(),
+    profiling_status: z.string().nullable().optional(),
+    additional_context: TargetAdditionalContextSchema.nullable().optional(),
+  })
+  .passthrough();
+export type TargetReference = z.infer<typeof TargetReferenceSchema>;
+
+export const JobResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    name: z.string(),
+    target: TargetReferenceSchema,
+    job_type: z.string(),
+    job_metadata: z.unknown(),
+    version: z.number().int().nullable().optional(),
+    extra_info: z.record(z.unknown()).nullable().optional(),
+    target_id: z.string(),
+    target_type: z.string(),
+    total: z.number().int().nullable().optional(),
+    completed: z.number().int().nullable().optional(),
+    status: z.string().optional(),
+    score: z.number().nullable().optional(),
+    asr: z.number().nullable().optional(),
+    time_record: JobTimeRecordSchema.nullable().optional(),
+    created_at: z.string().nullable().optional(),
+    updated_at: z.string().nullable().optional(),
+    created_by_user_id: z.string().nullable().optional(),
+    report_stats: z.unknown().optional(),
+    metering_quota_uuid: z.string().nullable().optional(),
+    counted_towards_quota: z.string().optional(),
+    invocation_id: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type JobResponse = z.infer<typeof JobResponseSchema>;
+
+export const JobListResponseSchema = z
+  .object({
+    pagination: RedTeamPaginationSchema,
+    data: z.array(JobResponseSchema),
+  })
+  .passthrough();
+export type JobListResponse = z.infer<typeof JobListResponseSchema>;
+
+export const JobAbortResponseSchema = z.object({
+  job_id: z.string(),
+  message: z.string(),
+});
+export type JobAbortResponse = z.infer<typeof JobAbortResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Category schemas
+// ---------------------------------------------------------------------------
+
+export const PrerequisiteModelSchema = z.object({
+  id: z.string(),
+  display_name: z.string(),
+  description: z.string(),
+});
+export type PrerequisiteModel = z.infer<typeof PrerequisiteModelSchema>;
+
+export const SubCategoryModelSchema = z
+  .object({
+    id: z.string(),
+    display_name: z.string(),
+    description: z.string(),
+    preselect: z.boolean().optional(),
+    prerequisites: z.array(PrerequisiteModelSchema).nullable().optional(),
+    active: z.boolean().optional(),
+  })
+  .passthrough();
+export type SubCategoryModel = z.infer<typeof SubCategoryModelSchema>;
+
+export const CategoryModelSchema = z
+  .object({
+    id: z.string(),
+    display_name: z.string(),
+    description: z.string(),
+    preselect: z.boolean().optional(),
+    sub_categories: z.array(SubCategoryModelSchema),
+  })
+  .passthrough();
+export type CategoryModel = z.infer<typeof CategoryModelSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Attack schemas
+// ---------------------------------------------------------------------------
+
+export const AttackOutputSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    attack_id: z.string(),
+    job_id: z.string(),
+    target_id: z.string(),
+    output: z.string(),
+    threat: z.boolean().nullable().optional(),
+    marked_safe: z.boolean().nullable().optional(),
+  })
+  .passthrough();
+export type AttackOutput = z.infer<typeof AttackOutputSchema>;
+
+export const AttackMultiTurnOutputSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    attack_id: z.string(),
+    job_id: z.string(),
+    target_id: z.string(),
+    output: z.string(),
+    prompt: z.string(),
+    turn: z.number().int(),
+    threat: z.boolean().nullable().optional(),
+    marked_safe: z.boolean().nullable().optional(),
+    generation: z.number().int().optional(),
+    multi_turn: z.boolean().optional(),
+  })
+  .passthrough();
+export type AttackMultiTurnOutput = z.infer<typeof AttackMultiTurnOutputSchema>;
+
+export const AttackListItemSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    job_id: z.string(),
+    target_id: z.string(),
+    prompt: z.string(),
+    prompt_mapping_id: z.string(),
+    prompt_id: z.string(),
+    category: z.string(),
+    sub_category: z.string(),
+    category_display_name: z.string(),
+    sub_category_display_name: z.string(),
+    status: z.string().optional(),
+    marked_safe: z.boolean().nullable().optional(),
+    extra_info: z.record(z.unknown()).optional(),
+    threat: z.boolean().nullable().optional(),
+    attack_type: z.string().optional(),
+    multi_turn: z.boolean().optional(),
+    asr: z.number().nullable().optional(),
+    version: z.number().int().nullable().optional(),
+    severity: z.string().optional(),
+  })
+  .passthrough();
+export type AttackListItem = z.infer<typeof AttackListItemSchema>;
+
+export const AttackListResponseSchema = z
+  .object({
+    pagination: RedTeamPaginationSchema,
+    data: z.array(AttackListItemSchema),
+  })
+  .passthrough();
+export type AttackListResponse = z.infer<typeof AttackListResponseSchema>;
+
+export const AttackDetailResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    job_id: z.string(),
+    target_id: z.string(),
+    prompt: z.string(),
+    prompt_mapping_id: z.string(),
+    prompt_id: z.string(),
+    category: z.string(),
+    sub_category: z.string(),
+    category_display_name: z.string(),
+    sub_category_display_name: z.string(),
+    compliance_frameworks: z.array(z.unknown()),
+    goal: z.string().nullable(),
+    status: z.string().optional(),
+    marked_safe: z.boolean().nullable().optional(),
+    extra_info: z.record(z.unknown()).optional(),
+    threat: z.boolean().nullable().optional(),
+    attack_type: z.string().optional(),
+    multi_turn: z.boolean().optional(),
+    asr: z.number().nullable().optional(),
+    version: z.number().int().nullable().optional(),
+    severity: z.string().optional(),
+    outputs: z.array(AttackOutputSchema).optional(),
+  })
+  .passthrough();
+export type AttackDetailResponse = z.infer<typeof AttackDetailResponseSchema>;
+
+export const AttackMultiTurnDetailResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    job_id: z.string(),
+    target_id: z.string(),
+    prompt: z.string(),
+    prompt_mapping_id: z.string(),
+    prompt_id: z.string(),
+    category: z.string(),
+    sub_category: z.string(),
+    category_display_name: z.string(),
+    sub_category_display_name: z.string(),
+    compliance_frameworks: z.array(z.unknown()),
+    goal: z.string().nullable(),
+    status: z.string().optional(),
+    marked_safe: z.boolean().nullable().optional(),
+    extra_info: z.record(z.unknown()).optional(),
+    threat: z.boolean().nullable().optional(),
+    attack_type: z.string().optional(),
+    multi_turn: z.boolean().optional(),
+    asr: z.number().nullable().optional(),
+    version: z.number().int().nullable().optional(),
+    severity: z.string().optional(),
+    outputs: z.array(AttackMultiTurnOutputSchema).optional(),
+  })
+  .passthrough();
+export type AttackMultiTurnDetailResponse = z.infer<typeof AttackMultiTurnDetailResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Report schemas
+// ---------------------------------------------------------------------------
+
+export const SubCategoryStatsSchema = z
+  .object({
+    id: z.string(),
+    display_name: z.string(),
+    description: z.string(),
+    preselect: z.boolean().optional(),
+    prerequisites: z.array(PrerequisiteModelSchema).nullable().optional(),
+    active: z.boolean().optional(),
+    successful: z.number().int(),
+    failed: z.number().int(),
+    total: z.number().int().optional(),
+  })
+  .passthrough();
+export type SubCategoryStats = z.infer<typeof SubCategoryStatsSchema>;
+
+export const CategoryReportSchema = z
+  .object({
+    id: z.string(),
+    display_name: z.string(),
+    description: z.string(),
+    preselect: z.boolean().optional(),
+    sub_categories: z.array(SubCategoryStatsSchema),
+    asr: z.number(),
+    total_prompts: z.number().int(),
+    total_attacks: z.number().int(),
+    successful: z.number().int(),
+    failed: z.number().int(),
+  })
+  .passthrough();
+export type CategoryReport = z.infer<typeof CategoryReportSchema>;
+
+export const SeverityStatsSchema = z
+  .object({
+    severity: z.string(),
+    successful: z.number().int().optional(),
+    failed: z.number().int().optional(),
+  })
+  .passthrough();
+export type SeverityStats = z.infer<typeof SeverityStatsSchema>;
+
+export const SeverityReportSchema = z
+  .object({
+    stats: z.array(SeverityStatsSchema),
+    successful: z.number().int().optional(),
+    failed: z.number().int().optional(),
+    total_attacks: z.number().int().optional(),
+  })
+  .passthrough();
+export type SeverityReport = z.infer<typeof SeverityReportSchema>;
+
+export const ComplianceTechniqueSchema = z
+  .object({
+    id: z.string(),
+    display_name: z.string(),
+    compliance_id: z.string(),
+    description: z.string(),
+    link: z.string(),
+    version: z.string(),
+    active: z.boolean(),
+    successful: z.number().int().optional(),
+    failed: z.number().int().optional(),
+    total: z.number().int().optional(),
+  })
+  .passthrough();
+export type ComplianceTechnique = z.infer<typeof ComplianceTechniqueSchema>;
+
+export const ComplianceReportSchema = z
+  .object({
+    id: z.string(),
+    display_name: z.string(),
+    description: z.string(),
+    active: z.boolean(),
+    version: z.string(),
+    link: z.string(),
+    techniques: z.array(ComplianceTechniqueSchema),
+    score: z.number().int().optional(),
+  })
+  .passthrough();
+export type ComplianceReport = z.infer<typeof ComplianceReportSchema>;
+
+export const RuntimeSecurityPolicySchema = z
+  .object({
+    policy_id: z.string(),
+    display_name: z.string(),
+    config: z.record(z.unknown()),
+  })
+  .passthrough();
+export type RuntimeSecurityPolicy = z.infer<typeof RuntimeSecurityPolicySchema>;
+
+export const StaticJobRemediationSchema = z
+  .object({
+    remediation: z.string(),
+    description: z.string(),
+    mapping_remediation_id: z.string().nullable().optional(),
+    subcategories: z.array(z.string()).nullable().optional(),
+    effectiveness: z.number().int().optional(),
+    ease_of_implementation: z.number().int().optional(),
+    priority: z.number().int().optional(),
+    resource_links: z.array(z.string()).optional(),
+    categories: z.array(z.string()).nullable().optional(),
+  })
+  .passthrough();
+export type StaticJobRemediation = z.infer<typeof StaticJobRemediationSchema>;
+
+export const StaticJobRemediationRecommendationSchema = z
+  .object({
+    runtime_security_policy_configuration: z
+      .array(RuntimeSecurityPolicySchema)
+      .nullable()
+      .optional(),
+    other_measures: z.array(StaticJobRemediationSchema).optional(),
+  })
+  .passthrough();
+export type StaticJobRemediationRecommendation = z.infer<
+  typeof StaticJobRemediationRecommendationSchema
+>;
+
+export const StaticJobReportSchema = z
+  .object({
+    severity_report: SeverityReportSchema,
+    asr: z.number().nullable().optional(),
+    score: z.number().nullable().optional(),
+    security_report: CategoryReportSchema.nullable().optional(),
+    safety_report: CategoryReportSchema.nullable().optional(),
+    brand_report: CategoryReportSchema.nullable().optional(),
+    compliance_report: z.array(ComplianceReportSchema).nullable().optional(),
+    report_summary: z.string().nullable().optional(),
+    recommendations: StaticJobRemediationRecommendationSchema.nullable().optional(),
+  })
+  .passthrough();
+export type StaticJobReport = z.infer<typeof StaticJobReportSchema>;
+
+export const DynamicJobReportSchema = z
+  .object({
+    total_goals: z.number().int().optional(),
+    total_streams: z.number().int().optional(),
+    total_threats: z.number().int().optional(),
+    goals_achieved: z.number().int().optional(),
+    report_summary: z.string().nullable().optional(),
+    score: z.number().optional(),
+    asr: z.number().optional(),
+  })
+  .passthrough();
+export type DynamicJobReport = z.infer<typeof DynamicJobReportSchema>;
+
+export const RemediationDetailSchema = z
+  .object({
+    remediation: z.string(),
+    description: z.string(),
+    resource_links: z.array(z.string()).optional(),
+    priority_level: z.string().optional(),
+    ease_of_implementation_level: z.string().optional(),
+    effectiveness_level: z.string().optional(),
+  })
+  .passthrough();
+export type RemediationDetail = z.infer<typeof RemediationDetailSchema>;
+
+export const RemediationResponseSchema = z
+  .object({ remediations: z.array(RemediationDetailSchema).optional() })
+  .passthrough();
+export type RemediationResponse = z.infer<typeof RemediationResponseSchema>;
+
+export const RuntimeSecurityProfileResponseSchema = z
+  .object({
+    runtime_security_profile: z.array(RuntimeSecurityPolicySchema).nullable().optional(),
+  })
+  .passthrough();
+export type RuntimeSecurityProfileResponse = z.infer<typeof RuntimeSecurityProfileResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Goal & Stream schemas (dynamic reports)
+// ---------------------------------------------------------------------------
+
+export const GoalSchema = z
+  .object({
+    goal: z.string(),
+    safe_response: z.string(),
+    jailbroken_response: z.string(),
+    goal_metadata: z.record(z.unknown()).optional(),
+    custom_goal: z.boolean().optional(),
+    goal_type: z.string().optional(),
+    uuid: z.string(),
+    tsg_id: z.string(),
+    job_id: z.string(),
+    goal_to_show: z.string().nullable().optional(),
+    threat: z.boolean().optional(),
+    version: z.number().int().nullable().optional(),
+    extra_info: z.record(z.unknown()).nullable().optional(),
+  })
+  .passthrough();
+export type Goal = z.infer<typeof GoalSchema>;
+
+export const GoalListResponseSchema = z
+  .object({ pagination: RedTeamPaginationSchema, data: z.array(GoalSchema) })
+  .passthrough();
+export type GoalListResponse = z.infer<typeof GoalListResponseSchema>;
+
+export const StreamIterationDataSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    job_id: z.string(),
+    stream_id: z.string(),
+    goal_id: z.string(),
+    iteration: z.number().int(),
+    prompt: z.string(),
+    techniques: z.string(),
+    improvement: z.string(),
+    prompts_objective: z.string(),
+    summary: z.string(),
+    output: z.string().nullable().optional(),
+    score: z.number().int().nullable().optional(),
+    judge_reasoning: z.string().nullable().optional(),
+    threat: z.boolean().optional(),
+    created_at: z.string().nullable().optional(),
+    updated_at: z.string().nullable().optional(),
+    extra_info: z.record(z.unknown()).nullable().optional(),
+    version: z.number().int().nullable().optional(),
+  })
+  .passthrough();
+export type StreamIterationData = z.infer<typeof StreamIterationDataSchema>;
+
+export const StreamDetailResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    job_id: z.string(),
+    target_id: z.string(),
+    goal_id: z.string(),
+    stream_idx: z.number().int().optional(),
+    iteration: z.number().int().optional(),
+    goal: z.unknown().optional(),
+    marked_safe: z.boolean().optional(),
+    stream_type: z.string().nullable().optional(),
+    threat: z.boolean().optional(),
+    first_threat_iteration: StreamIterationDataSchema.nullable().optional(),
+    created_at: z.string().nullable().optional(),
+    updated_at: z.string().nullable().optional(),
+    extra_info: z.record(z.unknown()).optional(),
+    version: z.number().int().nullable().optional(),
+    iterations: z.array(StreamIterationDataSchema).optional(),
+  })
+  .passthrough();
+export type StreamDetailResponse = z.infer<typeof StreamDetailResponseSchema>;
+
+export const StreamListResponseSchema = z
+  .object({ pagination: RedTeamPaginationSchema, data: z.array(StreamDetailResponseSchema) })
+  .passthrough();
+export type StreamListResponse = z.infer<typeof StreamListResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Custom attack report schemas
+// ---------------------------------------------------------------------------
+
+export const CustomAttackOutputSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    custom_attack_id: z.string(),
+    job_id: z.string(),
+    target_id: z.string(),
+    output: z.string(),
+    threat: z.boolean().nullable().optional(),
+    marked_safe: z.boolean().nullable().optional(),
+  })
+  .passthrough();
+export type CustomAttackOutput = z.infer<typeof CustomAttackOutputSchema>;
+
+export const PropertyAssignmentSchema = z.object({
+  name: z.string(),
+  value: z.string(),
+});
+export type PropertyAssignment = z.infer<typeof PropertyAssignmentSchema>;
+
+export const PropertyValueStatisticSchema = z.object({
+  value: z.string(),
+  successful_attack_count: z.number().int(),
+  total_attack_count: z.number().int(),
+  success_rate: z.number(),
+});
+export type PropertyValueStatistic = z.infer<typeof PropertyValueStatisticSchema>;
+
+export const PropertyStatisticSchema = z.object({
+  property_name: z.string(),
+  values: z.array(PropertyValueStatisticSchema),
+});
+export type PropertyStatistic = z.infer<typeof PropertyStatisticSchema>;
+
+export const PromptSetSummarySchema = z
+  .object({
+    prompt_set_id: z.string(),
+    prompt_set_name: z.string(),
+    total_prompts: z.number().int(),
+    total_attacks: z.number().int(),
+    total_threats: z.number().int(),
+    failed_attacks: z.number().int(),
+    threat_rate: z.number(),
+    property_names: z.array(z.string()).optional(),
+    property_statistics: z.array(PropertyStatisticSchema).optional(),
+  })
+  .passthrough();
+export type PromptSetSummary = z.infer<typeof PromptSetSummarySchema>;
+
+export const CustomAttackReportResponseSchema = z
+  .object({
+    total_prompts: z.number().int(),
+    total_attacks: z.number().int(),
+    total_threats: z.number().int(),
+    failed_attacks: z.number().int(),
+    score: z.number(),
+    asr: z.number(),
+    custom_attack_reports: z.array(PromptSetSummarySchema).optional(),
+    property_statistics: z.array(PropertyStatisticSchema).optional(),
+  })
+  .passthrough();
+export type CustomAttackReportResponse = z.infer<typeof CustomAttackReportResponseSchema>;
+
+export const PromptSetsReportResponseSchema = z
+  .object({
+    prompt_sets: z.array(PromptSetSummarySchema),
+    total_prompt_sets: z.number().int(),
+    applied_filters: z.record(z.unknown()).optional(),
+  })
+  .passthrough();
+export type PromptSetsReportResponse = z.infer<typeof PromptSetsReportResponseSchema>;
+
+export const PromptDetailResponseSchema = z
+  .object({
+    prompt_id: z.string(),
+    prompt_text: z.string(),
+    goal: z.string().nullable().optional(),
+    user_defined_goal: z.boolean().optional(),
+    properties: z.array(PropertyAssignmentSchema).optional(),
+    attack_id: z.string().nullable().optional(),
+    threat: z.boolean().nullable().optional(),
+    attack_outputs: z.array(CustomAttackOutputSchema).optional(),
+    asr: z.number().nullable().optional(),
+    prompt_set_id: z.string().nullable().optional(),
+    prompt_set_name: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type PromptDetailResponse = z.infer<typeof PromptDetailResponseSchema>;
+
+export const CustomAttacksListResponseSchema = z
+  .object({
+    pagination: RedTeamPaginationSchema,
+    data: z.array(z.unknown()),
+    total_attacks: z.number().int(),
+    total_threats: z.number().int(),
+  })
+  .passthrough();
+export type CustomAttacksListResponse = z.infer<typeof CustomAttacksListResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Dashboard schemas
+// ---------------------------------------------------------------------------
+
+export const RiskLevelSchema = z
+  .object({
+    risk_rating: z.string(),
+    total: z.number().int(),
+    targets_by_type: z.array(CountByNameSchema).optional(),
+  })
+  .passthrough();
+export type RiskLevel = z.infer<typeof RiskLevelSchema>;
+
+export const ScanStatisticsResponseSchema = z
+  .object({
+    total_scans: z.number().int(),
+    targets_scanned: z.number().int(),
+    targets_scanned_by_type: z.array(CountByNameSchema).optional(),
+    scan_status: z.array(CountByNameSchema).optional(),
+    risk_profile: z.array(RiskLevelSchema).optional(),
+  })
+  .passthrough();
+export type ScanStatisticsResponse = z.infer<typeof ScanStatisticsResponseSchema>;
+
+export const ScoreTrendSeriesSchema = z.object({
+  label: z.string(),
+  data: z.array(z.number().nullable()),
+});
+export type ScoreTrendSeries = z.infer<typeof ScoreTrendSeriesSchema>;
+
+export const ScoreTrendResponseSchema = z.object({
+  labels: z.array(z.string()),
+  series: z.array(ScoreTrendSeriesSchema),
+});
+export type ScoreTrendResponse = z.infer<typeof ScoreTrendResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// DataPlane — Sentiment, Quota, Error Log schemas
+// ---------------------------------------------------------------------------
+
+export const SentimentRequestSchema = z.object({
+  job_id: z.string(),
+  up_vote: z.boolean().optional(),
+  down_vote: z.boolean().optional(),
+});
+export type SentimentRequest = z.infer<typeof SentimentRequestSchema>;
+
+export const SentimentResponseSchema = z
+  .object({
+    job_id: z.string(),
+    up_vote: z.boolean().optional(),
+    down_vote: z.boolean().optional(),
+  })
+  .passthrough();
+export type SentimentResponse = z.infer<typeof SentimentResponseSchema>;
+
+export const QuotaDetailsSchema = z.object({
+  allocated: z.number().int(),
+  unlimited: z.boolean(),
+  consumed: z.number().int(),
+});
+export type QuotaDetails = z.infer<typeof QuotaDetailsSchema>;
+
+export const QuotaSummarySchema = z.object({
+  static: QuotaDetailsSchema,
+  dynamic: QuotaDetailsSchema,
+  custom: QuotaDetailsSchema,
+});
+export type QuotaSummary = z.infer<typeof QuotaSummarySchema>;
+
+export const ErrorLogSchema = z
+  .object({
+    created_at: z.string(),
+    updated_at: z.string(),
+    job_id: z.string().nullable().optional(),
+    target_id: z.string().nullable().optional(),
+    target_version: z.number().int().nullable().optional(),
+    attack_id: z.string().nullable().optional(),
+    error_type: z.string().nullable().optional(),
+    error_source: z.string().nullable().optional(),
+    error_message: z.string().nullable().optional(),
+    target_object: z.record(z.unknown()).nullable().optional(),
+    extra_info: z.record(z.unknown()).nullable().optional(),
+    version: z.number().int().optional(),
+  })
+  .passthrough();
+export type ErrorLog = z.infer<typeof ErrorLogSchema>;
+
+export const ErrorLogListResponseSchema = z
+  .object({ pagination: RedTeamPaginationSchema, data: z.array(ErrorLogSchema) })
+  .passthrough();
+export type ErrorLogListResponse = z.infer<typeof ErrorLogListResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Management — Target schemas
+// ---------------------------------------------------------------------------
+
+export const TargetCreateRequestSchema = z
+  .object({
+    name: z.string(),
+    description: z.unknown().optional(),
+    target_type: z.unknown().optional(),
+    connection_type: z.unknown().optional(),
+    api_endpoint_type: z.unknown().optional(),
+    response_mode: z.unknown().optional(),
+    connection_params: z.unknown().optional(),
+    session_supported: z.boolean().optional(),
+    target_metadata: z.unknown().optional(),
+    target_background: z.unknown().optional(),
+    additional_context: z.unknown().optional(),
+    extra_info: z.unknown().optional(),
+    network_broker_channel_uuid: z.unknown().optional(),
+  })
+  .passthrough();
+export type TargetCreateRequest = z.infer<typeof TargetCreateRequestSchema>;
+
+export const TargetUpdateRequestSchema = z
+  .object({
+    name: z.string(),
+    description: z.unknown().optional(),
+    target_type: z.unknown().optional(),
+    connection_type: z.unknown().optional(),
+    api_endpoint_type: z.unknown().optional(),
+    response_mode: z.unknown().optional(),
+    connection_params: z.unknown().optional(),
+    session_supported: z.boolean().optional(),
+    target_metadata: z.unknown().optional(),
+    target_background: z.unknown().optional(),
+    additional_context: z.unknown().optional(),
+    extra_info: z.unknown().optional(),
+    network_broker_channel_uuid: z.unknown().optional(),
+  })
+  .passthrough();
+export type TargetUpdateRequest = z.infer<typeof TargetUpdateRequestSchema>;
+
+export const TargetContextUpdateSchema = z
+  .object({
+    target_background: z.unknown().optional(),
+    additional_context: z.unknown().optional(),
+  })
+  .passthrough();
+export type TargetContextUpdate = z.infer<typeof TargetContextUpdateSchema>;
+
+export const TargetResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    name: z.string(),
+    status: z.unknown(),
+    active: z.boolean(),
+    validated: z.boolean(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    description: z.unknown().optional(),
+    target_type: z.unknown().optional(),
+    connection_type: z.unknown().optional(),
+    api_endpoint_type: z.unknown().optional(),
+    response_mode: z.unknown().optional(),
+    session_supported: z.boolean().optional(),
+    extra_info: z.unknown().optional(),
+    version: z.unknown().optional(),
+    secret_version: z.unknown().optional(),
+    created_by_user_id: z.unknown().optional(),
+    updated_by_user_id: z.unknown().optional(),
+    target_metadata: z.unknown().optional(),
+    target_background: z.unknown().optional(),
+    profiling_status: z.unknown().optional(),
+    additional_context: z.unknown().optional(),
+  })
+  .passthrough();
+export type TargetResponse = z.infer<typeof TargetResponseSchema>;
+
+export const TargetListItemSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    name: z.string(),
+    status: z.unknown(),
+    active: z.boolean(),
+    validated: z.boolean(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    description: z.unknown().optional(),
+    target_type: z.unknown().optional(),
+    connection_type: z.unknown().optional(),
+    api_endpoint_type: z.unknown().optional(),
+    response_mode: z.unknown().optional(),
+    session_supported: z.boolean().optional(),
+    extra_info: z.unknown().optional(),
+    version: z.unknown().optional(),
+    secret_version: z.unknown().optional(),
+    created_by_user_id: z.unknown().optional(),
+    updated_by_user_id: z.unknown().optional(),
+  })
+  .passthrough();
+export type TargetListItem = z.infer<typeof TargetListItemSchema>;
+
+export const TargetListSchema = z
+  .object({ pagination: RedTeamPaginationSchema, data: z.array(TargetListItemSchema).optional() })
+  .passthrough();
+export type TargetList = z.infer<typeof TargetListSchema>;
+
+export const TargetProbeRequestSchema = z
+  .object({
+    name: z.string(),
+    uuid: z.unknown().optional(),
+    description: z.unknown().optional(),
+    target_type: z.unknown().optional(),
+    connection_type: z.unknown().optional(),
+    api_endpoint_type: z.unknown().optional(),
+    response_mode: z.unknown().optional(),
+    connection_params: z.unknown().optional(),
+    session_supported: z.boolean().optional(),
+    target_metadata: z.unknown().optional(),
+    target_background: z.unknown().optional(),
+    additional_context: z.unknown().optional(),
+    extra_info: z.unknown().optional(),
+    network_broker_channel_uuid: z.unknown().optional(),
+    probe_fields: z.unknown().optional(),
+  })
+  .passthrough();
+export type TargetProbeRequest = z.infer<typeof TargetProbeRequestSchema>;
+
+export const TargetProfileResponseSchema = z
+  .object({
+    target_id: z.string(),
+    target_version: z.number().int(),
+    status: z.string(),
+    profiling_status: z.unknown().optional(),
+    target_background: z.unknown().optional(),
+    additional_context: z.unknown().optional(),
+    ai_generated_fields: z.unknown().optional(),
+    other_details: z.unknown().optional(),
+  })
+  .passthrough();
+export type TargetProfileResponse = z.infer<typeof TargetProfileResponseSchema>;
+
+export const BaseResponseSchema = z.object({
+  message: z.string(),
+  status: z.number().int(),
+});
+export type BaseResponse = z.infer<typeof BaseResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Management — Custom attack / prompt set schemas
+// ---------------------------------------------------------------------------
+
+export const PromptSetStatsSchema = z
+  .object({
+    total_prompts: z.number().int(),
+    active_prompts: z.number().int(),
+    inactive_prompts: z.number().int(),
+    failed_prompts: z.number().int().optional(),
+    validation_prompts: z.number().int().optional(),
+  })
+  .passthrough();
+export type PromptSetStats = z.infer<typeof PromptSetStatsSchema>;
+
+export const CustomPromptSetCreateRequestSchema = z.object({
+  name: z.string(),
+  description: z.unknown().optional(),
+  property_names: z.array(z.string()).optional(),
+});
+export type CustomPromptSetCreateRequest = z.infer<typeof CustomPromptSetCreateRequestSchema>;
+
+export const CustomPromptSetUpdateRequestSchema = z
+  .object({
+    name: z.unknown().optional(),
+    description: z.unknown().optional(),
+    archive: z.unknown().optional(),
+    property_names: z.unknown().optional(),
+  })
+  .passthrough();
+export type CustomPromptSetUpdateRequest = z.infer<typeof CustomPromptSetUpdateRequestSchema>;
+
+export const CustomPromptSetArchiveRequestSchema = z.object({ archive: z.boolean() });
+export type CustomPromptSetArchiveRequest = z.infer<typeof CustomPromptSetArchiveRequestSchema>;
+
+export const CustomPromptSetResponseSchema = z
+  .object({
+    uuid: z.string(),
+    name: z.string(),
+    active: z.boolean(),
+    archive: z.boolean(),
+    status: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    description: z.unknown().optional(),
+    property_names: z.array(z.string()).optional(),
+    properties: z.array(z.unknown()).optional(),
+    stats: z.unknown().optional(),
+    extra_info: z.unknown().optional(),
+    version: z.unknown().optional(),
+    created_by_user_id: z.unknown().optional(),
+    updated_by_user_id: z.unknown().optional(),
+  })
+  .passthrough();
+export type CustomPromptSetResponse = z.infer<typeof CustomPromptSetResponseSchema>;
+
+export const CustomPromptSetListItemSchema = z
+  .object({
+    uuid: z.string(),
+    name: z.string(),
+    active: z.boolean(),
+    archive: z.boolean(),
+    status: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    description: z.unknown().optional(),
+    property_names: z.array(z.string()).optional(),
+    stats: z.unknown().optional(),
+    created_by_user_id: z.unknown().optional(),
+  })
+  .passthrough();
+export type CustomPromptSetListItem = z.infer<typeof CustomPromptSetListItemSchema>;
+
+export const CustomPromptSetListSchema = z
+  .object({
+    pagination: RedTeamPaginationSchema,
+    data: z.array(CustomPromptSetListItemSchema).optional(),
+  })
+  .passthrough();
+export type CustomPromptSetList = z.infer<typeof CustomPromptSetListSchema>;
+
+export const CustomPromptSetListActiveSchema = z
+  .object({ data: z.array(CustomPromptSetListItemSchema).optional() })
+  .passthrough();
+export type CustomPromptSetListActive = z.infer<typeof CustomPromptSetListActiveSchema>;
+
+export const CustomPromptSetReferenceSchema = z
+  .object({
+    uuid: z.string(),
+    name: z.string(),
+    status: z.string(),
+    active: z.boolean(),
+    tsg_id: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    version: z.unknown().optional(),
+  })
+  .passthrough();
+export type CustomPromptSetReference = z.infer<typeof CustomPromptSetReferenceSchema>;
+
+export const CustomPromptSetVersionInfoSchema = z
+  .object({
+    uuid: z.string(),
+    status: z.string(),
+    is_latest: z.boolean(),
+    version: z.unknown().optional(),
+    stats: z.unknown().optional(),
+    snapshot_created_at: z.unknown().optional(),
+  })
+  .passthrough();
+export type CustomPromptSetVersionInfo = z.infer<typeof CustomPromptSetVersionInfoSchema>;
+
+export const CustomPromptCreateRequestSchema = z.object({
+  prompt: z.string(),
+  prompt_set_id: z.string(),
+  goal: z.unknown().optional(),
+  properties: z.unknown().optional(),
+});
+export type CustomPromptCreateRequest = z.infer<typeof CustomPromptCreateRequestSchema>;
+
+export const CustomPromptUpdateRequestSchema = z
+  .object({
+    prompt: z.unknown().optional(),
+    goal: z.unknown().optional(),
+    properties: z.unknown().optional(),
+  })
+  .passthrough();
+export type CustomPromptUpdateRequest = z.infer<typeof CustomPromptUpdateRequestSchema>;
+
+export const CustomPromptResponseSchema = z
+  .object({
+    uuid: z.string(),
+    prompt: z.string(),
+    user_defined_goal: z.boolean(),
+    status: z.string(),
+    active: z.boolean(),
+    prompt_set_id: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    goal: z.unknown().optional(),
+    properties: z.unknown().optional(),
+    property_assignments: z.array(z.unknown()).optional(),
+    detector_category: z.unknown().optional(),
+    severity: z.unknown().optional(),
+    extra_info: z.unknown().optional(),
+  })
+  .passthrough();
+export type CustomPromptResponse = z.infer<typeof CustomPromptResponseSchema>;
+
+export const CustomPromptListItemSchema = z
+  .object({
+    uuid: z.string(),
+    prompt: z.string(),
+    user_defined_goal: z.boolean(),
+    status: z.string(),
+    active: z.boolean(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    goal: z.unknown().optional(),
+    properties: z.unknown().optional(),
+  })
+  .passthrough();
+export type CustomPromptListItem = z.infer<typeof CustomPromptListItemSchema>;
+
+export const CustomPromptListSchema = z
+  .object({
+    pagination: RedTeamPaginationSchema,
+    data: z.array(CustomPromptListItemSchema).optional(),
+  })
+  .passthrough();
+export type CustomPromptList = z.infer<typeof CustomPromptListSchema>;
+
+// ---------------------------------------------------------------------------
+// Management — Property schemas
+// ---------------------------------------------------------------------------
+
+export const PropertyNameCreateRequestSchema = z.object({ name: z.string() });
+export type PropertyNameCreateRequest = z.infer<typeof PropertyNameCreateRequestSchema>;
+
+export const PropertyValueCreateRequestSchema = z.object({
+  property_name: z.string(),
+  property_value: z.string(),
+});
+export type PropertyValueCreateRequest = z.infer<typeof PropertyValueCreateRequestSchema>;
+
+export const PropertyDefinitionSchema = z.object({
+  property_name: z.string(),
+  created_at: z.string(),
+});
+export type PropertyDefinition = z.infer<typeof PropertyDefinitionSchema>;
+
+export const PropertyNamesListResponseSchema = z
+  .object({ data: z.array(PropertyDefinitionSchema).optional() })
+  .passthrough();
+export type PropertyNamesListResponse = z.infer<typeof PropertyNamesListResponseSchema>;
+
+export const PropertyValuesResponseSchema = z
+  .object({
+    name: z.string(),
+    values: z.array(z.string()).optional(),
+  })
+  .passthrough();
+export type PropertyValuesResponse = z.infer<typeof PropertyValuesResponseSchema>;
+
+export const PropertyValuesMultipleResponseSchema = z
+  .object({ data: z.record(z.array(z.string())).optional() })
+  .passthrough();
+export type PropertyValuesMultipleResponse = z.infer<typeof PropertyValuesMultipleResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Management — Dashboard schemas
+// ---------------------------------------------------------------------------
+
+export const DashboardOverviewResponseSchema = z
+  .object({
+    total_targets: z.number().int(),
+    targets_by_type: z.array(CountByNameSchema).optional(),
+  })
+  .passthrough();
+export type DashboardOverviewResponse = z.infer<typeof DashboardOverviewResponseSchema>;

--- a/src/red-team/client.ts
+++ b/src/red-team/client.ts
@@ -1,0 +1,278 @@
+import {
+  DEFAULT_RED_TEAM_DATA_ENDPOINT,
+  DEFAULT_RED_TEAM_MGMT_ENDPOINT,
+  RED_TEAM_CLIENT_ID,
+  RED_TEAM_CLIENT_SECRET,
+  RED_TEAM_TSG_ID,
+  RED_TEAM_DATA_ENDPOINT,
+  RED_TEAM_MGMT_ENDPOINT,
+  RED_TEAM_TOKEN_ENDPOINT,
+  MGMT_CLIENT_ID,
+  MGMT_CLIENT_SECRET,
+  MGMT_TSG_ID,
+  MGMT_TOKEN_ENDPOINT,
+  MAX_NUMBER_OF_RETRIES,
+  RED_TEAM_DASHBOARD_PATH,
+  RED_TEAM_QUOTA_PATH,
+  RED_TEAM_ERROR_LOG_PATH,
+  RED_TEAM_SENTIMENT_PATH,
+  RED_TEAM_MGMT_DASHBOARD_PATH,
+} from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { isValidUuid } from '../utils.js';
+import { OAuthClient } from '../management/oauth-client.js';
+import { managementHttpRequest } from '../management/management-http-client.js';
+import { RedTeamScansClient } from './scans-client.js';
+import { RedTeamReportsClient } from './reports-client.js';
+import { RedTeamCustomAttackReportsClient } from './custom-attack-reports-client.js';
+import { RedTeamTargetsClient } from './targets-client.js';
+import { RedTeamCustomAttacksClient } from './custom-attacks-client.js';
+import type { RedTeamListOptions } from './scans-client.js';
+import type {
+  ScanStatisticsResponse,
+  ScoreTrendResponse,
+  QuotaSummary,
+  ErrorLogListResponse,
+  SentimentRequest,
+  SentimentResponse,
+  DashboardOverviewResponse,
+} from '../models/red-team.js';
+
+/** Options for constructing a {@link RedTeamClient}. */
+export interface RedTeamClientOptions {
+  /** OAuth2 client ID. Falls back to `PANW_RED_TEAM_CLIENT_ID`, then `PANW_MGMT_CLIENT_ID`. */
+  clientId?: string;
+  /** OAuth2 client secret. Falls back to `PANW_RED_TEAM_CLIENT_SECRET`, then `PANW_MGMT_CLIENT_SECRET`. */
+  clientSecret?: string;
+  /** Tenant Service Group ID. Falls back to `PANW_RED_TEAM_TSG_ID`, then `PANW_MGMT_TSG_ID`. */
+  tsgId?: string;
+  /** Data plane endpoint URL. Falls back to `PANW_RED_TEAM_DATA_ENDPOINT`. */
+  dataEndpoint?: string;
+  /** Management plane endpoint URL. Falls back to `PANW_RED_TEAM_MGMT_ENDPOINT`. */
+  mgmtEndpoint?: string;
+  /** OAuth2 token endpoint URL. Falls back to `PANW_RED_TEAM_TOKEN_ENDPOINT`, then `PANW_MGMT_TOKEN_ENDPOINT`. */
+  tokenEndpoint?: string;
+  /** Max retry attempts (0-5). Defaults to 5. */
+  numRetries?: number;
+}
+
+function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
+  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}
+
+/**
+ * Client for AIRS Red Teaming API operations.
+ * Uses two base URLs: data plane for scans/reports, management plane for targets/custom attacks.
+ */
+export class RedTeamClient {
+  /** Data plane scan operations. */
+  public readonly scans: RedTeamScansClient;
+  /** Data plane report operations. */
+  public readonly reports: RedTeamReportsClient;
+  /** Data plane custom attack report operations. */
+  public readonly customAttackReports: RedTeamCustomAttackReportsClient;
+  /** Management plane target operations. */
+  public readonly targets: RedTeamTargetsClient;
+  /** Management plane custom attack/prompt set operations. */
+  public readonly customAttacks: RedTeamCustomAttacksClient;
+
+  private readonly dataEndpoint: string;
+  private readonly mgmtEndpoint: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: RedTeamClientOptions = {}) {
+    const clientId =
+      opts.clientId ?? process.env[RED_TEAM_CLIENT_ID] ?? process.env[MGMT_CLIENT_ID];
+    const clientSecret =
+      opts.clientSecret ?? process.env[RED_TEAM_CLIENT_SECRET] ?? process.env[MGMT_CLIENT_SECRET];
+    const tsgId = opts.tsgId ?? process.env[RED_TEAM_TSG_ID] ?? process.env[MGMT_TSG_ID];
+    const dataEndpoint =
+      opts.dataEndpoint ?? process.env[RED_TEAM_DATA_ENDPOINT] ?? DEFAULT_RED_TEAM_DATA_ENDPOINT;
+    const mgmtEndpoint =
+      opts.mgmtEndpoint ?? process.env[RED_TEAM_MGMT_ENDPOINT] ?? DEFAULT_RED_TEAM_MGMT_ENDPOINT;
+    const tokenEndpoint =
+      opts.tokenEndpoint ??
+      process.env[RED_TEAM_TOKEN_ENDPOINT] ??
+      process.env[MGMT_TOKEN_ENDPOINT];
+    const numRetries = Math.min(
+      Math.max(opts.numRetries ?? MAX_NUMBER_OF_RETRIES, 0),
+      MAX_NUMBER_OF_RETRIES,
+    );
+
+    if (!clientId) {
+      throw new AISecSDKException(
+        'clientId is required (option or PANW_RED_TEAM_CLIENT_ID / PANW_MGMT_CLIENT_ID env var)',
+        ErrorType.MISSING_VARIABLE,
+      );
+    }
+    if (!clientSecret) {
+      throw new AISecSDKException(
+        'clientSecret is required (option or PANW_RED_TEAM_CLIENT_SECRET / PANW_MGMT_CLIENT_SECRET env var)',
+        ErrorType.MISSING_VARIABLE,
+      );
+    }
+    if (!tsgId) {
+      throw new AISecSDKException(
+        'tsgId is required (option or PANW_RED_TEAM_TSG_ID / PANW_MGMT_TSG_ID env var)',
+        ErrorType.MISSING_VARIABLE,
+      );
+    }
+
+    this.oauthClient = new OAuthClient({ clientId, clientSecret, tsgId, tokenEndpoint });
+    this.dataEndpoint = dataEndpoint;
+    this.mgmtEndpoint = mgmtEndpoint;
+    this.numRetries = numRetries;
+
+    this.scans = new RedTeamScansClient({
+      baseUrl: dataEndpoint,
+      oauthClient: this.oauthClient,
+      numRetries,
+    });
+
+    this.reports = new RedTeamReportsClient({
+      baseUrl: dataEndpoint,
+      oauthClient: this.oauthClient,
+      numRetries,
+    });
+
+    this.customAttackReports = new RedTeamCustomAttackReportsClient({
+      baseUrl: dataEndpoint,
+      oauthClient: this.oauthClient,
+      numRetries,
+    });
+
+    this.targets = new RedTeamTargetsClient({
+      baseUrl: mgmtEndpoint,
+      oauthClient: this.oauthClient,
+      numRetries,
+    });
+
+    this.customAttacks = new RedTeamCustomAttacksClient({
+      baseUrl: mgmtEndpoint,
+      oauthClient: this.oauthClient,
+      numRetries,
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // Data plane convenience methods
+  // -----------------------------------------------------------------------
+
+  /** Get scan statistics and risk profile (data plane dashboard). */
+  async getScanStatistics(params?: {
+    date_range?: string;
+    target_id?: string;
+  }): Promise<ScanStatisticsResponse> {
+    const p: Record<string, string> = {};
+    if (params?.date_range !== undefined) p.date_range = params.date_range;
+    if (params?.target_id !== undefined) p.target_id = params.target_id;
+
+    const res = await managementHttpRequest<ScanStatisticsResponse>({
+      method: 'GET',
+      baseUrl: this.dataEndpoint,
+      path: `${RED_TEAM_DASHBOARD_PATH}/scan-statistics`,
+      params: p,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get score trend for a target (data plane dashboard). */
+  async getScoreTrend(targetId: string): Promise<ScoreTrendResponse> {
+    if (!isValidUuid(targetId)) {
+      throw new AISecSDKException(
+        `Invalid target id: ${targetId}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+    const res = await managementHttpRequest<ScoreTrendResponse>({
+      method: 'GET',
+      baseUrl: this.dataEndpoint,
+      path: `${RED_TEAM_DASHBOARD_PATH}/score-trend`,
+      params: { target_id: targetId },
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get quota summary. */
+  async getQuota(): Promise<QuotaSummary> {
+    const res = await managementHttpRequest<QuotaSummary>({
+      method: 'POST',
+      baseUrl: this.dataEndpoint,
+      path: RED_TEAM_QUOTA_PATH,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** List error logs for a scan job. */
+  async getErrorLogs(jobId: string, opts?: RedTeamListOptions): Promise<ErrorLogListResponse> {
+    if (!isValidUuid(jobId)) {
+      throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+    }
+    const res = await managementHttpRequest<ErrorLogListResponse>({
+      method: 'GET',
+      baseUrl: this.dataEndpoint,
+      path: `${RED_TEAM_ERROR_LOG_PATH}/${jobId}`,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Update sentiment for a scan report. */
+  async updateSentiment(request: SentimentRequest): Promise<SentimentResponse> {
+    const res = await managementHttpRequest<SentimentResponse>({
+      method: 'POST',
+      baseUrl: this.dataEndpoint,
+      path: RED_TEAM_SENTIMENT_PATH,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get sentiment for a scan report. */
+  async getSentiment(jobId: string): Promise<SentimentResponse> {
+    if (!isValidUuid(jobId)) {
+      throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+    }
+    const res = await managementHttpRequest<SentimentResponse>({
+      method: 'GET',
+      baseUrl: this.dataEndpoint,
+      path: `${RED_TEAM_SENTIMENT_PATH}/${jobId}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  // -----------------------------------------------------------------------
+  // Management plane convenience methods
+  // -----------------------------------------------------------------------
+
+  /** Get management dashboard overview. */
+  async getDashboardOverview(): Promise<DashboardOverviewResponse> {
+    const res = await managementHttpRequest<DashboardOverviewResponse>({
+      method: 'GET',
+      baseUrl: this.mgmtEndpoint,
+      path: RED_TEAM_MGMT_DASHBOARD_PATH,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/red-team/custom-attack-reports-client.ts
+++ b/src/red-team/custom-attack-reports-client.ts
@@ -1,0 +1,170 @@
+import { RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH } from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { isValidUuid } from '../utils.js';
+import { managementHttpRequest } from '../management/management-http-client.js';
+import type { OAuthClient } from '../management/oauth-client.js';
+import type { RedTeamListOptions } from './scans-client.js';
+import type {
+  CustomAttackReportResponse,
+  PromptSetsReportResponse,
+  PromptDetailResponse,
+  CustomAttacksListResponse,
+  PropertyStatistic,
+} from '../models/red-team.js';
+
+/** @internal */
+export interface RedTeamCustomAttackReportsClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
+  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}
+
+function validateJobId(jobId: string): void {
+  if (!isValidUuid(jobId)) {
+    throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+  }
+}
+
+/** Client for Red Team custom attack report operations. */
+export class RedTeamCustomAttackReportsClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: RedTeamCustomAttackReportsClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  /** Get custom attack report for a scan. */
+  async getReport(jobId: string): Promise<CustomAttackReportResponse> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<CustomAttackReportResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH}/report/${jobId}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get prompt sets for a custom attack scan. */
+  async getPromptSets(jobId: string): Promise<PromptSetsReportResponse> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<PromptSetsReportResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH}/report/${jobId}/prompt-sets`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get prompts for a specific prompt set in a scan. */
+  async getPromptsBySet(
+    jobId: string,
+    promptSetId: string,
+    opts?: RedTeamListOptions,
+  ): Promise<unknown> {
+    validateJobId(jobId);
+    if (!isValidUuid(promptSetId)) {
+      throw new AISecSDKException(
+        `Invalid prompt set id: ${promptSetId}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<unknown>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH}/report/${jobId}/prompt-set/${promptSetId}/prompts`,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get details for a specific prompt. */
+  async getPromptDetail(jobId: string, promptId: string): Promise<PromptDetailResponse> {
+    validateJobId(jobId);
+    if (!isValidUuid(promptId)) {
+      throw new AISecSDKException(
+        `Invalid prompt id: ${promptId}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<PromptDetailResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH}/report/${jobId}/prompt/${promptId}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** List custom attacks for a scan. */
+  async listCustomAttacks(
+    jobId: string,
+    opts?: RedTeamListOptions,
+  ): Promise<CustomAttacksListResponse> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<CustomAttacksListResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH}/job/${jobId}/list-custom-attacks`,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get attack outputs for a custom attack. */
+  async getAttackOutputs(jobId: string, attackId: string): Promise<unknown> {
+    validateJobId(jobId);
+    if (!isValidUuid(attackId)) {
+      throw new AISecSDKException(
+        `Invalid attack id: ${attackId}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<unknown>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH}/job/${jobId}/attack/${attackId}/list-outputs`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get property statistics for a custom attack scan. */
+  async getPropertyStats(jobId: string): Promise<PropertyStatistic[]> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<PropertyStatistic[]>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH}/job/${jobId}/property-stats`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/red-team/custom-attacks-client.ts
+++ b/src/red-team/custom-attacks-client.ts
@@ -1,0 +1,361 @@
+import { RED_TEAM_CUSTOM_ATTACK_PATH } from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { isValidUuid } from '../utils.js';
+import { managementHttpRequest } from '../management/management-http-client.js';
+import type { OAuthClient } from '../management/oauth-client.js';
+import type { RedTeamListOptions } from './scans-client.js';
+import type {
+  CustomPromptSetCreateRequest,
+  CustomPromptSetUpdateRequest,
+  CustomPromptSetArchiveRequest,
+  CustomPromptSetResponse,
+  CustomPromptSetList,
+  CustomPromptSetListActive,
+  CustomPromptSetReference,
+  CustomPromptSetVersionInfo,
+  CustomPromptCreateRequest,
+  CustomPromptUpdateRequest,
+  CustomPromptResponse,
+  CustomPromptList,
+  PropertyNameCreateRequest,
+  PropertyValueCreateRequest,
+  PropertyNamesListResponse,
+  PropertyValuesResponse,
+  PropertyValuesMultipleResponse,
+  BaseResponse,
+} from '../models/red-team.js';
+
+/** Prompt set list filter options. */
+export interface PromptSetListOptions extends RedTeamListOptions {
+  active?: boolean;
+  archive?: boolean;
+}
+
+/** Prompt list filter options. */
+export interface PromptListOptions extends RedTeamListOptions {
+  active?: boolean;
+}
+
+/** @internal */
+export interface RedTeamCustomAttacksClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
+  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}
+
+function validateUuid(uuid: string, label: string): void {
+  if (!isValidUuid(uuid)) {
+    throw new AISecSDKException(`Invalid ${label}: ${uuid}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+  }
+}
+
+/** Client for Red Team management plane custom attack operations. */
+export class RedTeamCustomAttacksClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: RedTeamCustomAttacksClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  // -----------------------------------------------------------------------
+  // Prompt Set operations
+  // -----------------------------------------------------------------------
+
+  /** Create a new custom prompt set. */
+  async createPromptSet(request: CustomPromptSetCreateRequest): Promise<CustomPromptSetResponse> {
+    const res = await managementHttpRequest<CustomPromptSetResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** List custom prompt sets. */
+  async listPromptSets(opts?: PromptSetListOptions): Promise<CustomPromptSetList> {
+    const params = buildListParams(opts);
+    if (opts?.active !== undefined) params.active = String(opts.active);
+    if (opts?.archive !== undefined) params.archive = String(opts.archive);
+
+    const res = await managementHttpRequest<CustomPromptSetList>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/list-custom-prompt-sets`,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get a prompt set by UUID. */
+  async getPromptSet(uuid: string): Promise<CustomPromptSetResponse> {
+    validateUuid(uuid, 'prompt set uuid');
+    const res = await managementHttpRequest<CustomPromptSetResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/${uuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Update a prompt set. */
+  async updatePromptSet(
+    uuid: string,
+    request: CustomPromptSetUpdateRequest,
+  ): Promise<CustomPromptSetResponse> {
+    validateUuid(uuid, 'prompt set uuid');
+    const res = await managementHttpRequest<CustomPromptSetResponse>({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/${uuid}`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Archive or unarchive a prompt set. */
+  async archivePromptSet(
+    uuid: string,
+    request: CustomPromptSetArchiveRequest,
+  ): Promise<CustomPromptSetResponse> {
+    validateUuid(uuid, 'prompt set uuid');
+    const res = await managementHttpRequest<CustomPromptSetResponse>({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/${uuid}/archive`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Resolve a prompt set reference for data plane consumption. */
+  async getPromptSetReference(uuid: string): Promise<CustomPromptSetReference> {
+    validateUuid(uuid, 'prompt set uuid');
+    const res = await managementHttpRequest<CustomPromptSetReference>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/${uuid}/reference`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get version information for a prompt set. */
+  async getPromptSetVersionInfo(uuid: string): Promise<CustomPromptSetVersionInfo> {
+    validateUuid(uuid, 'prompt set uuid');
+    const res = await managementHttpRequest<CustomPromptSetVersionInfo>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/${uuid}/version-info`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** List active prompt sets (for data plane). */
+  async listActivePromptSets(): Promise<CustomPromptSetListActive> {
+    const res = await managementHttpRequest<CustomPromptSetListActive>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/active-custom-prompt-sets`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Download CSV template for a prompt set. */
+  async downloadTemplate(uuid: string): Promise<unknown> {
+    validateUuid(uuid, 'prompt set uuid');
+    const res = await managementHttpRequest<unknown>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/download-template/${uuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  // -----------------------------------------------------------------------
+  // Prompt operations
+  // -----------------------------------------------------------------------
+
+  /** Create a new custom prompt. */
+  async createPrompt(request: CustomPromptCreateRequest): Promise<CustomPromptResponse> {
+    const res = await managementHttpRequest<CustomPromptResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/custom-prompt`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** List prompts in a prompt set. */
+  async listPrompts(promptSetUuid: string, opts?: PromptListOptions): Promise<CustomPromptList> {
+    validateUuid(promptSetUuid, 'prompt set uuid');
+    const params = buildListParams(opts);
+    if (opts?.active !== undefined) params.active = String(opts.active);
+
+    const res = await managementHttpRequest<CustomPromptList>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/${promptSetUuid}/list-custom-prompts`,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get a prompt by UUID. */
+  async getPrompt(promptSetUuid: string, promptUuid: string): Promise<CustomPromptResponse> {
+    validateUuid(promptSetUuid, 'prompt set uuid');
+    validateUuid(promptUuid, 'prompt uuid');
+    const res = await managementHttpRequest<CustomPromptResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/${promptSetUuid}/custom-prompt/${promptUuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Update a prompt. */
+  async updatePrompt(
+    promptSetUuid: string,
+    promptUuid: string,
+    request: CustomPromptUpdateRequest,
+  ): Promise<CustomPromptResponse> {
+    validateUuid(promptSetUuid, 'prompt set uuid');
+    validateUuid(promptUuid, 'prompt uuid');
+    const res = await managementHttpRequest<CustomPromptResponse>({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/${promptSetUuid}/custom-prompt/${promptUuid}`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Delete a prompt. */
+  async deletePrompt(promptSetUuid: string, promptUuid: string): Promise<BaseResponse> {
+    validateUuid(promptSetUuid, 'prompt set uuid');
+    validateUuid(promptUuid, 'prompt uuid');
+    const res = await managementHttpRequest<BaseResponse>({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/${promptSetUuid}/custom-prompt/${promptUuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  // -----------------------------------------------------------------------
+  // Property operations
+  // -----------------------------------------------------------------------
+
+  /** Get all property names. */
+  async getPropertyNames(): Promise<PropertyNamesListResponse> {
+    const res = await managementHttpRequest<PropertyNamesListResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/property-names`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Create a new property name. */
+  async createPropertyName(request: PropertyNameCreateRequest): Promise<BaseResponse> {
+    const res = await managementHttpRequest<BaseResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/property-names`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get values for a property name. */
+  async getPropertyValues(propertyName: string): Promise<PropertyValuesResponse> {
+    const res = await managementHttpRequest<PropertyValuesResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/property-values/${encodeURIComponent(propertyName)}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get values for multiple property names. */
+  async getPropertyValuesMultiple(
+    propertyNames: string[],
+  ): Promise<PropertyValuesMultipleResponse> {
+    const url = new URL(`https://placeholder${RED_TEAM_CUSTOM_ATTACK_PATH}/property-values`);
+    for (const name of propertyNames) {
+      url.searchParams.append('property_names', name);
+    }
+    const queryString = url.searchParams.toString();
+    const pathWithQuery = `${RED_TEAM_CUSTOM_ATTACK_PATH}/property-values${queryString ? `?${queryString}` : ''}`;
+
+    const res = await managementHttpRequest<PropertyValuesMultipleResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: pathWithQuery,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Create a property value. */
+  async createPropertyValue(request: PropertyValueCreateRequest): Promise<BaseResponse> {
+    const res = await managementHttpRequest<BaseResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/property-values`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/red-team/index.ts
+++ b/src/red-team/index.ts
@@ -1,0 +1,18 @@
+export { RedTeamClient, type RedTeamClientOptions } from './client.js';
+export {
+  RedTeamScansClient,
+  type RedTeamListOptions,
+  type RedTeamScanListOptions,
+} from './scans-client.js';
+export {
+  RedTeamReportsClient,
+  type AttackListOptions,
+  type GoalListOptions,
+} from './reports-client.js';
+export { RedTeamCustomAttackReportsClient } from './custom-attack-reports-client.js';
+export { RedTeamTargetsClient, type TargetListOptions } from './targets-client.js';
+export {
+  RedTeamCustomAttacksClient,
+  type PromptSetListOptions,
+  type PromptListOptions,
+} from './custom-attacks-client.js';

--- a/src/red-team/reports-client.ts
+++ b/src/red-team/reports-client.ts
@@ -1,0 +1,315 @@
+import {
+  RED_TEAM_REPORT_STATIC_PATH,
+  RED_TEAM_REPORT_DYNAMIC_PATH,
+  RED_TEAM_REPORT_PATH,
+} from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { isValidUuid } from '../utils.js';
+import { managementHttpRequest } from '../management/management-http-client.js';
+import type { OAuthClient } from '../management/oauth-client.js';
+import type { RedTeamListOptions } from './scans-client.js';
+import type {
+  AttackListResponse,
+  AttackDetailResponse,
+  AttackMultiTurnDetailResponse,
+  StaticJobReport,
+  DynamicJobReport,
+  RemediationResponse,
+  RuntimeSecurityProfileResponse,
+  GoalListResponse,
+  StreamListResponse,
+  StreamDetailResponse,
+} from '../models/red-team.js';
+
+/** Attack list filter options. */
+export interface AttackListOptions extends RedTeamListOptions {
+  status?: string;
+  severity?: string;
+  category?: string;
+  sub_category?: string;
+}
+
+/** Goal list filter options. */
+export interface GoalListOptions extends RedTeamListOptions {
+  goal_type?: string;
+}
+
+/** @internal */
+export interface RedTeamReportsClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
+  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}
+
+function validateJobId(jobId: string): void {
+  if (!isValidUuid(jobId)) {
+    throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+  }
+}
+
+/** Client for Red Team data plane report operations. */
+export class RedTeamReportsClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: RedTeamReportsClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  // -----------------------------------------------------------------------
+  // Static (attack library) report endpoints
+  // -----------------------------------------------------------------------
+
+  /** List attacks for a static scan. */
+  async listAttacks(jobId: string, opts?: AttackListOptions): Promise<AttackListResponse> {
+    validateJobId(jobId);
+    const params = buildListParams(opts);
+    if (opts?.status !== undefined) params.status = opts.status;
+    if (opts?.severity !== undefined) params.severity = opts.severity;
+    if (opts?.category !== undefined) params.category = opts.category;
+    if (opts?.sub_category !== undefined) params.sub_category = opts.sub_category;
+
+    const res = await managementHttpRequest<AttackListResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_STATIC_PATH}/${jobId}/list-attacks`,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get attack details for a static scan. */
+  async getAttackDetail(jobId: string, attackId: string): Promise<AttackDetailResponse> {
+    validateJobId(jobId);
+    if (!isValidUuid(attackId)) {
+      throw new AISecSDKException(
+        `Invalid attack id: ${attackId}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<AttackDetailResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_STATIC_PATH}/${jobId}/attack/${attackId}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get multi-turn attack details for a static scan. */
+  async getMultiTurnAttackDetail(
+    jobId: string,
+    attackId: string,
+  ): Promise<AttackMultiTurnDetailResponse> {
+    validateJobId(jobId);
+    if (!isValidUuid(attackId)) {
+      throw new AISecSDKException(
+        `Invalid attack id: ${attackId}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<AttackMultiTurnDetailResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_STATIC_PATH}/${jobId}/attack-multi-turn/${attackId}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get the attack library report for a static scan. */
+  async getStaticReport(jobId: string): Promise<StaticJobReport> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<StaticJobReport>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_STATIC_PATH}/${jobId}/report`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get remediation recommendations for a static scan. */
+  async getStaticRemediation(jobId: string): Promise<RemediationResponse> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<RemediationResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_STATIC_PATH}/${jobId}/remediation`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get runtime security profile config for a static scan. */
+  async getStaticRuntimePolicy(jobId: string): Promise<RuntimeSecurityProfileResponse> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<RuntimeSecurityProfileResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_STATIC_PATH}/${jobId}/runtime-policy-config`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  // -----------------------------------------------------------------------
+  // Dynamic (agent) report endpoints
+  // -----------------------------------------------------------------------
+
+  /** Get the agent scan report for a dynamic scan. */
+  async getDynamicReport(jobId: string): Promise<DynamicJobReport> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<DynamicJobReport>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_DYNAMIC_PATH}/${jobId}/report`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get remediation recommendations for a dynamic scan. */
+  async getDynamicRemediation(jobId: string): Promise<RemediationResponse> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<RemediationResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_DYNAMIC_PATH}/${jobId}/remediation`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get runtime security profile config for a dynamic scan. */
+  async getDynamicRuntimePolicy(jobId: string): Promise<RuntimeSecurityProfileResponse> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<RuntimeSecurityProfileResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_DYNAMIC_PATH}/${jobId}/runtime-policy-config`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** List goals for a dynamic scan. */
+  async listGoals(jobId: string, opts?: GoalListOptions): Promise<GoalListResponse> {
+    validateJobId(jobId);
+    const params = buildListParams(opts);
+    if (opts?.goal_type !== undefined) params.goal_type = opts.goal_type;
+
+    const res = await managementHttpRequest<GoalListResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_DYNAMIC_PATH}/${jobId}/list-goals`,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** List streams for a goal in a dynamic scan. */
+  async listGoalStreams(
+    jobId: string,
+    goalId: string,
+    opts?: RedTeamListOptions,
+  ): Promise<StreamListResponse> {
+    validateJobId(jobId);
+    if (!isValidUuid(goalId)) {
+      throw new AISecSDKException(
+        `Invalid goal id: ${goalId}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<StreamListResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_DYNAMIC_PATH}/${jobId}/goal/${goalId}/list-streams`,
+      params: buildListParams(opts),
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  // -----------------------------------------------------------------------
+  // Common report endpoints
+  // -----------------------------------------------------------------------
+
+  /** Get stream details by stream ID. */
+  async getStreamDetail(streamId: string): Promise<StreamDetailResponse> {
+    if (!isValidUuid(streamId)) {
+      throw new AISecSDKException(
+        `Invalid stream id: ${streamId}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<StreamDetailResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_DYNAMIC_PATH}/stream/${streamId}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Download a report in the specified format. */
+  async downloadReport(jobId: string, format?: string): Promise<unknown> {
+    validateJobId(jobId);
+    const params: Record<string, string> = {};
+    if (format !== undefined) params.file_format = format;
+
+    const res = await managementHttpRequest<unknown>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_PATH}/${jobId}/download`,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Generate a partial report for a running scan. */
+  async generatePartialReport(jobId: string): Promise<unknown> {
+    validateJobId(jobId);
+    const res = await managementHttpRequest<unknown>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_REPORT_PATH}/${jobId}/generate-partial-report`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/red-team/scans-client.ts
+++ b/src/red-team/scans-client.ts
@@ -1,0 +1,133 @@
+import { RED_TEAM_SCAN_PATH, RED_TEAM_CATEGORIES_PATH } from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { isValidUuid } from '../utils.js';
+import { managementHttpRequest } from '../management/management-http-client.js';
+import type { OAuthClient } from '../management/oauth-client.js';
+import type {
+  JobCreateRequest,
+  JobResponse,
+  JobListResponse,
+  JobAbortResponse,
+  CategoryModel,
+} from '../models/red-team.js';
+
+/** Pagination and filter options for Red Team list operations. */
+export interface RedTeamListOptions {
+  skip?: number;
+  limit?: number;
+  sort_by?: string;
+  sort_direction?: string;
+  search?: string;
+}
+
+/** Extended list options for scan/job listing. */
+export interface RedTeamScanListOptions extends RedTeamListOptions {
+  status?: string;
+  job_type?: string;
+  target_id?: string;
+}
+
+/** @internal */
+export interface RedTeamScansClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
+  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}
+
+/** Client for Red Team data plane scan operations. */
+export class RedTeamScansClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: RedTeamScansClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  /** Create a new red team scan job. */
+  async create(request: JobCreateRequest): Promise<JobResponse> {
+    const res = await managementHttpRequest<JobResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_SCAN_PATH,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** List red team scan jobs with optional filters. */
+  async list(opts?: RedTeamScanListOptions): Promise<JobListResponse> {
+    const params = buildListParams(opts);
+    if (opts?.status !== undefined) params.status = opts.status;
+    if (opts?.job_type !== undefined) params.job_type = opts.job_type;
+    if (opts?.target_id !== undefined) params.target_id = opts.target_id;
+
+    const res = await managementHttpRequest<JobListResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_SCAN_PATH,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get a single scan job by ID. */
+  async get(jobId: string): Promise<JobResponse> {
+    if (!isValidUuid(jobId)) {
+      throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+    }
+
+    const res = await managementHttpRequest<JobResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_SCAN_PATH}/${jobId}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Abort a running scan job. */
+  async abort(jobId: string): Promise<JobAbortResponse> {
+    if (!isValidUuid(jobId)) {
+      throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+    }
+
+    const res = await managementHttpRequest<JobAbortResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_SCAN_PATH}/${jobId}/abort`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get all categories with subcategories. */
+  async getCategories(): Promise<CategoryModel[]> {
+    const res = await managementHttpRequest<CategoryModel[]>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_CATEGORIES_PATH,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/red-team/targets-client.ts
+++ b/src/red-team/targets-client.ts
@@ -1,0 +1,194 @@
+import { RED_TEAM_TARGET_PATH } from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { isValidUuid } from '../utils.js';
+import { managementHttpRequest } from '../management/management-http-client.js';
+import type { OAuthClient } from '../management/oauth-client.js';
+import type { RedTeamListOptions } from './scans-client.js';
+import type {
+  TargetCreateRequest,
+  TargetUpdateRequest,
+  TargetContextUpdate,
+  TargetResponse,
+  TargetList,
+  TargetProbeRequest,
+  TargetProfileResponse,
+  BaseResponse,
+} from '../models/red-team.js';
+
+/** Target list filter options. */
+export interface TargetListOptions extends RedTeamListOptions {
+  target_type?: string;
+  status?: string;
+  active?: boolean;
+}
+
+/** @internal */
+export interface RedTeamTargetsClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
+  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}
+
+/** Client for Red Team management plane target operations. */
+export class RedTeamTargetsClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: RedTeamTargetsClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  /** Create a new target. */
+  async create(request: TargetCreateRequest): Promise<TargetResponse> {
+    const res = await managementHttpRequest<TargetResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_TARGET_PATH,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** List targets with optional filters. */
+  async list(opts?: TargetListOptions): Promise<TargetList> {
+    const params = buildListParams(opts);
+    if (opts?.target_type !== undefined) params.target_type = opts.target_type;
+    if (opts?.status !== undefined) params.status = opts.status;
+    if (opts?.active !== undefined) params.active = String(opts.active);
+
+    const res = await managementHttpRequest<TargetList>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_TARGET_PATH,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get a target by UUID. */
+  async get(uuid: string): Promise<TargetResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid target uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<TargetResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_TARGET_PATH}/${uuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Update a target. */
+  async update(uuid: string, request: TargetUpdateRequest): Promise<TargetResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid target uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<TargetResponse>({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_TARGET_PATH}/${uuid}`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Delete a target. */
+  async delete(uuid: string): Promise<BaseResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid target uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<BaseResponse>({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_TARGET_PATH}/${uuid}`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Run profiling probes on a target. */
+  async probe(request: TargetProbeRequest): Promise<TargetResponse> {
+    const res = await managementHttpRequest<TargetResponse>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_TARGET_PATH}/probe`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Get profiling results for a target. */
+  async getProfile(uuid: string): Promise<TargetProfileResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid target uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<TargetProfileResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_TARGET_PATH}/${uuid}/profile`,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /** Update a target profile (background + additional context). */
+  async updateProfile(uuid: string, request: TargetContextUpdate): Promise<TargetProfileResponse> {
+    if (!isValidUuid(uuid)) {
+      throw new AISecSDKException(
+        `Invalid target uuid: ${uuid}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<TargetProfileResponse>({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_TARGET_PATH}/${uuid}/profile`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/test/models/red-team-enums.spec.ts
+++ b/test/models/red-team-enums.spec.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ApiEndpointType,
+  AttackStatus,
+  AttackType,
+  AuthType,
+  BrandSubCategory,
+  ComplianceSubCategory,
+  CountedQuotaEnum,
+  DateRangeFilter,
+  ErrorSource,
+  RedTeamErrorType,
+  FileFormat,
+  GoalType,
+  GoalTypeQueryParam,
+  GuardrailAction,
+  JobStatus,
+  JobStatusFilter,
+  JobType,
+  PolicyType,
+  ProfilingStatus,
+  RedTeamCategory,
+  ResponseMode,
+  RiskRating,
+  SafetySubCategory,
+  SecuritySubCategory,
+  SeverityFilter,
+  StatusQueryParam,
+  StreamType,
+  TargetConnectionType,
+  TargetStatus,
+  TargetType,
+} from '../../src/models/red-team-enums.js';
+
+describe('ApiEndpointType', () => {
+  it('has expected values', () => {
+    expect(ApiEndpointType.PUBLIC).toBe('PUBLIC');
+    expect(ApiEndpointType.PRIVATE).toBe('PRIVATE');
+    expect(ApiEndpointType.NETWORK_BROKER).toBe('NETWORK_BROKER');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(ApiEndpointType)).toHaveLength(3);
+  });
+});
+
+describe('AttackStatus', () => {
+  it('has expected values', () => {
+    expect(AttackStatus.INIT).toBe('INIT');
+    expect(AttackStatus.ATTACK).toBe('ATTACK');
+    expect(AttackStatus.COMPLETED).toBe('COMPLETED');
+  });
+
+  it('has exactly 6 values', () => {
+    expect(Object.keys(AttackStatus)).toHaveLength(6);
+  });
+});
+
+describe('AttackType', () => {
+  it('has expected values', () => {
+    expect(AttackType.NORMAL).toBe('NORMAL');
+    expect(AttackType.CUSTOM).toBe('CUSTOM');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(AttackType)).toHaveLength(2);
+  });
+});
+
+describe('AuthType', () => {
+  it('has expected values', () => {
+    expect(AuthType.OAUTH).toBe('OAUTH');
+    expect(AuthType.ACCESS_TOKEN).toBe('ACCESS_TOKEN');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(AuthType)).toHaveLength(2);
+  });
+});
+
+describe('BrandSubCategory', () => {
+  it('has expected values', () => {
+    expect(BrandSubCategory.COMPETITOR_ENDORSEMENTS).toBe('COMPETITOR_ENDORSEMENTS');
+    expect(BrandSubCategory.BRAND_TARNISHING_SELF_CRITICISM).toBe(
+      'BRAND_TARNISHING_SELF_CRITICISM',
+    );
+    expect(BrandSubCategory.POLITICAL_ENDORSEMENTS).toBe('POLITICAL_ENDORSEMENTS');
+  });
+
+  it('has exactly 4 values', () => {
+    expect(Object.keys(BrandSubCategory)).toHaveLength(4);
+  });
+});
+
+describe('ComplianceSubCategory', () => {
+  it('has expected values', () => {
+    expect(ComplianceSubCategory.OWASP).toBe('OWASP');
+    expect(ComplianceSubCategory.MITRE_ATLAS).toBe('MITRE_ATLAS');
+    expect(ComplianceSubCategory.DASF_V2).toBe('DASF_V2');
+  });
+
+  it('has exactly 4 values', () => {
+    expect(Object.keys(ComplianceSubCategory)).toHaveLength(4);
+  });
+});
+
+describe('CountedQuotaEnum', () => {
+  it('has expected values', () => {
+    expect(CountedQuotaEnum.HELD).toBe('HELD');
+    expect(CountedQuotaEnum.COUNTED).toBe('COUNTED');
+    expect(CountedQuotaEnum.NOT_COUNTED).toBe('NOT_COUNTED');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(CountedQuotaEnum)).toHaveLength(3);
+  });
+});
+
+describe('DateRangeFilter', () => {
+  it('has expected values', () => {
+    expect(DateRangeFilter.LAST_7_DAYS).toBe('LAST_7_DAYS');
+    expect(DateRangeFilter.LAST_30_DAYS).toBe('LAST_30_DAYS');
+    expect(DateRangeFilter.ALL).toBe('ALL');
+  });
+
+  it('has exactly 4 values', () => {
+    expect(Object.keys(DateRangeFilter)).toHaveLength(4);
+  });
+});
+
+describe('ErrorSource', () => {
+  it('has expected values', () => {
+    expect(ErrorSource.TARGET).toBe('TARGET');
+    expect(ErrorSource.SYSTEM).toBe('SYSTEM');
+    expect(ErrorSource.TARGET_PROFILING).toBe('TARGET_PROFILING');
+  });
+
+  it('has exactly 5 values', () => {
+    expect(Object.keys(ErrorSource)).toHaveLength(5);
+  });
+});
+
+describe('RedTeamErrorType', () => {
+  it('has expected values', () => {
+    expect(RedTeamErrorType.CONTENT_FILTER).toBe('CONTENT_FILTER');
+    expect(RedTeamErrorType.RATE_LIMIT).toBe('RATE_LIMIT');
+    expect(RedTeamErrorType.UNKNOWN).toBe('UNKNOWN');
+  });
+
+  it('has exactly 7 values', () => {
+    expect(Object.keys(RedTeamErrorType)).toHaveLength(7);
+  });
+});
+
+describe('FileFormat', () => {
+  it('has expected values', () => {
+    expect(FileFormat.CSV).toBe('CSV');
+    expect(FileFormat.JSON).toBe('JSON');
+    expect(FileFormat.ALL).toBe('ALL');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(FileFormat)).toHaveLength(3);
+  });
+});
+
+describe('GoalType', () => {
+  it('has expected values', () => {
+    expect(GoalType.BASE).toBe('BASE');
+    expect(GoalType.TOOL_MISUSE).toBe('TOOL_MISUSE');
+    expect(GoalType.GOAL_MANIPULATION).toBe('GOAL_MANIPULATION');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(GoalType)).toHaveLength(3);
+  });
+});
+
+describe('GoalTypeQueryParam', () => {
+  it('has expected values', () => {
+    expect(GoalTypeQueryParam.AGENT).toBe('AGENT');
+    expect(GoalTypeQueryParam.HUMAN_AUGMENTED).toBe('HUMAN_AUGMENTED');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(GoalTypeQueryParam)).toHaveLength(2);
+  });
+});
+
+describe('GuardrailAction', () => {
+  it('has expected values', () => {
+    expect(GuardrailAction.ALLOW).toBe('ALLOW');
+    expect(GuardrailAction.BLOCK).toBe('BLOCK');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(GuardrailAction)).toHaveLength(2);
+  });
+});
+
+describe('JobStatus', () => {
+  it('has expected values', () => {
+    expect(JobStatus.INIT).toBe('INIT');
+    expect(JobStatus.RUNNING).toBe('RUNNING');
+    expect(JobStatus.ABORTED).toBe('ABORTED');
+  });
+
+  it('has exactly 7 values', () => {
+    expect(Object.keys(JobStatus)).toHaveLength(7);
+  });
+});
+
+describe('JobStatusFilter', () => {
+  it('has expected values', () => {
+    expect(JobStatusFilter.QUEUED).toBe('QUEUED');
+    expect(JobStatusFilter.COMPLETED).toBe('COMPLETED');
+    expect(JobStatusFilter.ABORTED).toBe('ABORTED');
+  });
+
+  it('has exactly 6 values', () => {
+    expect(Object.keys(JobStatusFilter)).toHaveLength(6);
+  });
+});
+
+describe('JobType', () => {
+  it('has expected values', () => {
+    expect(JobType.STATIC).toBe('STATIC');
+    expect(JobType.DYNAMIC).toBe('DYNAMIC');
+    expect(JobType.CUSTOM).toBe('CUSTOM');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(JobType)).toHaveLength(3);
+  });
+});
+
+describe('PolicyType', () => {
+  it('has expected values', () => {
+    expect(PolicyType.PROMPT_INJECTION).toBe('PROMPT_INJECTION');
+    expect(PolicyType.TOXIC_CONTENT).toBe('TOXIC_CONTENT');
+    expect(PolicyType.SENSITIVE_DATA_PROTECTION).toBe('SENSITIVE_DATA_PROTECTION');
+  });
+
+  it('has exactly 6 values', () => {
+    expect(Object.keys(PolicyType)).toHaveLength(6);
+  });
+});
+
+describe('ProfilingStatus', () => {
+  it('has expected values', () => {
+    expect(ProfilingStatus.INIT).toBe('INIT');
+    expect(ProfilingStatus.IN_PROGRESS).toBe('IN_PROGRESS');
+    expect(ProfilingStatus.FAILED).toBe('FAILED');
+  });
+
+  it('has exactly 5 values', () => {
+    expect(Object.keys(ProfilingStatus)).toHaveLength(5);
+  });
+});
+
+describe('RedTeamCategory', () => {
+  it('has expected values', () => {
+    expect(RedTeamCategory.SECURITY).toBe('SECURITY');
+    expect(RedTeamCategory.SAFETY).toBe('SAFETY');
+    expect(RedTeamCategory.BRAND).toBe('BRAND');
+  });
+
+  it('has exactly 4 values', () => {
+    expect(Object.keys(RedTeamCategory)).toHaveLength(4);
+  });
+});
+
+describe('ResponseMode', () => {
+  it('has expected values', () => {
+    expect(ResponseMode.REST).toBe('REST');
+    expect(ResponseMode.STREAMING).toBe('STREAMING');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(ResponseMode)).toHaveLength(2);
+  });
+});
+
+describe('RiskRating', () => {
+  it('has expected values', () => {
+    expect(RiskRating.LOW).toBe('LOW');
+    expect(RiskRating.HIGH).toBe('HIGH');
+    expect(RiskRating.CRITICAL).toBe('CRITICAL');
+  });
+
+  it('has exactly 4 values', () => {
+    expect(Object.keys(RiskRating)).toHaveLength(4);
+  });
+});
+
+describe('SafetySubCategory', () => {
+  it('has expected values', () => {
+    expect(SafetySubCategory.BIAS).toBe('BIAS');
+    expect(SafetySubCategory.CYBERCRIME).toBe('CYBERCRIME');
+    expect(SafetySubCategory.VIOLENT_CRIMES_WEAPONS).toBe('VIOLENT_CRIMES_WEAPONS');
+  });
+
+  it('has exactly 10 values', () => {
+    expect(Object.keys(SafetySubCategory)).toHaveLength(10);
+  });
+});
+
+describe('SecuritySubCategory', () => {
+  it('has expected values', () => {
+    expect(SecuritySubCategory.JAILBREAK).toBe('JAILBREAK');
+    expect(SecuritySubCategory.PROMPT_INJECTION).toBe('PROMPT_INJECTION');
+    expect(SecuritySubCategory.MALWARE_GENERATION).toBe('MALWARE_GENERATION');
+  });
+
+  it('has exactly 10 values', () => {
+    expect(Object.keys(SecuritySubCategory)).toHaveLength(10);
+  });
+});
+
+describe('SeverityFilter', () => {
+  it('has expected values', () => {
+    expect(SeverityFilter.LOW).toBe('LOW');
+    expect(SeverityFilter.MEDIUM).toBe('MEDIUM');
+    expect(SeverityFilter.CRITICAL).toBe('CRITICAL');
+  });
+
+  it('has exactly 4 values', () => {
+    expect(Object.keys(SeverityFilter)).toHaveLength(4);
+  });
+});
+
+describe('StatusQueryParam', () => {
+  it('has expected values', () => {
+    expect(StatusQueryParam.SUCCESSFUL).toBe('SUCCESSFUL');
+    expect(StatusQueryParam.FAILED).toBe('FAILED');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(StatusQueryParam)).toHaveLength(2);
+  });
+});
+
+describe('StreamType', () => {
+  it('has expected values', () => {
+    expect(StreamType.NORMAL).toBe('NORMAL');
+    expect(StreamType.ADVERSARIAL).toBe('ADVERSARIAL');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(StreamType)).toHaveLength(2);
+  });
+});
+
+describe('TargetConnectionType', () => {
+  it('has expected values', () => {
+    expect(TargetConnectionType.DATABRICKS).toBe('DATABRICKS');
+    expect(TargetConnectionType.OPENAI).toBe('OPENAI');
+    expect(TargetConnectionType.STREAMING).toBe('STREAMING');
+  });
+
+  it('has exactly 7 values', () => {
+    expect(Object.keys(TargetConnectionType)).toHaveLength(7);
+  });
+});
+
+describe('TargetStatus', () => {
+  it('has expected values', () => {
+    expect(TargetStatus.DRAFT).toBe('DRAFT');
+    expect(TargetStatus.ACTIVE).toBe('ACTIVE');
+    expect(TargetStatus.PENDING_AUTH).toBe('PENDING_AUTH');
+  });
+
+  it('has exactly 7 values', () => {
+    expect(Object.keys(TargetStatus)).toHaveLength(7);
+  });
+});
+
+describe('TargetType', () => {
+  it('has expected values', () => {
+    expect(TargetType.APPLICATION).toBe('APPLICATION');
+    expect(TargetType.AGENT).toBe('AGENT');
+    expect(TargetType.MODEL).toBe('MODEL');
+  });
+
+  it('has exactly 3 values', () => {
+    expect(Object.keys(TargetType)).toHaveLength(3);
+  });
+});

--- a/test/models/red-team.spec.ts
+++ b/test/models/red-team.spec.ts
@@ -1,0 +1,961 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RedTeamPaginationSchema,
+  JobCreateRequestSchema,
+  JobResponseSchema,
+  JobListResponseSchema,
+  JobAbortResponseSchema,
+  AttackListResponseSchema,
+  AttackDetailResponseSchema,
+  StaticJobReportSchema,
+  DynamicJobReportSchema,
+  GoalSchema,
+  StreamDetailResponseSchema,
+  CustomAttackReportResponseSchema,
+  ScanStatisticsResponseSchema,
+  ScoreTrendResponseSchema,
+  SentimentRequestSchema,
+  QuotaSummarySchema,
+  ErrorLogSchema,
+  TargetCreateRequestSchema,
+  TargetResponseSchema,
+  TargetListSchema,
+  CustomPromptSetCreateRequestSchema,
+  CustomPromptSetResponseSchema,
+  CustomPromptCreateRequestSchema,
+  CustomPromptResponseSchema,
+  PropertyNamesListResponseSchema,
+  BaseResponseSchema,
+  DashboardOverviewResponseSchema,
+} from '../../src/models/red-team.js';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+const now = '2025-01-01T00:00:00Z';
+
+const baseTargetRef = {
+  uuid: validUuid,
+  tsg_id: '123',
+  name: 'test-target',
+  status: 'active',
+  active: true,
+  validated: true,
+  created_at: now,
+  updated_at: now,
+};
+
+// ---------------------------------------------------------------------------
+// Shared / utility schemas
+// ---------------------------------------------------------------------------
+
+describe('RedTeamPaginationSchema', () => {
+  it('parses valid pagination', () => {
+    expect(RedTeamPaginationSchema.parse({ total_items: 42 })).toEqual({ total_items: 42 });
+  });
+
+  it('accepts null total_items', () => {
+    expect(RedTeamPaginationSchema.parse({ total_items: null })).toEqual({ total_items: null });
+  });
+
+  it('accepts missing total_items', () => {
+    expect(RedTeamPaginationSchema.parse({})).toEqual({});
+  });
+
+  it('passes through unknown fields', () => {
+    const res = RedTeamPaginationSchema.parse({ total_items: 1, extra: true });
+    expect((res as Record<string, unknown>).extra).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataPlane — Job schemas
+// ---------------------------------------------------------------------------
+
+describe('JobCreateRequestSchema', () => {
+  it('parses valid static job request', () => {
+    const req = {
+      name: 'test-job',
+      target: { uuid: validUuid },
+      job_type: 'static',
+      job_metadata: { categories: { security: true } },
+    };
+    const parsed = JobCreateRequestSchema.parse(req);
+    expect(parsed.name).toBe('test-job');
+    expect(parsed.job_type).toBe('static');
+  });
+
+  it('parses with optional version and extra_info', () => {
+    const req = {
+      name: 'test-job',
+      target: { uuid: validUuid, version: 2 },
+      job_type: 'dynamic',
+      job_metadata: { stream_breadth: 3, stream_depth: 5 },
+      version: 1,
+      extra_info: { note: 'test' },
+    };
+    const parsed = JobCreateRequestSchema.parse(req);
+    expect(parsed.version).toBe(1);
+    expect(parsed.extra_info).toEqual({ note: 'test' });
+  });
+
+  it('accepts null version and extra_info', () => {
+    const req = {
+      name: 'test-job',
+      target: { uuid: validUuid },
+      job_type: 'custom',
+      job_metadata: { custom_prompt_sets: [validUuid] },
+      version: null,
+      extra_info: null,
+    };
+    const parsed = JobCreateRequestSchema.parse(req);
+    expect(parsed.version).toBeNull();
+    expect(parsed.extra_info).toBeNull();
+  });
+
+  it('rejects missing required fields', () => {
+    expect(() => JobCreateRequestSchema.parse({ name: 'x' })).toThrow();
+  });
+});
+
+describe('JobResponseSchema', () => {
+  const baseJob = {
+    uuid: validUuid,
+    tsg_id: '123',
+    name: 'my-job',
+    target: baseTargetRef,
+    job_type: 'static',
+    job_metadata: {},
+    target_id: validUuid,
+    target_type: 'api',
+  };
+
+  it('parses valid job response', () => {
+    const parsed = JobResponseSchema.parse(baseJob);
+    expect(parsed.uuid).toBe(validUuid);
+    expect(parsed.name).toBe('my-job');
+  });
+
+  it('accepts optional fields', () => {
+    const full = {
+      ...baseJob,
+      version: 1,
+      total: 100,
+      completed: 50,
+      status: 'running',
+      score: 85.5,
+      asr: 0.15,
+      time_record: { queued_at: now, started_at: now },
+      created_at: now,
+      updated_at: now,
+      created_by_user_id: 'user-1',
+      report_stats: { summary: 'ok' },
+      metering_quota_uuid: validUuid,
+      counted_towards_quota: 'yes',
+      invocation_id: 'inv-1',
+    };
+    const parsed = JobResponseSchema.parse(full);
+    expect(parsed.status).toBe('running');
+    expect(parsed.score).toBe(85.5);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = JobResponseSchema.parse({ ...baseJob, future_field: 'hello' });
+    expect((res as Record<string, unknown>).future_field).toBe('hello');
+  });
+});
+
+describe('JobListResponseSchema', () => {
+  it('parses valid list', () => {
+    const baseJob = {
+      uuid: validUuid,
+      tsg_id: '123',
+      name: 'j1',
+      target: baseTargetRef,
+      job_type: 'static',
+      job_metadata: {},
+      target_id: validUuid,
+      target_type: 'api',
+    };
+    const data = { pagination: { total_items: 1 }, data: [baseJob] };
+    const parsed = JobListResponseSchema.parse(data);
+    expect(parsed.data).toHaveLength(1);
+    expect(parsed.pagination.total_items).toBe(1);
+  });
+
+  it('passes through unknown fields', () => {
+    const data = { pagination: {}, data: [], extra: 42 };
+    const parsed = JobListResponseSchema.parse(data);
+    expect((parsed as Record<string, unknown>).extra).toBe(42);
+  });
+});
+
+describe('JobAbortResponseSchema', () => {
+  it('parses valid abort response', () => {
+    const parsed = JobAbortResponseSchema.parse({ job_id: validUuid, message: 'Job aborted' });
+    expect(parsed.job_id).toBe(validUuid);
+    expect(parsed.message).toBe('Job aborted');
+  });
+
+  it('rejects missing message', () => {
+    expect(() => JobAbortResponseSchema.parse({ job_id: validUuid })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataPlane — Attack schemas
+// ---------------------------------------------------------------------------
+
+describe('AttackListResponseSchema', () => {
+  it('parses valid attack list', () => {
+    const attack = {
+      uuid: validUuid,
+      tsg_id: '123',
+      job_id: validUuid,
+      target_id: validUuid,
+      prompt: 'test prompt',
+      prompt_mapping_id: 'pm-1',
+      prompt_id: 'p-1',
+      category: 'security',
+      sub_category: 'injection',
+      category_display_name: 'Security',
+      sub_category_display_name: 'Injection',
+    };
+    const data = { pagination: { total_items: 1 }, data: [attack] };
+    const parsed = AttackListResponseSchema.parse(data);
+    expect(parsed.data).toHaveLength(1);
+    expect(parsed.data[0].category).toBe('security');
+  });
+
+  it('parses empty list', () => {
+    const parsed = AttackListResponseSchema.parse({ pagination: {}, data: [] });
+    expect(parsed.data).toHaveLength(0);
+  });
+});
+
+describe('AttackDetailResponseSchema', () => {
+  const baseAttack = {
+    uuid: validUuid,
+    tsg_id: '123',
+    job_id: validUuid,
+    target_id: validUuid,
+    prompt: 'test prompt',
+    prompt_mapping_id: 'pm-1',
+    prompt_id: 'p-1',
+    category: 'security',
+    sub_category: 'injection',
+    category_display_name: 'Security',
+    sub_category_display_name: 'Injection',
+    compliance_frameworks: [],
+    goal: 'Extract PII data',
+  };
+
+  it('parses valid attack detail', () => {
+    const parsed = AttackDetailResponseSchema.parse(baseAttack);
+    expect(parsed.goal).toBe('Extract PII data');
+    expect(parsed.compliance_frameworks).toEqual([]);
+  });
+
+  it('accepts null goal', () => {
+    const parsed = AttackDetailResponseSchema.parse({ ...baseAttack, goal: null });
+    expect(parsed.goal).toBeNull();
+  });
+
+  it('accepts outputs array', () => {
+    const output = {
+      uuid: validUuid,
+      tsg_id: '123',
+      attack_id: validUuid,
+      job_id: validUuid,
+      target_id: validUuid,
+      output: 'response text',
+    };
+    const parsed = AttackDetailResponseSchema.parse({ ...baseAttack, outputs: [output] });
+    expect(parsed.outputs).toHaveLength(1);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = AttackDetailResponseSchema.parse({ ...baseAttack, new_field: 'x' });
+    expect((res as Record<string, unknown>).new_field).toBe('x');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataPlane — Report schemas
+// ---------------------------------------------------------------------------
+
+describe('StaticJobReportSchema', () => {
+  const minReport = {
+    severity_report: { stats: [] },
+  };
+
+  it('parses minimal report', () => {
+    const parsed = StaticJobReportSchema.parse(minReport);
+    expect(parsed.severity_report.stats).toEqual([]);
+  });
+
+  it('parses full report', () => {
+    const full = {
+      severity_report: {
+        stats: [{ severity: 'high', successful: 5, failed: 2 }],
+        successful: 5,
+        failed: 2,
+        total_attacks: 7,
+      },
+      asr: 0.71,
+      score: 71,
+      security_report: {
+        id: 'sec',
+        display_name: 'Security',
+        description: 'Security attacks',
+        sub_categories: [
+          {
+            id: 'inj',
+            display_name: 'Injection',
+            description: 'Prompt injection',
+            successful: 3,
+            failed: 1,
+          },
+        ],
+        asr: 0.75,
+        total_prompts: 4,
+        total_attacks: 4,
+        successful: 3,
+        failed: 1,
+      },
+      safety_report: null,
+      brand_report: null,
+      compliance_report: [],
+      report_summary: 'High risk',
+      recommendations: null,
+    };
+    const parsed = StaticJobReportSchema.parse(full);
+    expect(parsed.asr).toBe(0.71);
+    expect(parsed.security_report?.asr).toBe(0.75);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = StaticJobReportSchema.parse({ ...minReport, future: true });
+    expect((res as Record<string, unknown>).future).toBe(true);
+  });
+});
+
+describe('DynamicJobReportSchema', () => {
+  it('parses valid dynamic report', () => {
+    const data = {
+      total_goals: 10,
+      total_streams: 30,
+      total_threats: 5,
+      goals_achieved: 3,
+      report_summary: 'Moderate risk',
+      score: 65,
+      asr: 0.3,
+    };
+    const parsed = DynamicJobReportSchema.parse(data);
+    expect(parsed.total_goals).toBe(10);
+    expect(parsed.score).toBe(65);
+  });
+
+  it('parses empty object (all optional)', () => {
+    const parsed = DynamicJobReportSchema.parse({});
+    expect(parsed).toEqual({});
+  });
+
+  it('passes through unknown fields', () => {
+    const res = DynamicJobReportSchema.parse({ extra_metric: 42 });
+    expect((res as Record<string, unknown>).extra_metric).toBe(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataPlane — Goal & Stream schemas
+// ---------------------------------------------------------------------------
+
+describe('GoalSchema', () => {
+  const baseGoal = {
+    goal: 'Extract confidential data',
+    safe_response: 'I cannot help with that.',
+    jailbroken_response: 'Here is the data...',
+    uuid: validUuid,
+    tsg_id: '123',
+    job_id: validUuid,
+  };
+
+  it('parses valid goal', () => {
+    const parsed = GoalSchema.parse(baseGoal);
+    expect(parsed.goal).toBe('Extract confidential data');
+    expect(parsed.safe_response).toBe('I cannot help with that.');
+  });
+
+  it('accepts optional fields', () => {
+    const full = {
+      ...baseGoal,
+      goal_metadata: { difficulty: 'hard' },
+      custom_goal: true,
+      goal_type: 'extraction',
+      goal_to_show: 'Show this goal',
+      threat: true,
+      version: 2,
+      extra_info: { note: 'test' },
+    };
+    const parsed = GoalSchema.parse(full);
+    expect(parsed.custom_goal).toBe(true);
+    expect(parsed.threat).toBe(true);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = GoalSchema.parse({ ...baseGoal, new_field: 'y' });
+    expect((res as Record<string, unknown>).new_field).toBe('y');
+  });
+});
+
+describe('StreamDetailResponseSchema', () => {
+  const baseStream = {
+    uuid: validUuid,
+    tsg_id: '123',
+    job_id: validUuid,
+    target_id: validUuid,
+    goal_id: validUuid,
+  };
+
+  it('parses minimal stream', () => {
+    const parsed = StreamDetailResponseSchema.parse(baseStream);
+    expect(parsed.uuid).toBe(validUuid);
+    expect(parsed.goal_id).toBe(validUuid);
+  });
+
+  it('accepts optional iteration data', () => {
+    const iteration = {
+      uuid: validUuid,
+      tsg_id: '123',
+      job_id: validUuid,
+      stream_id: validUuid,
+      goal_id: validUuid,
+      iteration: 1,
+      prompt: 'test prompt',
+      techniques: 'jailbreak',
+      improvement: 'refined approach',
+      prompts_objective: 'extract data',
+      summary: 'first attempt',
+      output: 'model response',
+      score: 7,
+    };
+    const parsed = StreamDetailResponseSchema.parse({
+      ...baseStream,
+      stream_idx: 0,
+      iteration: 3,
+      threat: true,
+      first_threat_iteration: iteration,
+      iterations: [iteration],
+    });
+    expect(parsed.iterations).toHaveLength(1);
+    expect(parsed.first_threat_iteration?.iteration).toBe(1);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = StreamDetailResponseSchema.parse({ ...baseStream, extra: 'val' });
+    expect((res as Record<string, unknown>).extra).toBe('val');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataPlane — Custom attack report schemas
+// ---------------------------------------------------------------------------
+
+describe('CustomAttackReportResponseSchema', () => {
+  it('parses valid report', () => {
+    const data = {
+      total_prompts: 100,
+      total_attacks: 80,
+      total_threats: 15,
+      failed_attacks: 5,
+      score: 81.25,
+      asr: 0.1875,
+    };
+    const parsed = CustomAttackReportResponseSchema.parse(data);
+    expect(parsed.total_prompts).toBe(100);
+    expect(parsed.score).toBe(81.25);
+  });
+
+  it('accepts optional custom_attack_reports', () => {
+    const data = {
+      total_prompts: 10,
+      total_attacks: 10,
+      total_threats: 2,
+      failed_attacks: 0,
+      score: 80,
+      asr: 0.2,
+      custom_attack_reports: [
+        {
+          prompt_set_id: validUuid,
+          prompt_set_name: 'set-1',
+          total_prompts: 10,
+          total_attacks: 10,
+          total_threats: 2,
+          failed_attacks: 0,
+          threat_rate: 0.2,
+        },
+      ],
+    };
+    const parsed = CustomAttackReportResponseSchema.parse(data);
+    expect(parsed.custom_attack_reports).toHaveLength(1);
+  });
+
+  it('passes through unknown fields', () => {
+    const data = {
+      total_prompts: 1,
+      total_attacks: 1,
+      total_threats: 0,
+      failed_attacks: 0,
+      score: 100,
+      asr: 0,
+      new_metric: 'test',
+    };
+    const res = CustomAttackReportResponseSchema.parse(data);
+    expect((res as Record<string, unknown>).new_metric).toBe('test');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataPlane — Dashboard schemas
+// ---------------------------------------------------------------------------
+
+describe('ScanStatisticsResponseSchema', () => {
+  it('parses valid stats', () => {
+    const data = {
+      total_scans: 50,
+      targets_scanned: 10,
+      targets_scanned_by_type: [{ name: 'api', count: 8 }],
+      scan_status: [{ name: 'completed', count: 45 }],
+      risk_profile: [
+        { risk_rating: 'high', total: 3, targets_by_type: [{ name: 'api', count: 2 }] },
+      ],
+    };
+    const parsed = ScanStatisticsResponseSchema.parse(data);
+    expect(parsed.total_scans).toBe(50);
+    expect(parsed.risk_profile).toHaveLength(1);
+  });
+
+  it('parses minimal stats', () => {
+    const parsed = ScanStatisticsResponseSchema.parse({ total_scans: 0, targets_scanned: 0 });
+    expect(parsed.total_scans).toBe(0);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = ScanStatisticsResponseSchema.parse({
+      total_scans: 1,
+      targets_scanned: 1,
+      extra: true,
+    });
+    expect((res as Record<string, unknown>).extra).toBe(true);
+  });
+});
+
+describe('ScoreTrendResponseSchema', () => {
+  it('parses valid trend', () => {
+    const data = {
+      labels: ['2025-01', '2025-02', '2025-03'],
+      series: [{ label: 'target-1', data: [85, 90, null] }],
+    };
+    const parsed = ScoreTrendResponseSchema.parse(data);
+    expect(parsed.labels).toHaveLength(3);
+    expect(parsed.series[0].data[2]).toBeNull();
+  });
+
+  it('parses empty trend', () => {
+    const parsed = ScoreTrendResponseSchema.parse({ labels: [], series: [] });
+    expect(parsed.labels).toHaveLength(0);
+    expect(parsed.series).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataPlane — Sentiment, Quota, Error Log schemas
+// ---------------------------------------------------------------------------
+
+describe('SentimentRequestSchema', () => {
+  it('parses valid request', () => {
+    const parsed = SentimentRequestSchema.parse({ job_id: validUuid, up_vote: true });
+    expect(parsed.job_id).toBe(validUuid);
+    expect(parsed.up_vote).toBe(true);
+  });
+
+  it('parses minimal request', () => {
+    const parsed = SentimentRequestSchema.parse({ job_id: validUuid });
+    expect(parsed.job_id).toBe(validUuid);
+    expect(parsed.up_vote).toBeUndefined();
+    expect(parsed.down_vote).toBeUndefined();
+  });
+
+  it('rejects missing job_id', () => {
+    expect(() => SentimentRequestSchema.parse({ up_vote: true })).toThrow();
+  });
+});
+
+describe('QuotaSummarySchema', () => {
+  it('parses valid quota', () => {
+    const data = {
+      static: { allocated: 100, unlimited: false, consumed: 25 },
+      dynamic: { allocated: 50, unlimited: false, consumed: 10 },
+      custom: { allocated: 0, unlimited: true, consumed: 0 },
+    };
+    const parsed = QuotaSummarySchema.parse(data);
+    expect(parsed.static.consumed).toBe(25);
+    expect(parsed.custom.unlimited).toBe(true);
+  });
+
+  it('rejects missing quota type', () => {
+    expect(() =>
+      QuotaSummarySchema.parse({
+        static: { allocated: 100, unlimited: false, consumed: 0 },
+        dynamic: { allocated: 50, unlimited: false, consumed: 0 },
+      }),
+    ).toThrow();
+  });
+});
+
+describe('ErrorLogSchema', () => {
+  it('parses valid error log', () => {
+    const data = {
+      created_at: now,
+      updated_at: now,
+      job_id: validUuid,
+      target_id: validUuid,
+      error_type: 'timeout',
+      error_source: 'target',
+      error_message: 'Request timed out',
+    };
+    const parsed = ErrorLogSchema.parse(data);
+    expect(parsed.error_type).toBe('timeout');
+    expect(parsed.error_message).toBe('Request timed out');
+  });
+
+  it('accepts nullable fields as null', () => {
+    const data = {
+      created_at: now,
+      updated_at: now,
+      job_id: null,
+      target_id: null,
+      error_type: null,
+      error_source: null,
+      error_message: null,
+    };
+    const parsed = ErrorLogSchema.parse(data);
+    expect(parsed.job_id).toBeNull();
+    expect(parsed.error_message).toBeNull();
+  });
+
+  it('parses minimal (only required timestamps)', () => {
+    const parsed = ErrorLogSchema.parse({ created_at: now, updated_at: now });
+    expect(parsed.created_at).toBe(now);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = ErrorLogSchema.parse({ created_at: now, updated_at: now, extra: 'val' });
+    expect((res as Record<string, unknown>).extra).toBe('val');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Management — Target schemas
+// ---------------------------------------------------------------------------
+
+describe('TargetCreateRequestSchema', () => {
+  it('parses minimal request', () => {
+    const parsed = TargetCreateRequestSchema.parse({ name: 'my-target' });
+    expect(parsed.name).toBe('my-target');
+  });
+
+  it('parses full request with optionals', () => {
+    const req = {
+      name: 'my-target',
+      description: 'A test target',
+      target_type: 'llm',
+      connection_type: 'api',
+      api_endpoint_type: 'openai',
+      response_mode: 'streaming',
+      session_supported: true,
+      target_metadata: { probe_message: 'hello' },
+      target_background: { industry: 'finance' },
+      additional_context: { base_model: 'gpt-4' },
+    };
+    const parsed = TargetCreateRequestSchema.parse(req);
+    expect(parsed.session_supported).toBe(true);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = TargetCreateRequestSchema.parse({ name: 'x', custom: true });
+    expect((res as Record<string, unknown>).custom).toBe(true);
+  });
+
+  it('rejects missing name', () => {
+    expect(() => TargetCreateRequestSchema.parse({})).toThrow();
+  });
+});
+
+describe('TargetResponseSchema', () => {
+  const baseTarget = {
+    uuid: validUuid,
+    tsg_id: '123',
+    name: 'my-target',
+    status: 'active',
+    active: true,
+    validated: true,
+    created_at: now,
+    updated_at: now,
+  };
+
+  it('parses valid target response', () => {
+    const parsed = TargetResponseSchema.parse(baseTarget);
+    expect(parsed.uuid).toBe(validUuid);
+    expect(parsed.active).toBe(true);
+  });
+
+  it('accepts optional fields', () => {
+    const full = {
+      ...baseTarget,
+      description: 'Test target',
+      target_type: 'llm',
+      connection_type: 'api',
+      session_supported: false,
+      version: 3,
+      target_metadata: { multi_turn: true },
+    };
+    const parsed = TargetResponseSchema.parse(full);
+    expect(parsed.session_supported).toBe(false);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = TargetResponseSchema.parse({ ...baseTarget, future: 'yes' });
+    expect((res as Record<string, unknown>).future).toBe('yes');
+  });
+});
+
+describe('TargetListSchema', () => {
+  it('parses valid list', () => {
+    const item = {
+      uuid: validUuid,
+      tsg_id: '123',
+      name: 't1',
+      status: 'active',
+      active: true,
+      validated: true,
+      created_at: now,
+      updated_at: now,
+    };
+    const data = { pagination: { total_items: 1 }, data: [item] };
+    const parsed = TargetListSchema.parse(data);
+    expect(parsed.data).toHaveLength(1);
+  });
+
+  it('accepts missing data array', () => {
+    const parsed = TargetListSchema.parse({ pagination: {} });
+    expect(parsed.data).toBeUndefined();
+  });
+
+  it('passes through unknown fields', () => {
+    const res = TargetListSchema.parse({ pagination: {}, extra: 42 });
+    expect((res as Record<string, unknown>).extra).toBe(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Management — Custom prompt set schemas
+// ---------------------------------------------------------------------------
+
+describe('CustomPromptSetCreateRequestSchema', () => {
+  it('parses minimal request', () => {
+    const parsed = CustomPromptSetCreateRequestSchema.parse({ name: 'my-set' });
+    expect(parsed.name).toBe('my-set');
+  });
+
+  it('parses full request', () => {
+    const req = {
+      name: 'my-set',
+      description: 'Test prompt set',
+      property_names: ['category', 'severity'],
+    };
+    const parsed = CustomPromptSetCreateRequestSchema.parse(req);
+    expect(parsed.property_names).toEqual(['category', 'severity']);
+  });
+
+  it('rejects missing name', () => {
+    expect(() => CustomPromptSetCreateRequestSchema.parse({})).toThrow();
+  });
+});
+
+describe('CustomPromptSetResponseSchema', () => {
+  const baseSet = {
+    uuid: validUuid,
+    name: 'my-set',
+    active: true,
+    archive: false,
+    status: 'ready',
+    created_at: now,
+    updated_at: now,
+  };
+
+  it('parses valid response', () => {
+    const parsed = CustomPromptSetResponseSchema.parse(baseSet);
+    expect(parsed.uuid).toBe(validUuid);
+    expect(parsed.archive).toBe(false);
+  });
+
+  it('accepts optional fields', () => {
+    const full = {
+      ...baseSet,
+      description: 'A prompt set',
+      property_names: ['cat'],
+      properties: [{ name: 'cat', value: 'security' }],
+      stats: { total_prompts: 10 },
+      version: 2,
+      created_by_user_id: 'user-1',
+      updated_by_user_id: 'user-2',
+    };
+    const parsed = CustomPromptSetResponseSchema.parse(full);
+    expect(parsed.property_names).toEqual(['cat']);
+  });
+
+  it('passes through unknown fields', () => {
+    const res = CustomPromptSetResponseSchema.parse({ ...baseSet, extra: 'x' });
+    expect((res as Record<string, unknown>).extra).toBe('x');
+  });
+});
+
+describe('CustomPromptCreateRequestSchema', () => {
+  it('parses valid request', () => {
+    const req = { prompt: 'How do I hack?', prompt_set_id: validUuid };
+    const parsed = CustomPromptCreateRequestSchema.parse(req);
+    expect(parsed.prompt).toBe('How do I hack?');
+    expect(parsed.prompt_set_id).toBe(validUuid);
+  });
+
+  it('parses with optional goal and properties', () => {
+    const req = {
+      prompt: 'test',
+      prompt_set_id: validUuid,
+      goal: 'Extract secrets',
+      properties: [{ name: 'cat', value: 'security' }],
+    };
+    const parsed = CustomPromptCreateRequestSchema.parse(req);
+    expect(parsed.goal).toBe('Extract secrets');
+  });
+
+  it('rejects missing prompt', () => {
+    expect(() => CustomPromptCreateRequestSchema.parse({ prompt_set_id: validUuid })).toThrow();
+  });
+});
+
+describe('CustomPromptResponseSchema', () => {
+  const basePrompt = {
+    uuid: validUuid,
+    prompt: 'test prompt',
+    user_defined_goal: false,
+    status: 'active',
+    active: true,
+    prompt_set_id: validUuid,
+    created_at: now,
+    updated_at: now,
+  };
+
+  it('parses valid response', () => {
+    const parsed = CustomPromptResponseSchema.parse(basePrompt);
+    expect(parsed.uuid).toBe(validUuid);
+    expect(parsed.user_defined_goal).toBe(false);
+  });
+
+  it('accepts optional fields', () => {
+    const full = {
+      ...basePrompt,
+      goal: 'Extract data',
+      properties: [{ name: 'cat', value: 'sec' }],
+      property_assignments: [{ name: 'cat', value: 'sec' }],
+      detector_category: 'injection',
+      severity: 'high',
+      extra_info: { note: 'test' },
+    };
+    const parsed = CustomPromptResponseSchema.parse(full);
+    expect(parsed.goal).toBe('Extract data');
+  });
+
+  it('passes through unknown fields', () => {
+    const res = CustomPromptResponseSchema.parse({ ...basePrompt, future: true });
+    expect((res as Record<string, unknown>).future).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Management — Property schemas
+// ---------------------------------------------------------------------------
+
+describe('PropertyNamesListResponseSchema', () => {
+  it('parses valid list', () => {
+    const data = {
+      data: [
+        { property_name: 'category', created_at: now },
+        { property_name: 'severity', created_at: now },
+      ],
+    };
+    const parsed = PropertyNamesListResponseSchema.parse(data);
+    expect(parsed.data).toHaveLength(2);
+    expect(parsed.data![0].property_name).toBe('category');
+  });
+
+  it('accepts missing data', () => {
+    const parsed = PropertyNamesListResponseSchema.parse({});
+    expect(parsed.data).toBeUndefined();
+  });
+
+  it('passes through unknown fields', () => {
+    const res = PropertyNamesListResponseSchema.parse({ extra: 'val' });
+    expect((res as Record<string, unknown>).extra).toBe('val');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Management — Base response & Dashboard
+// ---------------------------------------------------------------------------
+
+describe('BaseResponseSchema', () => {
+  it('parses valid response', () => {
+    const parsed = BaseResponseSchema.parse({ message: 'OK', status: 200 });
+    expect(parsed.message).toBe('OK');
+    expect(parsed.status).toBe(200);
+  });
+
+  it('rejects missing message', () => {
+    expect(() => BaseResponseSchema.parse({ status: 200 })).toThrow();
+  });
+
+  it('rejects missing status', () => {
+    expect(() => BaseResponseSchema.parse({ message: 'OK' })).toThrow();
+  });
+});
+
+describe('DashboardOverviewResponseSchema', () => {
+  it('parses valid overview', () => {
+    const data = {
+      total_targets: 15,
+      targets_by_type: [
+        { name: 'api', count: 10 },
+        { name: 'web', count: 5 },
+      ],
+    };
+    const parsed = DashboardOverviewResponseSchema.parse(data);
+    expect(parsed.total_targets).toBe(15);
+    expect(parsed.targets_by_type).toHaveLength(2);
+  });
+
+  it('parses without optional targets_by_type', () => {
+    const parsed = DashboardOverviewResponseSchema.parse({ total_targets: 0 });
+    expect(parsed.total_targets).toBe(0);
+    expect(parsed.targets_by_type).toBeUndefined();
+  });
+
+  it('passes through unknown fields', () => {
+    const res = DashboardOverviewResponseSchema.parse({ total_targets: 1, extra: 'field' });
+    expect((res as Record<string, unknown>).extra).toBe('field');
+  });
+});

--- a/test/red-team/client.spec.ts
+++ b/test/red-team/client.spec.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { RedTeamClient } from '../../src/red-team/client.js';
+import { RedTeamScansClient } from '../../src/red-team/scans-client.js';
+import { RedTeamReportsClient } from '../../src/red-team/reports-client.js';
+import { RedTeamCustomAttackReportsClient } from '../../src/red-team/custom-attack-reports-client.js';
+import { RedTeamTargetsClient } from '../../src/red-team/targets-client.js';
+import { RedTeamCustomAttacksClient } from '../../src/red-team/custom-attacks-client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('RedTeamClient', () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    globalThis.fetch = originalFetch;
+  });
+
+  it('constructs with explicit options', () => {
+    const client = new RedTeamClient({
+      clientId: 'cid',
+      clientSecret: 'csec',
+      tsgId: '999',
+    });
+    expect(client.scans).toBeInstanceOf(RedTeamScansClient);
+    expect(client.reports).toBeInstanceOf(RedTeamReportsClient);
+    expect(client.customAttackReports).toBeInstanceOf(RedTeamCustomAttackReportsClient);
+    expect(client.targets).toBeInstanceOf(RedTeamTargetsClient);
+    expect(client.customAttacks).toBeInstanceOf(RedTeamCustomAttacksClient);
+  });
+
+  it('reads credentials from RED_TEAM env vars', () => {
+    process.env.PANW_RED_TEAM_CLIENT_ID = 'env-cid';
+    process.env.PANW_RED_TEAM_CLIENT_SECRET = 'env-csec';
+    process.env.PANW_RED_TEAM_TSG_ID = 'env-tsg';
+
+    const client = new RedTeamClient();
+    expect(client.scans).toBeInstanceOf(RedTeamScansClient);
+  });
+
+  it('falls back to MGMT env vars', () => {
+    process.env.PANW_MGMT_CLIENT_ID = 'mgmt-cid';
+    process.env.PANW_MGMT_CLIENT_SECRET = 'mgmt-csec';
+    process.env.PANW_MGMT_TSG_ID = 'mgmt-tsg';
+
+    const client = new RedTeamClient();
+    expect(client.scans).toBeInstanceOf(RedTeamScansClient);
+  });
+
+  it('RED_TEAM env vars take precedence over MGMT', () => {
+    process.env.PANW_RED_TEAM_CLIENT_ID = 'rt-cid';
+    process.env.PANW_RED_TEAM_CLIENT_SECRET = 'rt-csec';
+    process.env.PANW_RED_TEAM_TSG_ID = 'rt-tsg';
+    process.env.PANW_MGMT_CLIENT_ID = 'mgmt-cid';
+    process.env.PANW_MGMT_CLIENT_SECRET = 'mgmt-csec';
+    process.env.PANW_MGMT_TSG_ID = 'mgmt-tsg';
+
+    const client = new RedTeamClient();
+    expect(client.scans).toBeInstanceOf(RedTeamScansClient);
+  });
+
+  it('explicit opts override env vars', () => {
+    process.env.PANW_RED_TEAM_CLIENT_ID = 'env-cid';
+    process.env.PANW_RED_TEAM_CLIENT_SECRET = 'env-csec';
+    process.env.PANW_RED_TEAM_TSG_ID = 'env-tsg';
+
+    const client = new RedTeamClient({
+      clientId: 'override',
+      clientSecret: 'override-sec',
+      tsgId: 'override-tsg',
+    });
+    expect(client.scans).toBeInstanceOf(RedTeamScansClient);
+  });
+
+  it('throws when clientId missing', () => {
+    expect(
+      () =>
+        new RedTeamClient({
+          clientSecret: 'sec',
+          tsgId: '1',
+        }),
+    ).toThrow(AISecSDKException);
+  });
+
+  it('throws when clientSecret missing', () => {
+    expect(
+      () =>
+        new RedTeamClient({
+          clientId: 'cid',
+          tsgId: '1',
+        }),
+    ).toThrow(AISecSDKException);
+  });
+
+  it('throws when tsgId missing', () => {
+    expect(
+      () =>
+        new RedTeamClient({
+          clientId: 'cid',
+          clientSecret: 'sec',
+        }),
+    ).toThrow(AISecSDKException);
+  });
+
+  it('accepts custom endpoints', () => {
+    const client = new RedTeamClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+      dataEndpoint: 'https://data.example.com',
+      mgmtEndpoint: 'https://mgmt.example.com',
+      tokenEndpoint: 'https://auth.example.com/token',
+    });
+    expect(client.scans).toBeInstanceOf(RedTeamScansClient);
+  });
+
+  it('reads endpoints from env vars', () => {
+    process.env.PANW_RED_TEAM_CLIENT_ID = 'cid';
+    process.env.PANW_RED_TEAM_CLIENT_SECRET = 'sec';
+    process.env.PANW_RED_TEAM_TSG_ID = '1';
+    process.env.PANW_RED_TEAM_DATA_ENDPOINT = 'https://data.env.com';
+    process.env.PANW_RED_TEAM_MGMT_ENDPOINT = 'https://mgmt.env.com';
+    process.env.PANW_RED_TEAM_TOKEN_ENDPOINT = 'https://auth.env.com/token';
+
+    const client = new RedTeamClient();
+    expect(client.scans).toBeInstanceOf(RedTeamScansClient);
+  });
+
+  it('clamps numRetries to valid range', () => {
+    const client = new RedTeamClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+      numRetries: 10,
+    });
+    expect(client.scans).toBeInstanceOf(RedTeamScansClient);
+  });
+
+  it('clamps negative numRetries to 0', () => {
+    const client = new RedTeamClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+      numRetries: -1,
+    });
+    expect(client.scans).toBeInstanceOf(RedTeamScansClient);
+  });
+
+  it('defaults numRetries to 5', () => {
+    const client = new RedTeamClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+    });
+    expect(client.scans).toBeInstanceOf(RedTeamScansClient);
+  });
+
+  // -----------------------------------------------------------------------
+  // Convenience methods
+  // -----------------------------------------------------------------------
+
+  function mockTwoFetches(data: unknown) {
+    const tokenResp = { access_token: 'tok', token_type: 'bearer', expires_in: 3600 };
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(tokenResp),
+        text: () => Promise.resolve(JSON.stringify(tokenResp)),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify(data)),
+      });
+  }
+
+  function makeClient() {
+    return new RedTeamClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+      numRetries: 0,
+    });
+  }
+
+  describe('getScanStatistics', () => {
+    it('GETs /v1/dashboard/scan-statistics', async () => {
+      const resp = { total_scans: 10 };
+      mockTwoFetches(resp);
+      const client = makeClient();
+      const result = await client.getScanStatistics();
+      expect(result.total_scans).toBe(10);
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain('/v1/dashboard/scan-statistics');
+    });
+  });
+
+  describe('getScoreTrend', () => {
+    it('GETs /v1/dashboard/score-trend', async () => {
+      const resp = { trends: [] };
+      mockTwoFetches(resp);
+      const client = makeClient();
+      const result = await client.getScoreTrend(validUuid);
+      expect(result.trends).toEqual([]);
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain('/v1/dashboard/score-trend');
+    });
+
+    it('rejects invalid UUID', async () => {
+      const client = makeClient();
+      await expect(client.getScoreTrend('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getQuota', () => {
+    it('POSTs to /v1/metering/quota', async () => {
+      const resp = { used: 5, total: 100 };
+      mockTwoFetches(resp);
+      const client = makeClient();
+      const result = await client.getQuota();
+      expect(result.used).toBe(5);
+
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain('/v1/metering/quota');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  describe('getErrorLogs', () => {
+    it('GETs /v1/error-log/job/:jobId', async () => {
+      const resp = { logs: [] };
+      mockTwoFetches(resp);
+      const client = makeClient();
+      const result = await client.getErrorLogs(validUuid);
+      expect(result.logs).toEqual([]);
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain(`/v1/error-log/job/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      const client = makeClient();
+      await expect(client.getErrorLogs('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('updateSentiment', () => {
+    it('POSTs to /v1/sentiment', async () => {
+      const resp = { job_id: validUuid, sentiment: 'positive' };
+      mockTwoFetches(resp);
+      const client = makeClient();
+      const result = await client.updateSentiment({ job_id: validUuid, sentiment: 'positive' });
+      expect(result.sentiment).toBe('positive');
+
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain('/v1/sentiment');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  describe('getSentiment', () => {
+    it('GETs /v1/sentiment/:jobId', async () => {
+      const resp = { job_id: validUuid, sentiment: 'positive' };
+      mockTwoFetches(resp);
+      const client = makeClient();
+      const result = await client.getSentiment(validUuid);
+      expect(result.sentiment).toBe('positive');
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain(`/v1/sentiment/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      const client = makeClient();
+      await expect(client.getSentiment('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getDashboardOverview', () => {
+    it('GETs /v1/dashboard/overview', async () => {
+      const resp = { overview: {} };
+      mockTwoFetches(resp);
+      const client = makeClient();
+      const result = await client.getDashboardOverview();
+      expect(result.overview).toEqual({});
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain('/v1/dashboard/overview');
+    });
+  });
+});

--- a/test/red-team/custom-attack-reports-client.spec.ts
+++ b/test/red-team/custom-attack-reports-client.spec.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RedTeamCustomAttackReportsClient } from '../../src/red-team/custom-attack-reports-client.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+const validUuid2 = '660e8400-e29b-41d4-a716-446655440000';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('RedTeamCustomAttackReportsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: RedTeamCustomAttackReportsClient;
+
+  beforeEach(() => {
+    client = new RedTeamCustomAttackReportsClient({
+      baseUrl: 'https://data.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // -----------------------------------------------------------------------
+  // getReport
+  // -----------------------------------------------------------------------
+  describe('getReport', () => {
+    it('GETs /v1/custom-attacks/report/:jobId', async () => {
+      mockFetch({ job_id: validUuid, score: 90 });
+      const result = await client.getReport(validUuid);
+
+      expect(result.job_id).toBe(validUuid);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attacks/report/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getReport('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getPromptSets
+  // -----------------------------------------------------------------------
+  describe('getPromptSets', () => {
+    it('GETs /v1/custom-attacks/report/:jobId/prompt-sets', async () => {
+      mockFetch({ prompt_sets: [] });
+      const result = await client.getPromptSets(validUuid);
+
+      expect(result.prompt_sets).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attacks/report/${validUuid}/prompt-sets`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getPromptSets('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getPromptsBySet
+  // -----------------------------------------------------------------------
+  describe('getPromptsBySet', () => {
+    it('GETs /v1/custom-attacks/report/:jobId/prompt-set/:promptSetId/prompts', async () => {
+      mockFetch({ prompts: [] });
+      const result = await client.getPromptsBySet(validUuid, validUuid2);
+
+      expect(result).toBeDefined();
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(
+        `/v1/custom-attacks/report/${validUuid}/prompt-set/${validUuid2}/prompts`,
+      );
+    });
+
+    it('rejects invalid job UUID', async () => {
+      await expect(client.getPromptsBySet('bad', validUuid2)).rejects.toThrow(AISecSDKException);
+    });
+
+    it('rejects invalid prompt set UUID', async () => {
+      await expect(client.getPromptsBySet(validUuid, 'bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getPromptDetail
+  // -----------------------------------------------------------------------
+  describe('getPromptDetail', () => {
+    it('GETs /v1/custom-attacks/report/:jobId/prompt/:promptId', async () => {
+      mockFetch({ id: validUuid2, text: 'test prompt' });
+      const result = await client.getPromptDetail(validUuid, validUuid2);
+
+      expect(result.id).toBe(validUuid2);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attacks/report/${validUuid}/prompt/${validUuid2}`);
+    });
+
+    it('rejects invalid job UUID', async () => {
+      await expect(client.getPromptDetail('bad', validUuid2)).rejects.toThrow(AISecSDKException);
+    });
+
+    it('rejects invalid prompt UUID', async () => {
+      await expect(client.getPromptDetail(validUuid, 'bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // listCustomAttacks
+  // -----------------------------------------------------------------------
+  describe('listCustomAttacks', () => {
+    it('GETs /v1/custom-attacks/job/:jobId/list-custom-attacks', async () => {
+      mockFetch({ attacks: [], total: 0 });
+      const result = await client.listCustomAttacks(validUuid);
+
+      expect(result.attacks).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attacks/job/${validUuid}/list-custom-attacks`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.listCustomAttacks('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getAttackOutputs
+  // -----------------------------------------------------------------------
+  describe('getAttackOutputs', () => {
+    it('GETs /v1/custom-attacks/job/:jobId/attack/:attackId/list-outputs', async () => {
+      mockFetch({ outputs: [] });
+      const result = await client.getAttackOutputs(validUuid, validUuid2);
+
+      expect(result).toBeDefined();
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(
+        `/v1/custom-attacks/job/${validUuid}/attack/${validUuid2}/list-outputs`,
+      );
+    });
+
+    it('rejects invalid job UUID', async () => {
+      await expect(client.getAttackOutputs('bad', validUuid2)).rejects.toThrow(AISecSDKException);
+    });
+
+    it('rejects invalid attack UUID', async () => {
+      await expect(client.getAttackOutputs(validUuid, 'bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getPropertyStats
+  // -----------------------------------------------------------------------
+  describe('getPropertyStats', () => {
+    it('GETs /v1/custom-attacks/job/:jobId/property-stats', async () => {
+      const stats = [{ name: 'severity', count: 5 }];
+      mockFetch(stats);
+      const result = await client.getPropertyStats(validUuid);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('severity');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attacks/job/${validUuid}/property-stats`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getPropertyStats('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+});

--- a/test/red-team/custom-attacks-client.spec.ts
+++ b/test/red-team/custom-attacks-client.spec.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RedTeamCustomAttacksClient } from '../../src/red-team/custom-attacks-client.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+const validUuid2 = '660e8400-e29b-41d4-a716-446655440000';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('RedTeamCustomAttacksClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: RedTeamCustomAttacksClient;
+
+  beforeEach(() => {
+    client = new RedTeamCustomAttacksClient({
+      baseUrl: 'https://mgmt.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // -----------------------------------------------------------------------
+  // Prompt Set operations
+  // -----------------------------------------------------------------------
+
+  describe('createPromptSet', () => {
+    it('POSTs to /v1/custom-attack/custom-prompt-set', async () => {
+      const ps = { id: validUuid, name: 'test-set' };
+      mockFetch(ps, 201);
+      const result = await client.createPromptSet({ name: 'test-set' });
+
+      expect(result.id).toBe(validUuid);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://mgmt.example.com/v1/custom-attack/custom-prompt-set');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  describe('listPromptSets', () => {
+    it('GETs /v1/custom-attack/list-custom-prompt-sets', async () => {
+      mockFetch({ prompt_sets: [], total: 0 });
+      const result = await client.listPromptSets();
+
+      expect(result.prompt_sets).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/custom-attack/list-custom-prompt-sets');
+    });
+
+    it('passes filter params', async () => {
+      mockFetch({ prompt_sets: [], total: 0 });
+      await client.listPromptSets({ active: true, archive: false });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('active=true');
+      expect(url).toContain('archive=false');
+    });
+  });
+
+  describe('getPromptSet', () => {
+    it('GETs /v1/custom-attack/custom-prompt-set/:uuid', async () => {
+      mockFetch({ id: validUuid, name: 'my-set' });
+      const result = await client.getPromptSet(validUuid);
+
+      expect(result.id).toBe(validUuid);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attack/custom-prompt-set/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getPromptSet('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('updatePromptSet', () => {
+    it('PUTs to /v1/custom-attack/custom-prompt-set/:uuid', async () => {
+      mockFetch({ id: validUuid, name: 'updated' });
+      const result = await client.updatePromptSet(validUuid, { name: 'updated' });
+
+      expect(result.name).toBe('updated');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attack/custom-prompt-set/${validUuid}`);
+      expect(init.method).toBe('PUT');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.updatePromptSet('bad', { name: 'x' })).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('archivePromptSet', () => {
+    it('PUTs to /v1/custom-attack/custom-prompt-set/:uuid/archive', async () => {
+      mockFetch({ id: validUuid, archived: true });
+      const result = await client.archivePromptSet(validUuid, { archive: true });
+
+      expect(result.archived).toBe(true);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attack/custom-prompt-set/${validUuid}/archive`);
+      expect(init.method).toBe('PUT');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.archivePromptSet('bad', { archive: true })).rejects.toThrow(
+        AISecSDKException,
+      );
+    });
+  });
+
+  describe('getPromptSetReference', () => {
+    it('GETs /v1/custom-attack/custom-prompt-set/:uuid/reference', async () => {
+      mockFetch({ uuid: validUuid, version: 1 });
+      const result = await client.getPromptSetReference(validUuid);
+
+      expect(result.uuid).toBe(validUuid);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attack/custom-prompt-set/${validUuid}/reference`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getPromptSetReference('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getPromptSetVersionInfo', () => {
+    it('GETs /v1/custom-attack/custom-prompt-set/:uuid/version-info', async () => {
+      mockFetch({ uuid: validUuid, version: 3 });
+      const result = await client.getPromptSetVersionInfo(validUuid);
+
+      expect(result.version).toBe(3);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attack/custom-prompt-set/${validUuid}/version-info`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getPromptSetVersionInfo('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('listActivePromptSets', () => {
+    it('GETs /v1/custom-attack/active-custom-prompt-sets', async () => {
+      mockFetch({ prompt_sets: [] });
+      const result = await client.listActivePromptSets();
+
+      expect(result.prompt_sets).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/custom-attack/active-custom-prompt-sets');
+    });
+  });
+
+  describe('downloadTemplate', () => {
+    it('GETs /v1/custom-attack/download-template/:uuid', async () => {
+      mockFetch('csv-data');
+      const result = await client.downloadTemplate(validUuid);
+
+      expect(result).toBe('csv-data');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attack/download-template/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.downloadTemplate('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Prompt operations
+  // -----------------------------------------------------------------------
+
+  describe('createPrompt', () => {
+    it('POSTs to /v1/custom-attack/custom-prompt-set/custom-prompt', async () => {
+      const prompt = { id: validUuid, text: 'test prompt' };
+      mockFetch(prompt, 201);
+      const result = await client.createPrompt({
+        prompt_set_uuid: validUuid,
+        text: 'test prompt',
+      });
+
+      expect(result.id).toBe(validUuid);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/custom-attack/custom-prompt-set/custom-prompt');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  describe('listPrompts', () => {
+    it('GETs /v1/custom-attack/custom-prompt-set/:uuid/list-custom-prompts', async () => {
+      mockFetch({ prompts: [], total: 0 });
+      const result = await client.listPrompts(validUuid);
+
+      expect(result.prompts).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/custom-attack/custom-prompt-set/${validUuid}/list-custom-prompts`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.listPrompts('bad')).rejects.toThrow(AISecSDKException);
+    });
+
+    it('passes active filter param', async () => {
+      mockFetch({ prompts: [], total: 0 });
+      await client.listPrompts(validUuid, { active: true });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('active=true');
+    });
+  });
+
+  describe('getPrompt', () => {
+    it('GETs /v1/custom-attack/custom-prompt-set/:setUuid/custom-prompt/:promptUuid', async () => {
+      mockFetch({ id: validUuid2, text: 'prompt text' });
+      const result = await client.getPrompt(validUuid, validUuid2);
+
+      expect(result.id).toBe(validUuid2);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(
+        `/v1/custom-attack/custom-prompt-set/${validUuid}/custom-prompt/${validUuid2}`,
+      );
+    });
+
+    it('rejects invalid prompt set UUID', async () => {
+      await expect(client.getPrompt('bad', validUuid2)).rejects.toThrow(AISecSDKException);
+    });
+
+    it('rejects invalid prompt UUID', async () => {
+      await expect(client.getPrompt(validUuid, 'bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('updatePrompt', () => {
+    it('PUTs to /v1/custom-attack/custom-prompt-set/:setUuid/custom-prompt/:promptUuid', async () => {
+      mockFetch({ id: validUuid2, text: 'updated' });
+      const result = await client.updatePrompt(validUuid, validUuid2, { text: 'updated' });
+
+      expect(result.text).toBe('updated');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(
+        `/v1/custom-attack/custom-prompt-set/${validUuid}/custom-prompt/${validUuid2}`,
+      );
+      expect(init.method).toBe('PUT');
+    });
+
+    it('rejects invalid prompt set UUID', async () => {
+      await expect(client.updatePrompt('bad', validUuid2, { text: 'x' })).rejects.toThrow(
+        AISecSDKException,
+      );
+    });
+
+    it('rejects invalid prompt UUID', async () => {
+      await expect(client.updatePrompt(validUuid, 'bad', { text: 'x' })).rejects.toThrow(
+        AISecSDKException,
+      );
+    });
+  });
+
+  describe('deletePrompt', () => {
+    it('DELETEs /v1/custom-attack/custom-prompt-set/:setUuid/custom-prompt/:promptUuid', async () => {
+      mockFetch({ success: true });
+      const result = await client.deletePrompt(validUuid, validUuid2);
+
+      expect(result.success).toBe(true);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(
+        `/v1/custom-attack/custom-prompt-set/${validUuid}/custom-prompt/${validUuid2}`,
+      );
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('rejects invalid prompt set UUID', async () => {
+      await expect(client.deletePrompt('bad', validUuid2)).rejects.toThrow(AISecSDKException);
+    });
+
+    it('rejects invalid prompt UUID', async () => {
+      await expect(client.deletePrompt(validUuid, 'bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Property operations
+  // -----------------------------------------------------------------------
+
+  describe('getPropertyNames', () => {
+    it('GETs /v1/custom-attack/property-names', async () => {
+      mockFetch({ property_names: ['severity', 'category'] });
+      const result = await client.getPropertyNames();
+
+      expect(result.property_names).toEqual(['severity', 'category']);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/custom-attack/property-names');
+    });
+  });
+
+  describe('createPropertyName', () => {
+    it('POSTs to /v1/custom-attack/property-names', async () => {
+      mockFetch({ success: true });
+      const result = await client.createPropertyName({ name: 'severity' });
+
+      expect(result.success).toBe(true);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/custom-attack/property-names');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  describe('getPropertyValues', () => {
+    it('GETs /v1/custom-attack/property-values/:name', async () => {
+      mockFetch({ values: ['HIGH', 'LOW'] });
+      const result = await client.getPropertyValues('severity');
+
+      expect(result.values).toEqual(['HIGH', 'LOW']);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/custom-attack/property-values/severity');
+    });
+  });
+
+  describe('getPropertyValuesMultiple', () => {
+    it('GETs /v1/custom-attack/property-values with query params', async () => {
+      mockFetch({ values: {} });
+      const result = await client.getPropertyValuesMultiple(['severity', 'category']);
+
+      expect(result).toBeDefined();
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/custom-attack/property-values');
+      expect(url).toContain('property_names=severity');
+      expect(url).toContain('property_names=category');
+    });
+  });
+
+  describe('createPropertyValue', () => {
+    it('POSTs to /v1/custom-attack/property-values', async () => {
+      mockFetch({ success: true });
+      const result = await client.createPropertyValue({
+        property_name: 'severity',
+        value: 'CRITICAL',
+      });
+
+      expect(result.success).toBe(true);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/custom-attack/property-values');
+      expect(init.method).toBe('POST');
+    });
+  });
+});

--- a/test/red-team/reports-client.spec.ts
+++ b/test/red-team/reports-client.spec.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RedTeamReportsClient } from '../../src/red-team/reports-client.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+const validUuid2 = '660e8400-e29b-41d4-a716-446655440000';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('RedTeamReportsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: RedTeamReportsClient;
+
+  beforeEach(() => {
+    client = new RedTeamReportsClient({
+      baseUrl: 'https://data.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // -----------------------------------------------------------------------
+  // Static report endpoints
+  // -----------------------------------------------------------------------
+
+  describe('listAttacks', () => {
+    it('GETs /v1/report/static/:jobId/list-attacks', async () => {
+      mockFetch({ attacks: [], total: 0 });
+      const result = await client.listAttacks(validUuid);
+
+      expect(result.attacks).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/static/${validUuid}/list-attacks`);
+    });
+
+    it('passes filter params', async () => {
+      mockFetch({ attacks: [], total: 0 });
+      await client.listAttacks(validUuid, { status: 'FAILED', severity: 'HIGH' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('status=FAILED');
+      expect(url).toContain('severity=HIGH');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.listAttacks('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getAttackDetail', () => {
+    it('GETs /v1/report/static/:jobId/attack/:attackId', async () => {
+      mockFetch({ id: validUuid2, status: 'PASSED' });
+      const result = await client.getAttackDetail(validUuid, validUuid2);
+
+      expect(result.id).toBe(validUuid2);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/static/${validUuid}/attack/${validUuid2}`);
+    });
+
+    it('rejects invalid job UUID', async () => {
+      await expect(client.getAttackDetail('bad', validUuid2)).rejects.toThrow(AISecSDKException);
+    });
+
+    it('rejects invalid attack UUID', async () => {
+      await expect(client.getAttackDetail(validUuid, 'bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getMultiTurnAttackDetail', () => {
+    it('GETs /v1/report/static/:jobId/attack-multi-turn/:attackId', async () => {
+      mockFetch({ id: validUuid2, turns: [] });
+      const result = await client.getMultiTurnAttackDetail(validUuid, validUuid2);
+
+      expect(result.id).toBe(validUuid2);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/static/${validUuid}/attack-multi-turn/${validUuid2}`);
+    });
+
+    it('rejects invalid job UUID', async () => {
+      await expect(client.getMultiTurnAttackDetail('bad', validUuid2)).rejects.toThrow(
+        AISecSDKException,
+      );
+    });
+
+    it('rejects invalid attack UUID', async () => {
+      await expect(client.getMultiTurnAttackDetail(validUuid, 'bad')).rejects.toThrow(
+        AISecSDKException,
+      );
+    });
+  });
+
+  describe('getStaticReport', () => {
+    it('GETs /v1/report/static/:jobId/report', async () => {
+      mockFetch({ job_id: validUuid, score: 85 });
+      const result = await client.getStaticReport(validUuid);
+
+      expect(result.score).toBe(85);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/static/${validUuid}/report`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getStaticReport('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getStaticRemediation', () => {
+    it('GETs /v1/report/static/:jobId/remediation', async () => {
+      mockFetch({ recommendations: [] });
+      const result = await client.getStaticRemediation(validUuid);
+
+      expect(result.recommendations).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/static/${validUuid}/remediation`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getStaticRemediation('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getStaticRuntimePolicy', () => {
+    it('GETs /v1/report/static/:jobId/runtime-policy-config', async () => {
+      mockFetch({ profile: {} });
+      const result = await client.getStaticRuntimePolicy(validUuid);
+
+      expect(result.profile).toEqual({});
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/static/${validUuid}/runtime-policy-config`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getStaticRuntimePolicy('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Dynamic report endpoints
+  // -----------------------------------------------------------------------
+
+  describe('getDynamicReport', () => {
+    it('GETs /v1/report/dynamic/:jobId/report', async () => {
+      mockFetch({ job_id: validUuid, score: 72 });
+      const result = await client.getDynamicReport(validUuid);
+
+      expect(result.score).toBe(72);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/dynamic/${validUuid}/report`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getDynamicReport('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getDynamicRemediation', () => {
+    it('GETs /v1/report/dynamic/:jobId/remediation', async () => {
+      mockFetch({ recommendations: [] });
+      const result = await client.getDynamicRemediation(validUuid);
+
+      expect(result.recommendations).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/dynamic/${validUuid}/remediation`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getDynamicRemediation('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getDynamicRuntimePolicy', () => {
+    it('GETs /v1/report/dynamic/:jobId/runtime-policy-config', async () => {
+      mockFetch({ profile: {} });
+      const result = await client.getDynamicRuntimePolicy(validUuid);
+
+      expect(result.profile).toEqual({});
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/dynamic/${validUuid}/runtime-policy-config`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getDynamicRuntimePolicy('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('listGoals', () => {
+    it('GETs /v1/report/dynamic/:jobId/list-goals', async () => {
+      mockFetch({ goals: [], total: 0 });
+      const result = await client.listGoals(validUuid);
+
+      expect(result.goals).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/dynamic/${validUuid}/list-goals`);
+    });
+
+    it('passes goal_type filter', async () => {
+      mockFetch({ goals: [], total: 0 });
+      await client.listGoals(validUuid, { goal_type: 'JAILBREAK' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('goal_type=JAILBREAK');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.listGoals('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('listGoalStreams', () => {
+    it('GETs /v1/report/dynamic/:jobId/goal/:goalId/list-streams', async () => {
+      mockFetch({ streams: [], total: 0 });
+      const result = await client.listGoalStreams(validUuid, validUuid2);
+
+      expect(result.streams).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/dynamic/${validUuid}/goal/${validUuid2}/list-streams`);
+    });
+
+    it('rejects invalid job UUID', async () => {
+      await expect(client.listGoalStreams('bad', validUuid2)).rejects.toThrow(AISecSDKException);
+    });
+
+    it('rejects invalid goal UUID', async () => {
+      await expect(client.listGoalStreams(validUuid, 'bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Common report endpoints
+  // -----------------------------------------------------------------------
+
+  describe('getStreamDetail', () => {
+    it('GETs /v1/report/dynamic/stream/:streamId', async () => {
+      mockFetch({ id: validUuid, messages: [] });
+      const result = await client.getStreamDetail(validUuid);
+
+      expect(result.id).toBe(validUuid);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/dynamic/stream/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getStreamDetail('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('downloadReport', () => {
+    it('GETs /v1/report/:jobId/download', async () => {
+      mockFetch({ url: 'https://download.example.com/report.pdf' });
+      const result = await client.downloadReport(validUuid);
+
+      expect(result).toBeDefined();
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/${validUuid}/download`);
+    });
+
+    it('passes format param', async () => {
+      mockFetch({ url: 'https://download.example.com/report.csv' });
+      await client.downloadReport(validUuid, 'csv');
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('file_format=csv');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.downloadReport('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('generatePartialReport', () => {
+    it('POSTs to /v1/report/:jobId/generate-partial-report', async () => {
+      mockFetch({ status: 'GENERATING' });
+      const result = await client.generatePartialReport(validUuid);
+
+      expect(result).toBeDefined();
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/report/${validUuid}/generate-partial-report`);
+      expect(init.method).toBe('POST');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.generatePartialReport('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+});

--- a/test/red-team/scans-client.spec.ts
+++ b/test/red-team/scans-client.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RedTeamScansClient } from '../../src/red-team/scans-client.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('RedTeamScansClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: RedTeamScansClient;
+
+  beforeEach(() => {
+    client = new RedTeamScansClient({
+      baseUrl: 'https://data.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // -----------------------------------------------------------------------
+  // create
+  // -----------------------------------------------------------------------
+  describe('create', () => {
+    it('POSTs to /v1/scan', async () => {
+      const job = { id: validUuid, status: 'PENDING' };
+      mockFetch(job, 201);
+      const result = await client.create({ target_id: validUuid, job_type: 'STATIC' });
+
+      expect(result.id).toBe(validUuid);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://data.example.com/v1/scan');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // list
+  // -----------------------------------------------------------------------
+  describe('list', () => {
+    it('GETs /v1/scan', async () => {
+      mockFetch({ jobs: [], total: 0 });
+      const result = await client.list();
+
+      expect(result.jobs).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/scan');
+    });
+
+    it('passes pagination params', async () => {
+      mockFetch({ jobs: [], total: 0 });
+      await client.list({ skip: 10, limit: 5 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('skip=10');
+      expect(url).toContain('limit=5');
+    });
+
+    it('passes filter params', async () => {
+      mockFetch({ jobs: [], total: 0 });
+      await client.list({ status: 'COMPLETED', job_type: 'STATIC', target_id: validUuid });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('status=COMPLETED');
+      expect(url).toContain('job_type=STATIC');
+      expect(url).toContain(`target_id=${validUuid}`);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // get
+  // -----------------------------------------------------------------------
+  describe('get', () => {
+    it('GETs /v1/scan/:jobId', async () => {
+      const job = { id: validUuid, status: 'COMPLETED' };
+      mockFetch(job);
+      const result = await client.get(validUuid);
+
+      expect(result.id).toBe(validUuid);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/scan/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.get('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // abort
+  // -----------------------------------------------------------------------
+  describe('abort', () => {
+    it('POSTs to /v1/scan/:jobId/abort', async () => {
+      const resp = { id: validUuid, status: 'ABORTED' };
+      mockFetch(resp);
+      const result = await client.abort(validUuid);
+
+      expect(result.status).toBe('ABORTED');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/scan/${validUuid}/abort`);
+      expect(init.method).toBe('POST');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.abort('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getCategories
+  // -----------------------------------------------------------------------
+  describe('getCategories', () => {
+    it('GETs /v1/categories', async () => {
+      const categories = [{ name: 'Jailbreak', subcategories: [] }];
+      mockFetch(categories);
+      const result = await client.getCategories();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Jailbreak');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/categories');
+    });
+  });
+});

--- a/test/red-team/targets-client.spec.ts
+++ b/test/red-team/targets-client.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RedTeamTargetsClient } from '../../src/red-team/targets-client.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('RedTeamTargetsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: RedTeamTargetsClient;
+
+  beforeEach(() => {
+    client = new RedTeamTargetsClient({
+      baseUrl: 'https://mgmt.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // -----------------------------------------------------------------------
+  // create
+  // -----------------------------------------------------------------------
+  describe('create', () => {
+    it('POSTs to /v1/target', async () => {
+      const target = { id: validUuid, name: 'test-target' };
+      mockFetch(target, 201);
+      const result = await client.create({ name: 'test-target', target_type: 'API' });
+
+      expect(result.id).toBe(validUuid);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://mgmt.example.com/v1/target');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // list
+  // -----------------------------------------------------------------------
+  describe('list', () => {
+    it('GETs /v1/target', async () => {
+      mockFetch({ targets: [], total: 0 });
+      const result = await client.list();
+
+      expect(result.targets).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/target');
+    });
+
+    it('passes filter params', async () => {
+      mockFetch({ targets: [], total: 0 });
+      await client.list({ target_type: 'API', status: 'ACTIVE', active: true });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('target_type=API');
+      expect(url).toContain('status=ACTIVE');
+      expect(url).toContain('active=true');
+    });
+
+    it('passes pagination params', async () => {
+      mockFetch({ targets: [], total: 0 });
+      await client.list({ skip: 5, limit: 10 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('skip=5');
+      expect(url).toContain('limit=10');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // get
+  // -----------------------------------------------------------------------
+  describe('get', () => {
+    it('GETs /v1/target/:uuid', async () => {
+      const target = { id: validUuid, name: 'test-target' };
+      mockFetch(target);
+      const result = await client.get(validUuid);
+
+      expect(result.id).toBe(validUuid);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/target/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.get('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // update
+  // -----------------------------------------------------------------------
+  describe('update', () => {
+    it('PUTs to /v1/target/:uuid', async () => {
+      const target = { id: validUuid, name: 'updated' };
+      mockFetch(target);
+      const result = await client.update(validUuid, { name: 'updated' });
+
+      expect(result.name).toBe('updated');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/target/${validUuid}`);
+      expect(init.method).toBe('PUT');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.update('bad', { name: 'x' })).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // delete
+  // -----------------------------------------------------------------------
+  describe('delete', () => {
+    it('DELETEs /v1/target/:uuid', async () => {
+      mockFetch({ success: true });
+      const result = await client.delete(validUuid);
+
+      expect(result.success).toBe(true);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/target/${validUuid}`);
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.delete('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // probe
+  // -----------------------------------------------------------------------
+  describe('probe', () => {
+    it('POSTs to /v1/target/probe', async () => {
+      const target = { id: validUuid, status: 'PROBING' };
+      mockFetch(target);
+      const result = await client.probe({ target_id: validUuid });
+
+      expect(result.status).toBe('PROBING');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/target/probe');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getProfile
+  // -----------------------------------------------------------------------
+  describe('getProfile', () => {
+    it('GETs /v1/target/:uuid/profile', async () => {
+      mockFetch({ target_id: validUuid, background: 'test' });
+      const result = await client.getProfile(validUuid);
+
+      expect(result.target_id).toBe(validUuid);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/target/${validUuid}/profile`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getProfile('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // updateProfile
+  // -----------------------------------------------------------------------
+  describe('updateProfile', () => {
+    it('PUTs to /v1/target/:uuid/profile', async () => {
+      mockFetch({ target_id: validUuid, background: 'updated' });
+      const result = await client.updateProfile(validUuid, { background: 'updated' });
+
+      expect(result.background).toBe('updated');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`/v1/target/${validUuid}/profile`);
+      expect(init.method).toBe('PUT');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.updateProfile('bad', { background: 'x' })).rejects.toThrow(
+        AISecSDKException,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `RedTeamClient` with 5 sub-clients covering 60+ API endpoints (scans, reports, custom attack reports, targets, custom attacks)
- Add 30 typed enum const objects and ~80 Zod schemas for full Red Team API model coverage
- Add 263 new tests (598 total), 99%+ statement coverage

## Sub-clients
- **Scans**: create, list, get, abort, getCategories
- **Reports**: static/dynamic reports, attacks, remediation, runtime policy, goals, streams
- **Custom Attack Reports**: report, prompt sets, prompt details, attack outputs, property stats
- **Targets**: CRUD, probe, profile management
- **Custom Attacks**: prompt set/prompt CRUD, property name/value management

## Test plan
- [x] 598 tests pass (263 new)
- [x] Typecheck, lint, format all pass
- [x] 99%+ statement coverage
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)