### PR TITLE
Widen SDK scope in docs and README (v0.5.1)

### DIFF
--- a/.changeset/0005-widen-project-scope-docs.md
+++ b/.changeset/0005-widen-project-scope-docs.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Update README, package description, and docs to reflect full SDK scope across all Prisma AIRS service domains (AI Runtime Security, Model Security, AI Red Teaming, Management CRUD).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-TypeScript SDK for Palo Alto Networks AI Runtime Security (AIRS) API. Mirrors the official Python `pan-aisecurity` SDK. Published as `@cdot65/prisma-airs-sdk` on npm. Zero external HTTP dependencies (native fetch + crypto).
+TypeScript SDK for Palo Alto Networks Prisma AIRS — covers the full lifecycle across all three service domains (AI Runtime Security, Model Security, AI Red Teaming) plus configuration management. Extends beyond the official Python `pan-aisecurity` SDK. Published as `@cdot65/prisma-airs-sdk` on npm. Zero external HTTP dependencies (native fetch + crypto).
 
 ## Commands
 
@@ -34,21 +34,25 @@ npx vitest run -t "test name pattern"
 
 ## Architecture
 
-**Global singleton config** → `init()` must be called before using Scanner. Reads env vars `PANW_AI_SEC_API_KEY`, `PANW_AI_SEC_API_TOKEN`, `PANW_AI_SEC_API_ENDPOINT`.
+**4 service domains**, 2 auth methods:
 
-**Core flow:** `init(opts)` → `Scanner.syncScan(profile, content)` → `httpRequest()` → AIRS API
+- **Scan API** (API Key): `init()` → `Scanner.syncScan()` → AIRS content scanning endpoint
+- **Management API** (OAuth2): `ManagementClient` → profiles/topics CRUD for AIRS config
+- **Model Security API** (OAuth2): `ModelSecurityClient` → model scans, security groups, rules
+- **Red Team API** (OAuth2): `RedTeamClient` → scans, reports, targets, custom attacks
 
 Key modules:
 
-- `src/configuration.ts` — global Configuration singleton, `init()` entry point
-- `src/http-client.ts` — fetch wrapper with exponential backoff retry (500/502/503/504)
-- `src/scan/scanner.ts` — 4 public methods: `syncScan`, `asyncScan`, `queryByScanIds`, `queryByReportIds`
-- `src/scan/content.ts` — Content class with byte-length validation and JSON serialization
+- `src/scan/` — Scanner, Content (API key auth via `init()`)
+- `src/management/` — ManagementClient, OAuthClient, ProfilesClient, TopicsClient
+- `src/model-security/` — ModelSecurityClient + 3 sub-clients (scans, groups, rules)
+- `src/red-team/` — RedTeamClient + 5 sub-clients (scans, reports, customAttackReports, targets, customAttacks)
+- `src/http-retry.ts` — shared exponential backoff retry (used by all HTTP clients)
 - `src/models/` — Zod schemas + inferred TypeScript types for all API models
-- `src/errors.ts` — `AISecSDKException` with `ErrorType` enum (5 types)
+- `src/errors.ts` — `AISecSDKException` with `ErrorType` enum (6 types)
 - `src/constants.ts` — API paths, content limits, batch limits, header names, retry config
 
-**Auth:** Two methods — API key (X-Pan-Token header + HMAC-SHA256 payload hash) or Bearer token.
+**Auth:** API key (HMAC-SHA256) for AIRS scans only. OAuth2 client_credentials for everything else (management CRUD, model security, red teaming).
 
 **Validation strategy:** Content validates at setter time, Scanner validates arguments, Zod validates API responses. Models use `.passthrough()` for forward compat.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prisma-airs-sdk
 
-TypeScript SDK for Palo Alto Networks **AI Runtime Security (AIRS)**. API-compatible with the official [Python `pan-aisecurity` SDK](https://pypi.org/project/pan-aisecurity/).
+TypeScript SDK for Palo Alto Networks **Prisma AIRS** — covering the full lifecycle from configuration management to operational scanning across all three service domains: **AI Runtime Security**, **AI Red Teaming**, and **Model Security**.
 
 ## Installation
 
@@ -8,14 +8,26 @@ TypeScript SDK for Palo Alto Networks **AI Runtime Security (AIRS)**. API-compat
 npm install @cdot65/prisma-airs-sdk
 ```
 
-Requires Node.js 18+.
+Requires Node.js 18+. Zero external HTTP dependencies (native `fetch` + `crypto`).
+
+## What's Included
+
+| Service                 | Client                | Auth    | Capabilities                                               |
+| ----------------------- | --------------------- | ------- | ---------------------------------------------------------- |
+| **AI Runtime Security** | `Scanner`             | API Key | Sync/async content scanning, prompt injection detection    |
+| **Management**          | `ManagementClient`    | OAuth2  | Security profiles and custom topics CRUD                   |
+| **Model Security**      | `ModelSecurityClient` | OAuth2  | ML model scanning, security groups, rule management        |
+| **AI Red Teaming**      | `RedTeamClient`       | OAuth2  | Automated red team scans, reports, targets, custom attacks |
+
+All OAuth2 services share credentials and handle token lifecycle automatically (caching, proactive refresh, 401/403 auto-retry).
 
 ## Quick Start
+
+### AI Runtime Security — Content Scanning (API Key)
 
 ```ts
 import { init, Scanner, Content } from '@cdot65/prisma-airs-sdk';
 
-// Initialize (mirrors Python's aisecurity.init())
 init({ apiKey: 'YOUR_API_KEY' });
 
 const scanner = new Scanner();
@@ -30,20 +42,72 @@ console.log(result.category); // "benign" | "malicious"
 console.log(result.action); // "allow" | "block"
 ```
 
-## Initialization
+### Management — Configuration CRUD (OAuth2)
+
+CRUD operations for all three Prisma AIRS services use OAuth2:
 
 ```ts
-import { init } from '@cdot65/prisma-airs-sdk';
+import { ManagementClient } from '@cdot65/prisma-airs-sdk';
 
-init({
-  apiKey: 'your-api-key', // or set PANW_AI_SEC_API_KEY env var
-  apiToken: 'your-bearer-token', // or set PANW_AI_SEC_API_TOKEN env var
-  apiEndpoint: 'https://...', // optional, defaults to production
-  numRetries: 3, // optional, 0-5, default 5
+const client = new ManagementClient(); // reads PANW_MGMT_* env vars
+
+// Security Profiles
+const profiles = await client.profiles.list();
+const created = await client.profiles.create({
+  profile_name: 'my-profile',
+  active: true,
+  policy: {
+    /* ... */
+  },
+});
+
+// Custom Topics
+const topic = await client.topics.create({
+  topic_name: 'pii-detector',
+  examples: ['SSN: 123-45-6789'],
 });
 ```
 
-At least one of `apiKey` or `apiToken` must be provided (directly or via environment variables).
+### Model Security — ML Model Scanning (OAuth2)
+
+```ts
+import { ModelSecurityClient } from '@cdot65/prisma-airs-sdk';
+
+const client = new ModelSecurityClient(); // falls back to PANW_MGMT_* env vars
+
+const scans = await client.scans.list({ limit: 10 });
+const groups = await client.securityGroups.list();
+const rules = await client.securityRules.list();
+```
+
+### AI Red Teaming — Automated Testing (OAuth2)
+
+```ts
+import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
+
+const client = new RedTeamClient(); // falls back to PANW_MGMT_* env vars
+
+const scans = await client.scans.list({ limit: 5 });
+const targets = await client.targets.list();
+const categories = await client.scans.getCategories();
+```
+
+## Authentication
+
+| Auth Method                     | Used By                                                     |
+| ------------------------------- | ----------------------------------------------------------- |
+| **API Key** (HMAC-SHA256)       | AI Runtime Security scans only                              |
+| **OAuth2** (client_credentials) | Everything else — Management CRUD, Red Team, Model Security |
+
+```bash
+# AI Runtime Security scans
+export PANW_AI_SEC_API_KEY=your-api-key
+
+# OAuth2 (shared by Management, Red Team, Model Security)
+export PANW_MGMT_CLIENT_ID=your-client-id
+export PANW_MGMT_CLIENT_SECRET=your-client-secret
+export PANW_MGMT_TSG_ID=1234567890
+```
 
 ## Scanner Methods
 
@@ -54,66 +118,6 @@ At least one of `apiKey` or `apiToken` must be provided (directly or via environ
 | `queryByScanIds(scanIds)`             | Get results by scan IDs (up to 5)          |
 | `queryByReportIds(reportIds)`         | Get threat reports by report IDs (up to 5) |
 
-### Sync Scan
-
-```ts
-const result = await scanner.syncScan(
-  { profile_name: 'my-profile' },
-  new Content({ prompt: 'user input', response: 'model output' }),
-  {
-    trId: 'transaction-123',
-    sessionId: 'session-456',
-    metadata: { app_name: 'my-app', ai_model: 'gpt-4' },
-  },
-);
-```
-
-### Async Scan
-
-```ts
-const result = await scanner.asyncScan([
-  {
-    req_id: 1,
-    scan_req: {
-      ai_profile: { profile_name: 'my-profile' },
-      contents: [{ prompt: 'hello', response: 'world' }],
-    },
-  },
-]);
-```
-
-### Query Results
-
-```ts
-const results = await scanner.queryByScanIds(['scan-uuid-here']);
-const reports = await scanner.queryByReportIds(['report-id-here']);
-```
-
-## Content Class
-
-```ts
-import { Content } from '@cdot65/prisma-airs-sdk';
-
-const content = new Content({
-  prompt: 'user prompt',
-  response: 'model response',
-  context: 'grounding context',
-  codePrompt: 'code input',
-  codeResponse: 'code output',
-  toolEvent: {
-    metadata: { ecosystem: 'mcp', method: 'invoke', server_name: 'my-server' },
-    input: '{"query": "test"}',
-  },
-});
-
-// Serialize
-const json = content.toJSON();
-
-// Deserialize
-const restored = Content.fromJSON(json);
-const fromFile = Content.fromJSONFile('./content.json');
-```
-
 ## Error Handling
 
 ```ts
@@ -123,65 +127,26 @@ try {
   await scanner.syncScan(profile, content);
 } catch (err) {
   if (err instanceof AISecSDKException) {
-    console.error(err.message); // includes ErrorType prefix
-    console.error(err.errorType); // ErrorType enum value
+    console.error(err.message);
+    console.error(err.errorType);
   }
 }
 ```
 
 Error types: `SERVER_SIDE_ERROR`, `CLIENT_SIDE_ERROR`, `USER_REQUEST_PAYLOAD_ERROR`, `MISSING_VARIABLE`, `AISEC_SDK_ERROR`, `OAUTH_ERROR`.
 
-## Management API
+## Documentation
 
-Separate client for CRUD operations on Security Profiles and Custom Topics via OAuth2 client credentials. See [docs/management-api.md](docs/management-api.md) for full details.
-
-```bash
-# Required env vars (or pass as constructor options)
-export PANW_MGMT_CLIENT_ID=your-client-id
-export PANW_MGMT_CLIENT_SECRET=your-client-secret
-export PANW_MGMT_TSG_ID=1234567890
-# Optional: override for EU/UK/FedRAMP
-# export PANW_MGMT_ENDPOINT=https://api.eu.sase.paloaltonetworks.com/aisec
-```
-
-```ts
-import { ManagementClient } from '@cdot65/prisma-airs-sdk';
-
-const client = new ManagementClient();
-
-// Security Profiles
-const profiles = await client.profiles.list();
-const created = await client.profiles.create({ profile_name: 'my-profile', active: true, policy: { ... } });
-await client.profiles.update(created.profile_id, { ... });
-await client.profiles.delete(created.profile_id);
-
-// Custom Topics
-const topics = await client.topics.list();
-const topic = await client.topics.create({ topic_name: 'pii-detector', examples: ['SSN: 123-45-6789'] });
-await client.topics.update(topic.topic_id, { ... });
-await client.topics.delete(topic.topic_id);
-await client.topics.forceDelete(topic.topic_id); // even if referenced by a profile
-```
-
-## Migration from v0.1
-
-| v0.1                                    | v0.2                                          |
-| --------------------------------------- | --------------------------------------------- |
-| `new PrismaAirsSdkClient({ apiToken })` | `init({ apiKey }); new Scanner()`             |
-| `client.scanSyncRequest(body)`          | `scanner.syncScan(aiProfile, content, opts?)` |
-| `client.scanAsyncRequest(body)`         | `scanner.asyncScan(scanObjects)`              |
-| `client.getScanResultsByScanIds(ids)`   | `scanner.queryByScanIds(ids)`                 |
-| `client.getThreatScanReports(ids)`      | `scanner.queryByReportIds(ids)`               |
-| `PrismaAirsApiError`                    | `AISecSDKException`                           |
-| `axios` dependency                      | Native `fetch` (zero HTTP deps)               |
+Full documentation at **[cdot65.github.io/prisma-airs-sdk](https://cdot65.github.io/prisma-airs-sdk/)** — includes API reference, service guides, OAuth lifecycle docs, and examples.
 
 ## Development
 
 ```bash
 npm install
-npm run build     # tsup (CJS + ESM + .d.ts)
-npm run test      # vitest
-npm run lint      # eslint
+npm run build          # tsup (CJS + ESM + .d.ts)
+npm run test           # vitest (617 tests, 99%+ coverage)
+npm run lint           # eslint
+npm run typecheck      # tsc --noEmit
 ```
 
 ## License

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,10 +19,17 @@ The SDK is ESM-first (`"type": "module"`) with dual exports:
 
 ```ts
 // ESM (recommended)
-import { init, Scanner, Content } from '@cdot65/prisma-airs-sdk';
+import {
+  init,
+  Scanner,
+  Content,
+  ManagementClient,
+  RedTeamClient,
+  ModelSecurityClient,
+} from '@cdot65/prisma-airs-sdk';
 
 // CJS (also supported)
-const { init, Scanner, Content } = require('@cdot65/prisma-airs-sdk');
+const { init, Scanner, Content, ManagementClient } = require('@cdot65/prisma-airs-sdk');
 ```
 
 ## Dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ title: Home
 
 # Prisma AIRS SDK
 
-**TypeScript SDK for Palo Alto Networks AI Runtime Security**
+**TypeScript SDK for Palo Alto Networks Prisma AIRS**
 
 [![CI](https://github.com/cdot65/prisma-airs-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/cdot65/prisma-airs-sdk/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@cdot65/prisma-airs-sdk)](https://www.npmjs.com/package/@cdot65/prisma-airs-sdk)
@@ -98,7 +98,7 @@ flowchart LR
 
   ***
 
-  Run your first content scan in under 5 minutes.
+  Scanning, management, and more in under 5 minutes.
 
   [:octicons-arrow-right-24: Quick Start](getting-started/quick-start.md)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.5.0",
-  "description": "TypeScript SDK for Palo Alto Networks AI Runtime Security",
+  "version": "0.5.1",
+  "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",
   "type": "module",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.5.0';
+export const SDK_VERSION = '0.5.1';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
## Summary

Multiple files described the SDK too narrowly, focusing only on AI Runtime Security scanning. Updated to reflect the full Prisma AIRS scope:

- **README.md**: Complete rewrite — now shows all 4 service domains (scan, management, model security, red team) with auth model table, examples for each service, and link to docs site
- **package.json**: Description updated from "AI Runtime Security" to cover all APIs
- **CLAUDE.md**: Overview and Architecture sections now describe all 4 domains, auth split, and module layout
- **docs/index.md**: Hero subtitle widened to "Prisma AIRS" instead of just "AI Runtime Security"
- **docs/getting-started/installation.md**: Import examples now show all clients
- **Version**: 0.5.0 → 0.5.1 (hotfix for npm package metadata + README)

### Files changed

| File | What changed |
|---|---|
| `README.md` | Full rewrite — service table, multi-service quick start, auth section |
| `package.json` | `description` + version bump |
| `src/constants.ts` | `SDK_VERSION` bump |
| `CLAUDE.md` | Overview + Architecture sections |
| `docs/index.md` | Hero subtitle |
| `docs/getting-started/installation.md` | Import examples |

## Test plan

- [x] 617 tests pass
- [x] Lint, format, typecheck clean
- [x] No code changes — docs/metadata only + version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)