### PR TITLE
Add e2e example scripts for Model Security and Red Team

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,17 @@ PANW_MGMT_CLIENT_SECRET=
 PANW_MGMT_TSG_ID=
 # PANW_MGMT_ENDPOINT=https://api.sase.paloaltonetworks.com/aisec
 # PANW_MGMT_TOKEN_ENDPOINT=https://auth.apps.paloaltonetworks.com/oauth2/access_token
+
+# ── Model Security API (falls back to PANW_MGMT_* vars above) ──────
+# PANW_MODEL_SEC_CLIENT_ID=
+# PANW_MODEL_SEC_CLIENT_SECRET=
+# PANW_MODEL_SEC_TSG_ID=
+# PANW_MODEL_SEC_DATA_ENDPOINT=https://api.sase.paloaltonetworks.com/aims/data
+# PANW_MODEL_SEC_MGMT_ENDPOINT=https://api.sase.paloaltonetworks.com/aims/mgmt
+
+# ── Red Team API (falls back to PANW_MGMT_* vars above) ────────────
+# PANW_RED_TEAM_CLIENT_ID=
+# PANW_RED_TEAM_CLIENT_SECRET=
+# PANW_RED_TEAM_TSG_ID=
+# PANW_RED_TEAM_DATA_ENDPOINT=https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane
+# PANW_RED_TEAM_MGMT_ENDPOINT=https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane

--- a/examples/model-security-scans.ts
+++ b/examples/model-security-scans.ts
@@ -1,0 +1,67 @@
+import { ModelSecurityClient, AISecSDKException } from '@cdot65/prisma-airs-sdk';
+
+async function main() {
+  // Uses PANW_MGMT_* env vars as fallback for auth
+  const client = new ModelSecurityClient();
+
+  try {
+    // --- LIST SCANS ---
+    console.log('Listing model security scans...');
+    const scans = await client.scans.list({ limit: 5 });
+    console.log(`Found ${scans.pagination?.total_items ?? 0} total scans:`);
+    for (const scan of scans.scans) {
+      console.log(`  - ${scan.uuid}: ${scan.name ?? 'unnamed'} [${scan.eval_outcome}]`);
+    }
+
+    // --- GET SCAN DETAILS ---
+    if (scans.scans.length) {
+      const scanId = scans.scans[0].uuid;
+      console.log(`\nGetting scan details for ${scanId}...`);
+      const detail = await client.scans.get(scanId);
+      console.log('  Name:', detail.name);
+      console.log('  Outcome:', detail.eval_outcome);
+      console.log('  Created:', detail.created_at);
+
+      // --- LIST EVALUATIONS ---
+      console.log(`\nListing evaluations for scan ${scanId}...`);
+      const evals = await client.scans.getEvaluations(scanId);
+      console.log(`  Found ${evals.pagination?.total_items ?? 0} evaluations`);
+      for (const ev of evals.evaluations) {
+        console.log(`    - ${ev.uuid}: ${ev.rule_name} [${ev.result}]`);
+      }
+
+      // --- LIST FILES ---
+      console.log(`\nListing files for scan ${scanId}...`);
+      const files = await client.scans.getFiles(scanId);
+      console.log(`  Found ${files.pagination?.total_items ?? 0} files`);
+      for (const f of files.files) {
+        console.log(`    - ${f.path} [${f.type}]`);
+      }
+    }
+
+    // --- LIST SECURITY GROUPS ---
+    console.log('\nListing security groups...');
+    const groups = await client.securityGroups.list();
+    console.log(`Found ${groups.pagination?.total_items ?? 0} security groups:`);
+    for (const g of groups.security_groups) {
+      console.log(`  - ${g.uuid}: ${g.name} [${g.state}]`);
+    }
+
+    // --- LIST SECURITY RULES ---
+    console.log('\nListing security rules...');
+    const rules = await client.securityRules.list();
+    console.log(`Found ${rules.pagination?.total_items ?? 0} security rules:`);
+    for (const r of rules.rules) {
+      console.log(`  - ${r.uuid}: ${r.name} [${r.type}]`);
+    }
+  } catch (error) {
+    if (error instanceof AISecSDKException) {
+      console.error('Error:', error.message);
+      console.error('Type:', error.errorType);
+    } else {
+      throw error;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/red-team-scans.ts
+++ b/examples/red-team-scans.ts
@@ -1,0 +1,68 @@
+import { RedTeamClient, AISecSDKException } from '@cdot65/prisma-airs-sdk';
+
+async function main() {
+  // Uses PANW_MGMT_* env vars as fallback for auth
+  const client = new RedTeamClient();
+
+  try {
+    // --- LIST SCANS ---
+    console.log('Listing red team scans...');
+    const scans = await client.scans.list({ limit: 5 });
+    console.log(`Found ${scans.pagination?.total_items ?? 0} total scans:`);
+    for (const job of scans.data ?? []) {
+      console.log(`  - ${job.uuid}: ${job.name ?? 'unnamed'} [${job.status}] (${job.job_type})`);
+    }
+
+    // --- GET SCAN DETAILS ---
+    if (scans.data?.length) {
+      const jobId = scans.data[0].uuid;
+      console.log(`\nGetting scan details for ${jobId}...`);
+      const detail = await client.scans.get(jobId);
+      console.log('  Name:', detail.name);
+      console.log('  Status:', detail.status);
+      console.log('  Type:', detail.job_type);
+    }
+
+    // --- LIST CATEGORIES ---
+    console.log('\nListing attack categories...');
+    const categories = await client.scans.getCategories();
+    for (const cat of categories) {
+      console.log(`  - ${cat.display_name}: ${cat.sub_categories?.length ?? 0} subcategories`);
+    }
+
+    // --- LIST TARGETS ---
+    console.log('\nListing targets...');
+    const targets = await client.targets.list({ limit: 5 });
+    console.log(`Found ${targets.pagination?.total_items ?? 0} total targets:`);
+    for (const t of targets.data ?? []) {
+      console.log(`  - ${t.uuid}: ${t.name} [${t.status}] (${t.target_type})`);
+    }
+
+    // --- QUOTA (may require additional permissions) ---
+    try {
+      console.log('\nChecking quota...');
+      const quota = await client.getQuota();
+      console.log('  Quota:', JSON.stringify(quota, null, 2));
+    } catch {
+      console.log('  Quota not available (may require elevated permissions)');
+    }
+
+    // --- DASHBOARD (may require additional permissions) ---
+    try {
+      console.log('\nGetting scan statistics...');
+      const stats = await client.getScanStatistics();
+      console.log('  Stats:', JSON.stringify(stats, null, 2));
+    } catch {
+      console.log('  Statistics not available (may require elevated permissions)');
+    }
+  } catch (error) {
+    if (error instanceof AISecSDKException) {
+      console.error('Error:', error.message);
+      console.error('Type:', error.errorType);
+    } else {
+      throw error;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/red-team-targets.ts
+++ b/examples/red-team-targets.ts
@@ -1,0 +1,62 @@
+import { RedTeamClient, AISecSDKException } from '@cdot65/prisma-airs-sdk';
+
+async function main() {
+  // Uses PANW_MGMT_* env vars as fallback for auth
+  const client = new RedTeamClient();
+
+  try {
+    // --- LIST TARGETS ---
+    console.log('Listing targets...');
+    const targets = await client.targets.list({ limit: 10 });
+    console.log(`Found ${targets.pagination?.total_items ?? 0} targets:`);
+    for (const t of targets.data ?? []) {
+      console.log(
+        `  - ${t.uuid}: ${t.name} [${t.status}] (${t.target_type}, ${t.connection_type})`,
+      );
+    }
+
+    // --- GET TARGET DETAILS ---
+    const first = targets.data?.[0];
+    if (first) {
+      console.log(`\nGetting target details for ${first.uuid}...`);
+      const detail = await client.targets.get(first.uuid);
+      console.log('  Name:', detail.name);
+      console.log('  Type:', detail.target_type);
+      console.log('  Connection:', detail.connection_type);
+      console.log('  Endpoint:', detail.api_endpoint_type);
+      console.log('  Response mode:', detail.response_mode);
+      console.log('  Status:', detail.status);
+      console.log('  Active:', detail.active);
+      console.log('  Validated:', detail.validated);
+      console.log('  Created:', detail.created_at);
+
+      // --- GET TARGET PROFILE ---
+      console.log(`\nGetting target profile for ${first.uuid}...`);
+      try {
+        const profile = await client.targets.getProfile(first.uuid);
+        console.log('  Profile:', JSON.stringify(profile, null, 2));
+      } catch (e) {
+        if (e instanceof AISecSDKException) {
+          console.log('  Profile not available:', e.message);
+        }
+      }
+    }
+
+    // --- LIST CUSTOM PROMPT SETS ---
+    console.log('\nListing custom prompt sets...');
+    const promptSets = await client.customAttacks.listPromptSets();
+    console.log(`Found ${promptSets.pagination?.total_items ?? 0} prompt sets:`);
+    for (const ps of promptSets.data ?? []) {
+      console.log(`  - ${ps.uuid}: ${ps.name}`);
+    }
+  } catch (error) {
+    if (error instanceof AISecSDKException) {
+      console.error('Error:', error.message);
+      console.error('Type:', error.errorType);
+    } else {
+      throw error;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "example:query": "npx tsx --env-file=.env examples/query-results.ts",
     "example:mgmt-auth": "npx tsx --env-file=.env examples/mgmt-auth.ts",
     "example:mgmt-profiles": "npx tsx --env-file=.env examples/mgmt-profiles.ts",
-    "example:mgmt-topics": "npx tsx --env-file=.env examples/mgmt-topics.ts"
+    "example:mgmt-topics": "npx tsx --env-file=.env examples/mgmt-topics.ts",
+    "example:model-sec-scans": "npx tsx --env-file=.env examples/model-security-scans.ts",
+    "example:red-team-scans": "npx tsx --env-file=.env examples/red-team-scans.ts",
+    "example:red-team-targets": "npx tsx --env-file=.env examples/red-team-targets.ts"
   },
   "dependencies": {
     "zod": "^3.24.0"


### PR DESCRIPTION
## Summary
- Add 3 example scripts for e2e testing against live APIs
- Update `.env.example` with Model Security + Red Team env vars
- Add npm run scripts for all new examples

## Examples
- `npm run example:model-sec-scans` — lists scans, evaluations, files, security groups, rules
- `npm run example:red-team-scans` — lists scans, categories, targets, dashboard stats
- `npm run example:red-team-targets` — lists targets, gets details/profile, lists custom prompt sets

## Verified
All 3 examples tested against live AIRS APIs and return real data successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)