### PR TITLE
Add README badges, bump v0.5.2

### DIFF
--- a/.changeset/0006-readme-badges.md
+++ b/.changeset/0006-readme-badges.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Add CI, tests, npm version, downloads, coverage, TypeScript, Node, and license badges to README for code quality visibility on npm.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # prisma-airs-sdk
 
+[![CI](https://github.com/cdot65/prisma-airs-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/cdot65/prisma-airs-sdk/actions/workflows/ci.yml)
+[![Tests](https://github.com/cdot65/prisma-airs-sdk/actions/workflows/test.yml/badge.svg)](https://github.com/cdot65/prisma-airs-sdk/actions/workflows/test.yml)
+[![npm version](https://img.shields.io/npm/v/@cdot65/prisma-airs-sdk)](https://www.npmjs.com/package/@cdot65/prisma-airs-sdk)
+[![npm downloads](https://img.shields.io/npm/dm/@cdot65/prisma-airs-sdk)](https://www.npmjs.com/package/@cdot65/prisma-airs-sdk)
+[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen)](https://github.com/cdot65/prisma-airs-sdk)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178c6)](https://www.typescriptlang.org/)
+[![Node 18+](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
 TypeScript SDK for Palo Alto Networks **Prisma AIRS** — covering the full lifecycle from configuration management to operational scanning across all three service domains: **AI Runtime Security**, **AI Red Teaming**, and **Model Security**.
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.5.1';
+export const SDK_VERSION = '0.5.2';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
## Summary
- Add 8 badges to README: CI, Tests, npm version, npm downloads, coverage, TypeScript, Node 18+, License
- Bump version 0.5.1 → 0.5.2 so badges appear on npm

## Test plan
- [x] All 617 tests pass
- [x] Lint/format/typecheck pass
- [ ] Verify badges render on GitHub PR description
- [ ] Verify npm page shows badges after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)