### PR TITLE
Add OAuth token lifecycle management (v0.5.0)

### DIFF
--- a/.changeset/0004-oauth-token-lifecycle.md
+++ b/.changeset/0004-oauth-token-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Add OAuth token lifecycle management: `isTokenExpired()`, `isTokenExpiringSoon()`, `getTokenInfo()` methods on `OAuthClient`. Configurable pre-expiry buffer via `tokenBufferMs` option. `onTokenRefresh` callback for monitoring. Auto-retry on 403 (expired token) in addition to 401. `OAuthClient`, `OAuthClientOptions`, and `TokenInfo` now exported from public API.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## v0.5.0
+
+### OAuth Token Lifecycle Management
+
+- `OAuthClient` now exported from public API with `TokenInfo` type
+- `isTokenExpired()` — check if the current token has passed its expiry time
+- `isTokenExpiringSoon(bufferMs?)` — check if token is within the pre-expiry buffer
+- `getTokenInfo()` — snapshot of token state (hasToken, isValid, isExpired, isExpiringSoon, expiresInMs, expiresAt)
+- Configurable `tokenBufferMs` option (default 30s) to control pre-expiry refresh window
+- `onTokenRefresh` callback for monitoring/logging token refreshes
+- Auto-retry on 403 responses (in addition to existing 401 handling) for expired token recovery
+
+---
+
 ## v0.4.0
 
 ### Red Team Service

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -98,6 +98,38 @@ class ManagementClient {
 }
 ```
 
+### `OAuthClient`
+
+```ts
+interface TokenInfo {
+  hasToken: boolean; // whether a token has been fetched
+  isValid: boolean; // not expired and outside the buffer window
+  isExpired: boolean; // past expiry time
+  isExpiringSoon: boolean; // within the pre-expiry buffer
+  expiresInMs: number; // ms until expiry (0 if expired/no token)
+  expiresAt: number; // Unix timestamp in ms (0 if no token)
+}
+
+interface OAuthClientOptions {
+  clientId: string;
+  clientSecret: string;
+  tsgId: string;
+  tokenEndpoint?: string; // default: Palo Alto Networks auth endpoint
+  tokenBufferMs?: number; // pre-expiry refresh buffer (default: 30000)
+  onTokenRefresh?: (info: TokenInfo) => void; // callback on each refresh
+}
+
+class OAuthClient {
+  constructor(opts: OAuthClientOptions);
+  readonly tokenEndpoint: string;
+  getToken(): Promise<string>; // auto-refreshes if expired/expiring
+  clearToken(): void; // force re-fetch on next call
+  isTokenExpired(): boolean; // true if no token or past expiry
+  isTokenExpiringSoon(bufferMs?: number): boolean; // true if within buffer
+  getTokenInfo(): TokenInfo; // snapshot without exposing token value
+}
+```
+
 ### `ProfilesClient`
 
 ```ts

--- a/docs/reference/error-handling.md
+++ b/docs/reference/error-handling.md
@@ -50,4 +50,4 @@ The SDK automatically retries on transient errors:
 - **Status codes**: 500, 502, 503, 504
 - **Backoff**: Exponential (`2^attempt * 1000ms`)
 - **Max retries**: Configurable 0-5, default 5
-- **401 handling**: Management/Model Security/Red Team clients automatically refresh the OAuth token and retry once
+- **401/403 handling**: Management/Model Security/Red Team clients automatically refresh the OAuth token and retry once on 401 or 403 responses

--- a/docs/services/management-api.md
+++ b/docs/services/management-api.md
@@ -68,7 +68,36 @@ const client = new ManagementClient({
 });
 ```
 
-Token fetch, caching, and refresh are handled automatically. If a request gets a 401, the client refreshes the token and retries once.
+Token fetch, caching, and refresh are handled automatically. If a request gets a 401 or 403, the client refreshes the token and retries once.
+
+### Token Lifecycle
+
+The SDK provides fine-grained control over OAuth token state via `OAuthClient`:
+
+```ts
+import { OAuthClient } from '@cdot65/prisma-airs-sdk';
+
+const oauth = new OAuthClient({
+  clientId: 'your-client-id',
+  clientSecret: 'your-client-secret',
+  tsgId: '1234567890',
+  tokenBufferMs: 60_000, // refresh 60s before expiry (default: 30s)
+  onTokenRefresh: (info) => {
+    console.log(`Token refreshed, expires in ${info.expiresInMs}ms`);
+  },
+});
+
+// Check token state without triggering a refresh
+const info = oauth.getTokenInfo();
+// { hasToken, isValid, isExpired, isExpiringSoon, expiresInMs, expiresAt }
+
+// Individual checks
+oauth.isTokenExpired(); // true if past expiry time
+oauth.isTokenExpiringSoon(); // true if within buffer window
+oauth.isTokenExpiringSoon(120_000); // custom buffer override (2 min)
+```
+
+The `ManagementClient` handles this internally — you only need `OAuthClient` directly for advanced monitoring or custom auth workflows.
 
 ## Security Profiles
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TypeScript SDK for Palo Alto Networks AI Runtime Security",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.4.0';
+export const SDK_VERSION = '0.5.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/management/index.ts
+++ b/src/management/index.ts
@@ -1,3 +1,4 @@
 export { ManagementClient, type ManagementClientOptions } from './client.js';
+export { OAuthClient, type OAuthClientOptions, type TokenInfo } from './oauth-client.js';
 export { ProfilesClient, type PaginationOptions } from './profiles.js';
 export { TopicsClient } from './topics.js';

--- a/src/management/management-http-client.ts
+++ b/src/management/management-http-client.ts
@@ -52,7 +52,7 @@ export async function managementHttpRequest<T>(
       return fetch(url.toString(), { method, headers, body: bodyStr });
     },
     onRetryableFailure: async (response) => {
-      if (response.status === 401 && !hadTokenRefresh) {
+      if ((response.status === 401 || response.status === 403) && !hadTokenRefresh) {
         hadTokenRefresh = true;
         oauthClient.clearToken();
         return true;

--- a/src/management/oauth-client.ts
+++ b/src/management/oauth-client.ts
@@ -2,6 +2,22 @@ import { DEFAULT_TOKEN_ENDPOINT } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { OAuthTokenResponseSchema } from '../models/oauth-token.js';
 
+/** Snapshot of the current token state (never exposes the actual token). */
+export interface TokenInfo {
+  /** Whether a token has been fetched. */
+  hasToken: boolean;
+  /** Whether the token is valid (not expired and outside the pre-expiry buffer). */
+  isValid: boolean;
+  /** Whether the token has passed its expiry time. */
+  isExpired: boolean;
+  /** Whether the token is within the pre-expiry buffer window. */
+  isExpiringSoon: boolean;
+  /** Milliseconds until the token expires (0 if expired or no token). */
+  expiresInMs: number;
+  /** Unix timestamp (ms) when the token expires (0 if no token). */
+  expiresAt: number;
+}
+
 /** Options for constructing an {@link OAuthClient}. */
 export interface OAuthClientOptions {
   /** OAuth2 client ID. */
@@ -12,9 +28,13 @@ export interface OAuthClientOptions {
   tsgId: string;
   /** OAuth2 token endpoint URL. Defaults to Palo Alto Networks auth endpoint. */
   tokenEndpoint?: string;
+  /** Pre-expiry buffer in ms. Token refreshes this many ms before expiry. Defaults to 30000 (30s). */
+  tokenBufferMs?: number;
+  /** Callback invoked after each successful token refresh with current {@link TokenInfo}. */
+  onTokenRefresh?: (info: TokenInfo) => void;
 }
 
-const TOKEN_BUFFER_MS = 30_000; // refresh 30s before expiry
+const DEFAULT_TOKEN_BUFFER_MS = 30_000; // refresh 30s before expiry
 
 /**
  * OAuth2 client_credentials token manager.
@@ -25,6 +45,8 @@ export class OAuthClient {
   private readonly clientId: string;
   private readonly clientSecret: string;
   private readonly tsgId: string;
+  private readonly tokenBufferMs: number;
+  private readonly onTokenRefresh?: (info: TokenInfo) => void;
 
   private accessToken: string | null = null;
   private expiresAt = 0;
@@ -35,6 +57,8 @@ export class OAuthClient {
     this.clientSecret = opts.clientSecret;
     this.tsgId = opts.tsgId;
     this.tokenEndpoint = opts.tokenEndpoint ?? DEFAULT_TOKEN_ENDPOINT;
+    this.tokenBufferMs = opts.tokenBufferMs ?? DEFAULT_TOKEN_BUFFER_MS;
+    this.onTokenRefresh = opts.onTokenRefresh;
   }
 
   /**
@@ -42,7 +66,7 @@ export class OAuthClient {
    * @returns Bearer access token string.
    */
   async getToken(): Promise<string> {
-    if (this.accessToken && Date.now() < this.expiresAt - TOKEN_BUFFER_MS) {
+    if (this.accessToken && Date.now() < this.expiresAt - this.tokenBufferMs) {
       return this.accessToken;
     }
 
@@ -61,6 +85,43 @@ export class OAuthClient {
   clearToken(): void {
     this.accessToken = null;
     this.expiresAt = 0;
+  }
+
+  /** Check if the current token has passed its expiry time. Returns true if no token exists. */
+  isTokenExpired(): boolean {
+    if (!this.accessToken) return true;
+    return Date.now() >= this.expiresAt;
+  }
+
+  /**
+   * Check if the token is within the pre-expiry buffer window.
+   * Returns true if no token exists.
+   * @param bufferMs - Custom buffer in ms. Defaults to the configured `tokenBufferMs`.
+   */
+  isTokenExpiringSoon(bufferMs?: number): boolean {
+    if (!this.accessToken) return true;
+    const buffer = bufferMs ?? this.tokenBufferMs;
+    return Date.now() >= this.expiresAt - buffer;
+  }
+
+  /**
+   * Get a snapshot of the current token state without exposing the actual token value.
+   * @returns Current {@link TokenInfo}.
+   */
+  getTokenInfo(): TokenInfo {
+    const now = Date.now();
+    const hasToken = this.accessToken !== null;
+    const isExpired = !hasToken || now >= this.expiresAt;
+    const isExpiringSoon = !hasToken || now >= this.expiresAt - this.tokenBufferMs;
+    const expiresInMs = hasToken ? Math.max(0, this.expiresAt - now) : 0;
+    return {
+      hasToken,
+      isValid: hasToken && !isExpiringSoon,
+      isExpired,
+      isExpiringSoon,
+      expiresInMs,
+      expiresAt: hasToken ? this.expiresAt : 0,
+    };
   }
 
   private async fetchToken(): Promise<string> {
@@ -104,6 +165,15 @@ export class OAuthClient {
     const data = OAuthTokenResponseSchema.parse(await response.json());
     this.accessToken = data.access_token;
     this.expiresAt = Date.now() + data.expires_in * 1000;
+
+    if (this.onTokenRefresh) {
+      try {
+        this.onTokenRefresh(this.getTokenInfo());
+      } catch {
+        // Don't let callback errors block token delivery
+      }
+    }
+
     return this.accessToken;
   }
 }

--- a/test/management/management-http-client.spec.ts
+++ b/test/management/management-http-client.spec.ts
@@ -308,4 +308,62 @@ describe('managementHttpRequest', () => {
       }),
     ).rejects.toThrow(/fallback msg/);
   });
+
+  it('refreshes token on 403 and retries once', async () => {
+    const oauth = createMockOAuth('old-token');
+    (oauth.getToken as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce('old-token')
+      .mockResolvedValueOnce('new-token');
+
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve(JSON.stringify({ message: 'forbidden' })),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify({ ok: true })),
+      });
+    globalThis.fetch = fetchSpy;
+
+    const result = await managementHttpRequest({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/test',
+      oauthClient: oauth,
+      numRetries: 0,
+    });
+
+    expect(result.data).toEqual({ ok: true });
+    expect(oauth.clearToken).toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry 403 twice', async () => {
+    const oauth = createMockOAuth('old-token');
+    (oauth.getToken as ReturnType<typeof vi.fn>).mockResolvedValue('same-bad-token');
+
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve(JSON.stringify({ message: 'forbidden' })),
+    });
+    globalThis.fetch = fetchSpy;
+
+    await expect(
+      managementHttpRequest({
+        method: 'GET',
+        baseUrl: 'https://api.example.com',
+        path: '/v1/test',
+        oauthClient: oauth,
+        numRetries: 0,
+      }),
+    ).rejects.toThrow(/forbidden/);
+
+    // 1 initial + 1 retry after 403 = 2 calls, then fails
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/test/management/oauth-client.spec.ts
+++ b/test/management/oauth-client.spec.ts
@@ -186,4 +186,190 @@ describe('OAuthClient', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('tokenBufferMs option', () => {
+    it('uses default 30s buffer', async () => {
+      mockFetchToken('tok', 31); // expires in 31s
+      const client = new OAuthClient(opts);
+      await client.getToken();
+
+      // within default 30s buffer → should re-fetch
+      const info = client.getTokenInfo();
+      // 31s token, 30s buffer → valid for ~1s
+      expect(info.isValid).toBe(true);
+    });
+
+    it('accepts custom buffer', async () => {
+      mockFetchToken('tok', 120); // 120s token
+      const client = new OAuthClient({ ...opts, tokenBufferMs: 60_000 }); // 60s buffer
+      await client.getToken();
+
+      const info = client.getTokenInfo();
+      expect(info.isValid).toBe(true);
+    });
+
+    it('custom buffer triggers earlier refresh', async () => {
+      // Token that lasts 45s, buffer of 60s → should be "expiring soon"
+      mockFetchToken('tok', 45);
+      const client = new OAuthClient({ ...opts, tokenBufferMs: 60_000 });
+      await client.getToken();
+
+      // Token will be within 60s buffer → getToken should re-fetch
+      expect(client.isTokenExpiringSoon()).toBe(true);
+    });
+  });
+
+  describe('isTokenExpired', () => {
+    it('returns true when no token fetched', () => {
+      const client = new OAuthClient(opts);
+      expect(client.isTokenExpired()).toBe(true);
+    });
+
+    it('returns false for valid token', async () => {
+      mockFetchToken('tok', 3600);
+      const client = new OAuthClient(opts);
+      await client.getToken();
+
+      expect(client.isTokenExpired()).toBe(false);
+    });
+
+    it('returns true for expired token (expires_in=0)', async () => {
+      mockFetchToken('tok', 0);
+      const client = new OAuthClient(opts);
+      await client.getToken();
+
+      expect(client.isTokenExpired()).toBe(true);
+    });
+
+    it('returns true after clearToken', async () => {
+      mockFetchToken('tok', 3600);
+      const client = new OAuthClient(opts);
+      await client.getToken();
+      client.clearToken();
+
+      expect(client.isTokenExpired()).toBe(true);
+    });
+  });
+
+  describe('isTokenExpiringSoon', () => {
+    it('returns true when no token', () => {
+      const client = new OAuthClient(opts);
+      expect(client.isTokenExpiringSoon()).toBe(true);
+    });
+
+    it('returns false for token with plenty of time', async () => {
+      mockFetchToken('tok', 3600);
+      const client = new OAuthClient(opts);
+      await client.getToken();
+
+      expect(client.isTokenExpiringSoon()).toBe(false);
+    });
+
+    it('uses configured buffer by default', async () => {
+      mockFetchToken('tok', 25); // 25s, within default 30s buffer
+      const client = new OAuthClient(opts);
+      await client.getToken();
+
+      expect(client.isTokenExpiringSoon()).toBe(true);
+    });
+
+    it('accepts custom buffer override', async () => {
+      mockFetchToken('tok', 3600);
+      const client = new OAuthClient(opts);
+      await client.getToken();
+
+      expect(client.isTokenExpiringSoon(3600_000)).toBe(true); // 1hr buffer
+      expect(client.isTokenExpiringSoon(1000)).toBe(false); // 1s buffer
+    });
+  });
+
+  describe('getTokenInfo', () => {
+    it('returns no-token state before fetch', () => {
+      const client = new OAuthClient(opts);
+      const info = client.getTokenInfo();
+
+      expect(info.hasToken).toBe(false);
+      expect(info.isValid).toBe(false);
+      expect(info.isExpired).toBe(true);
+      expect(info.isExpiringSoon).toBe(true);
+      expect(info.expiresInMs).toBe(0);
+    });
+
+    it('returns valid state after fetch', async () => {
+      mockFetchToken('tok', 3600);
+      const client = new OAuthClient(opts);
+      await client.getToken();
+
+      const info = client.getTokenInfo();
+      expect(info.hasToken).toBe(true);
+      expect(info.isValid).toBe(true);
+      expect(info.isExpired).toBe(false);
+      expect(info.isExpiringSoon).toBe(false);
+      expect(info.expiresInMs).toBeGreaterThan(3500_000); // ~1hr minus processing
+      expect(info.expiresInMs).toBeLessThanOrEqual(3600_000);
+      expect(info.expiresAt).toBeGreaterThan(Date.now());
+    });
+
+    it('returns expired state for expired token', async () => {
+      mockFetchToken('tok', 0);
+      const client = new OAuthClient(opts);
+      await client.getToken();
+
+      const info = client.getTokenInfo();
+      expect(info.hasToken).toBe(true);
+      expect(info.isValid).toBe(false);
+      expect(info.isExpired).toBe(true);
+      expect(info.expiresInMs).toBe(0);
+    });
+  });
+
+  describe('onTokenRefresh callback', () => {
+    it('calls onTokenRefresh after successful fetch', async () => {
+      mockFetchToken('tok', 3600);
+      const onRefresh = vi.fn();
+      const client = new OAuthClient({ ...opts, onTokenRefresh: onRefresh });
+      await client.getToken();
+
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+      const info = onRefresh.mock.calls[0][0];
+      expect(info.expiresInMs).toBeGreaterThan(0);
+      expect(info.hasToken).toBe(true);
+      expect(info.isValid).toBe(true);
+    });
+
+    it('calls onTokenRefresh on each refresh', async () => {
+      const fetchSpy = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ access_token: 'tok1', expires_in: 0 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ access_token: 'tok2', expires_in: 3600 }),
+        });
+      globalThis.fetch = fetchSpy;
+      const onRefresh = vi.fn();
+      const client = new OAuthClient({ ...opts, onTokenRefresh: onRefresh });
+      await client.getToken();
+      await client.getToken(); // triggers refresh because expires_in=0
+
+      expect(onRefresh).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not block getToken if callback throws', async () => {
+      mockFetchToken('tok', 3600);
+      const onRefresh = vi.fn().mockImplementation(() => {
+        throw new Error('callback error');
+      });
+      const client = new OAuthClient({ ...opts, onTokenRefresh: onRefresh });
+
+      // should not throw despite callback error
+      const token = await client.getToken();
+      expect(token).toBe('tok');
+      expect(onRefresh).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Security audit**: 0 vulnerabilities, no CVEs in dependencies
- **OAuth token lifecycle**: `OAuthClient` now exposes `isTokenExpired()`, `isTokenExpiringSoon(bufferMs?)`, and `getTokenInfo()` for proactive token state inspection
- **Configurable buffer**: `tokenBufferMs` option (default 30s) controls pre-expiry refresh window
- **Refresh callback**: `onTokenRefresh` callback for monitoring/logging token refreshes
- **403 auto-retry**: Management HTTP client now handles 403 (in addition to 401) as potential expired token, with automatic refresh and retry
- **Public exports**: `OAuthClient`, `OAuthClientOptions`, `TokenInfo` now part of the public API
- **Version bump**: 0.4.0 → 0.5.0

## Test plan

- [x] 19 new tests covering all new OAuthClient methods and 403 handling
- [x] 617 total tests passing (up from 598)
- [x] 99.28% statement coverage maintained
- [x] Lint, format, typecheck all passing
- [x] Pre-commit hooks pass
- [x] CI matrix (Node 18/20/22) should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)