### PR TITLE
Red Team mgmt: typed schemas, validate param, CSV upload

### DIFF
--- a/.changeset/0007-red-team-mgmt-typed-schemas.md
+++ b/.changeset/0007-red-team-mgmt-typed-schemas.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Add typed Zod schemas for Red Team management API: multi-turn configs (stateful/stateless), provider-specific connection params (OpenAI, HuggingFace, Databricks, Bedrock), REST/Streaming connection params, typed TargetBackground/AdditionalContext/Metadata fields. Add `validate` query param to targets.create() and targets.update(). Add customAttacks.uploadPromptsCsv() for CSV prompt uploads. Fix CustomPromptSetVersionInfo.stats to use typed PromptSetStatsSchema.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v0.6.0
+
+### Red Team Management — Typed Schemas & New Methods
+
+- **Typed connection schemas**: `MultiTurnStatefulConfig`, `MultiTurnStatelessConfig`, `OpenAIConnectionParams`, `HuggingfaceConnectionParams`, `DatabricksConnectionParams`, `BedrockAccessConnectionParams`, `RestConnectionParams`, `StreamingConnectionParams`, `ConnectionParams` (union)
+- **Typed context schemas**: `TargetBackground` (industry/use_case/competitors as proper types), `TargetAdditionalContext` (base_model/system_prompt/languages as proper types), `TargetMetadata` sub-fields typed (rate_limit, error_json as records)
+- **`validate` query param**: `targets.create()` and `targets.update()` now accept `{ validate: true }` to trigger connection validation on the server
+- **`customAttacks.uploadPromptsCsv()`**: Upload CSV files of custom prompts for a prompt set (multipart/form-data)
+- **`CustomPromptSetVersionInfo.stats`** now uses typed `PromptSetStatsSchema` instead of `z.unknown()`
+
+---
+
 ## v0.5.0
 
 ### OAuth Token Lifecycle Management

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -499,11 +499,19 @@ interface TargetListOptions extends RedTeamListOptions {
   active?: boolean;
 }
 
+interface TargetOperationOptions {
+  validate?: boolean; // validate connection before saving
+}
+
 class RedTeamTargetsClient {
-  create(request: TargetCreateRequest): Promise<TargetResponse>;
+  create(request: TargetCreateRequest, opts?: TargetOperationOptions): Promise<TargetResponse>;
   list(opts?: TargetListOptions): Promise<TargetList>;
   get(uuid: string): Promise<TargetResponse>;
-  update(uuid: string, request: TargetUpdateRequest): Promise<TargetResponse>;
+  update(
+    uuid: string,
+    request: TargetUpdateRequest,
+    opts?: TargetOperationOptions,
+  ): Promise<TargetResponse>;
   delete(uuid: string): Promise<BaseResponse>;
   probe(request: TargetProbeRequest): Promise<TargetResponse>;
   getProfile(uuid: string): Promise<TargetProfileResponse>;
@@ -542,6 +550,7 @@ class RedTeamCustomAttacksClient {
   getPromptSetVersionInfo(uuid: string): Promise<CustomPromptSetVersionInfo>;
   listActivePromptSets(): Promise<CustomPromptSetListActive>;
   downloadTemplate(uuid: string): Promise<unknown>;
+  uploadPromptsCsv(promptSetUuid: string, file: Blob): Promise<BaseResponse>;
 
   // Prompt operations
   createPrompt(request: CustomPromptCreateRequest): Promise<CustomPromptResponse>;

--- a/examples/red-team-mgmt-validation.ts
+++ b/examples/red-team-mgmt-validation.ts
@@ -1,0 +1,337 @@
+/**
+ * Red Team Management API — E2E Validation Script
+ *
+ * Validates typed schemas, validate param, uploadPromptsCsv, and CRUD operations
+ * against a local mock server. No real credentials needed.
+ *
+ * Usage: npx tsx examples/red-team-mgmt-validation.ts
+ */
+
+import * as http from 'node:http';
+import {
+  // Typed schemas
+  MultiTurnStatefulConfigSchema,
+  MultiTurnStatelessConfigSchema,
+  OpenAIConnectionParamsSchema,
+  HuggingfaceConnectionParamsSchema,
+  DatabricksConnectionParamsSchema,
+  BedrockAccessConnectionParamsSchema,
+  RestConnectionParamsSchema,
+  StreamingConnectionParamsSchema,
+  ConnectionParamsSchema,
+  TargetBackgroundSchema,
+  TargetAdditionalContextSchema,
+  TargetMetadataSchema,
+  PromptSetStatsSchema,
+  CustomPromptSetVersionInfoSchema,
+} from '../src/models/red-team.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, label: string): void {
+  if (condition) {
+    passed++;
+    console.log(`  ✅ ${label}`);
+  } else {
+    failed++;
+    console.log(`  ❌ ${label}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: Schema validation
+// ---------------------------------------------------------------------------
+
+console.log('\n╔══════════════════════════════════════════════════════════════╗');
+console.log('║  Red Team Management API — Schema Validation               ║');
+console.log('╚══════════════════════════════════════════════════════════════╝\n');
+
+console.log('Phase 1: Multi-turn configuration schemas');
+console.log('─'.repeat(50));
+
+const stateful = MultiTurnStatefulConfigSchema.parse({
+  response_id_field: 'id',
+  request_id_field: 'previous_response_id',
+});
+assert(stateful.type === 'stateful', 'Stateful config defaults type to "stateful"');
+assert(stateful.response_id_field === 'id', 'Stateful response_id_field parsed');
+assert(stateful.request_id_field === 'previous_response_id', 'Stateful request_id_field parsed');
+
+const stateless = MultiTurnStatelessConfigSchema.parse({
+  assistant_role: 'assistant',
+});
+assert(stateless.type === 'stateless', 'Stateless config defaults type to "stateless"');
+assert(stateless.assistant_role === 'assistant', 'Stateless assistant_role parsed');
+
+const statelessNull = MultiTurnStatelessConfigSchema.parse({
+  assistant_role: null,
+});
+assert(statelessNull.assistant_role === null, 'Stateless accepts null assistant_role');
+
+console.log('\nPhase 2: Provider connection parameter schemas');
+console.log('─'.repeat(50));
+
+const openai = OpenAIConnectionParamsSchema.parse({
+  api_key: 'sk-test123',
+  model_name: 'gpt-4.1-nano',
+});
+assert(openai.api_key === 'sk-test123', 'OpenAI api_key parsed');
+assert(openai.model_name === 'gpt-4.1-nano', 'OpenAI model_name parsed');
+
+const hf = HuggingfaceConnectionParamsSchema.parse({
+  api_key: 'hf-test',
+  model_name: 'llama-3',
+});
+assert(hf.api_key === 'hf-test', 'HuggingFace api_key parsed');
+
+const databricks = DatabricksConnectionParamsSchema.parse({
+  auth_type: 'OAUTH',
+  workspace_url: 'https://db.example.com',
+  model_name: 'my-model',
+  client_id: 'cid',
+  secret: 'sec',
+});
+assert(databricks.auth_type === 'OAUTH', 'Databricks auth_type parsed');
+assert(databricks.workspace_url === 'https://db.example.com', 'Databricks workspace_url parsed');
+
+const bedrock = BedrockAccessConnectionParamsSchema.parse({
+  access_id: 'AKIAIOSFODNN7EXAMPLE',
+  access_secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  region: 'us-east-1',
+  model_id: 'anthropic.claude-3-5-sonnet',
+  session_token: null,
+});
+assert(bedrock.region === 'us-east-1', 'Bedrock region parsed');
+assert(bedrock.session_token === null, 'Bedrock accepts null session_token');
+
+console.log('\nPhase 3: REST & Streaming connection schemas');
+console.log('─'.repeat(50));
+
+const rest = RestConnectionParamsSchema.parse({
+  api_endpoint: 'https://api.openai.com/v1/responses',
+  request_headers: { 'Content-Type': 'application/json' },
+  request_json: { model: 'gpt-4', input: [{ role: 'user', content: '{INPUT}' }] },
+  response_key: 'output[0].content[0].text',
+  target_connection_config: { api_key: 'sk-xxx', model_name: 'gpt-4' },
+  multi_turn_config: { type: 'stateful', response_id_field: 'id', request_id_field: 'prev_id' },
+});
+assert(rest.api_endpoint === 'https://api.openai.com/v1/responses', 'REST api_endpoint parsed');
+assert(rest.response_key === 'output[0].content[0].text', 'REST response_key parsed');
+
+const streaming = StreamingConnectionParamsSchema.parse({
+  api_endpoint: 'https://api.openai.com/v1/responses',
+  response_stop_key: 'type',
+  response_stop_value: 'response.completed',
+});
+assert(streaming.response_stop_key === 'type', 'Streaming response_stop_key parsed');
+assert(
+  streaming.response_stop_value === 'response.completed',
+  'Streaming response_stop_value parsed',
+);
+
+const connRest = ConnectionParamsSchema.parse({
+  api_endpoint: 'https://example.com/api',
+  response_key: 'content',
+});
+assert(connRest.api_endpoint === 'https://example.com/api', 'ConnectionParams union: REST variant');
+
+const connStream = ConnectionParamsSchema.parse({
+  api_endpoint: 'https://example.com/api',
+  response_stop_key: 'event',
+  response_stop_value: 'done',
+});
+assert(
+  (connStream as Record<string, unknown>).response_stop_key === 'event',
+  'ConnectionParams union: Streaming variant',
+);
+
+console.log('\nPhase 4: Typed context schemas');
+console.log('─'.repeat(50));
+
+const bg = TargetBackgroundSchema.parse({
+  industry: 'Healthcare',
+  use_case: 'Patient Support Chatbot',
+  competitors: ['MedBot', 'HealthAI'],
+});
+assert(bg.industry === 'Healthcare', 'TargetBackground.industry is string');
+assert(Array.isArray(bg.competitors), 'TargetBackground.competitors is string[]');
+assert(bg.competitors!.length === 2, 'TargetBackground.competitors has 2 items');
+
+const ctx = TargetAdditionalContextSchema.parse({
+  base_model: 'GPT-4',
+  system_prompt: 'You are a medical assistant',
+  languages_supported: ['en', 'es', 'fr'],
+  banned_keywords: ['ignore previous instructions'],
+  tools_accessible: ['search_medical_db', 'schedule_appointment'],
+});
+assert(ctx.base_model === 'GPT-4', 'AdditionalContext.base_model is string');
+assert(ctx.languages_supported!.length === 3, 'AdditionalContext.languages_supported has 3 items');
+
+const meta = TargetMetadataSchema.parse({
+  multi_turn: true,
+  rate_limit: 60,
+  rate_limit_enabled: true,
+  rate_limit_error_code: 429,
+  rate_limit_error_json: { error: 'rate limited' },
+  content_filter_enabled: true,
+  content_filter_error_code: 400,
+  content_filter_error_json: { error: 'filtered' },
+  probe_message: 'Hello',
+  request_timeout: 30,
+});
+assert(meta.rate_limit === 60, 'TargetMetadata.rate_limit is number');
+assert(
+  typeof meta.rate_limit_error_json === 'object',
+  'TargetMetadata.rate_limit_error_json is object',
+);
+
+console.log('\nPhase 5: PromptSetStats & VersionInfo typed schemas');
+console.log('─'.repeat(50));
+
+const stats = PromptSetStatsSchema.parse({
+  total_prompts: 100,
+  active_prompts: 80,
+  inactive_prompts: 15,
+  failed_prompts: 3,
+  validation_prompts: 2,
+});
+assert(stats.total_prompts === 100, 'PromptSetStats.total_prompts parsed');
+assert(stats.failed_prompts === 3, 'PromptSetStats.failed_prompts parsed');
+
+const versionInfo = CustomPromptSetVersionInfoSchema.parse({
+  uuid: '550e8400-e29b-41d4-a716-446655440000',
+  status: 'ready',
+  is_latest: true,
+  version: 'gen-12345',
+  stats: { total_prompts: 50, active_prompts: 45, inactive_prompts: 5 },
+  snapshot_created_at: '2026-03-08T10:00:00Z',
+});
+assert(versionInfo.stats?.total_prompts === 50, 'VersionInfo.stats is typed PromptSetStats');
+assert(
+  versionInfo.snapshot_created_at === '2026-03-08T10:00:00Z',
+  'VersionInfo.snapshot_created_at is string',
+);
+
+// ---------------------------------------------------------------------------
+// Phase 6: Mock server for client operations
+// ---------------------------------------------------------------------------
+
+console.log('\nPhase 6: Client operations (validate param, CSV upload)');
+console.log('─'.repeat(50));
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+const requests: { url: string; method: string; contentType?: string }[] = [];
+
+const server = http.createServer((req, res) => {
+  const url = req.url ?? '';
+  const method = req.method ?? '';
+  const contentType = req.headers['content-type'] ?? '';
+  requests.push({ url, method, contentType });
+
+  // Mock token endpoint
+  if (url.includes('/oauth2/access_token')) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ access_token: 'mock-token', expires_in: 3600 }));
+    return;
+  }
+
+  // Mock target create/update with validate param
+  if (url.includes('/v1/target') && !url.includes('upload')) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        uuid: validUuid,
+        tsg_id: '123',
+        name: 'test-target',
+        status: 'VALIDATED',
+        active: true,
+        validated: true,
+        created_at: '2026-03-08T10:00:00Z',
+        updated_at: '2026-03-08T10:00:00Z',
+      }),
+    );
+    return;
+  }
+
+  // Mock CSV upload
+  if (url.includes('/upload-custom-prompts-csv')) {
+    res.writeHead(201, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: 'Uploaded 5 prompts', status: 201 }));
+    return;
+  }
+
+  res.writeHead(404);
+  res.end();
+});
+
+await new Promise<void>((resolve) => server.listen(0, resolve));
+const port = (server.address() as { port: number }).port;
+
+// Dynamic import of client classes
+const { RedTeamClient } = await import('../src/red-team/client.js');
+
+const client = new RedTeamClient({
+  clientId: 'test-id',
+  clientSecret: 'test-secret',
+  tsgId: '123456',
+  mgmtEndpoint: `http://localhost:${port}`,
+  tokenEndpoint: `http://localhost:${port}/oauth2/access_token`,
+});
+
+// Test validate param on create
+requests.length = 0;
+await client.targets.create({ name: 'test-target' }, { validate: true });
+assert(
+  requests.some((r) => r.url.includes('validate=true')),
+  'create() passes validate=true query param',
+);
+
+// Test validate param on update
+requests.length = 0;
+await client.targets.update(validUuid, { name: 'updated' }, { validate: false });
+assert(
+  requests.some((r) => r.url.includes('validate=false')),
+  'update() passes validate=false query param',
+);
+
+// Test no validate param when omitted
+requests.length = 0;
+await client.targets.create({ name: 'no-validate' });
+assert(
+  !requests.some((r) => r.url.includes('validate')),
+  'create() omits validate param when not specified',
+);
+
+// Test CSV upload
+requests.length = 0;
+const csvContent = 'prompt,goal\n"Inject system prompt","Extract secrets"';
+const csvBlob = new Blob([csvContent], { type: 'text/csv' });
+const uploadResult = await client.customAttacks.uploadPromptsCsv(validUuid, csvBlob);
+assert(uploadResult.message === 'Uploaded 5 prompts', 'uploadPromptsCsv returns parsed response');
+assert(
+  requests.some((r) => r.url.includes('upload-custom-prompts-csv')),
+  'uploadPromptsCsv hits correct endpoint',
+);
+assert(
+  requests.some((r) => r.url.includes(`prompt_set_uuid=${validUuid}`)),
+  'uploadPromptsCsv passes prompt_set_uuid query param',
+);
+assert(
+  requests.some((r) => r.contentType?.includes('multipart/form-data')),
+  'uploadPromptsCsv sends multipart/form-data',
+);
+
+server.close();
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log('\n' + '═'.repeat(60));
+console.log(`  Total: ${passed + failed}  |  Passed: ${passed}  |  Failed: ${failed}`);
+console.log('═'.repeat(60));
+
+if (failed > 0) {
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",
@@ -58,7 +58,8 @@
     "example:model-sec-scans": "npx tsx --env-file=.env examples/model-security-scans.ts",
     "example:red-team-scans": "npx tsx --env-file=.env examples/red-team-scans.ts",
     "example:red-team-targets": "npx tsx --env-file=.env examples/red-team-targets.ts",
-    "example:oauth-lifecycle": "npx tsx examples/oauth-lifecycle-validation.ts"
+    "example:oauth-lifecycle": "npx tsx examples/oauth-lifecycle-validation.ts",
+    "example:red-team-mgmt": "npx tsx examples/red-team-mgmt-validation.ts"
   },
   "dependencies": {
     "zod": "^3.24.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.5.2';
+export const SDK_VERSION = '0.6.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/models/red-team.ts
+++ b/src/models/red-team.ts
@@ -32,21 +32,21 @@ export type HTTPValidationError = z.infer<typeof HTTPValidationErrorSchema>;
 
 export const TargetBackgroundSchema = z
   .object({
-    industry: z.unknown().optional(),
-    use_case: z.unknown().optional(),
-    competitors: z.unknown().optional(),
+    industry: z.string().nullable().optional(),
+    use_case: z.string().nullable().optional(),
+    competitors: z.array(z.string()).nullable().optional(),
   })
   .passthrough();
 export type TargetBackground = z.infer<typeof TargetBackgroundSchema>;
 
 export const TargetAdditionalContextSchema = z
   .object({
-    base_model: z.unknown().optional(),
-    core_architecture: z.unknown().optional(),
-    system_prompt: z.unknown().optional(),
-    languages_supported: z.unknown().optional(),
-    banned_keywords: z.unknown().optional(),
-    tools_accessible: z.unknown().optional(),
+    base_model: z.string().nullable().optional(),
+    core_architecture: z.string().nullable().optional(),
+    system_prompt: z.string().nullable().optional(),
+    languages_supported: z.array(z.string()).nullable().optional(),
+    banned_keywords: z.array(z.string()).nullable().optional(),
+    tools_accessible: z.array(z.string()).nullable().optional(),
   })
   .passthrough();
 export type TargetAdditionalContext = z.infer<typeof TargetAdditionalContextSchema>;
@@ -54,21 +54,116 @@ export type TargetAdditionalContext = z.infer<typeof TargetAdditionalContextSche
 export const TargetMetadataSchema = z
   .object({
     multi_turn: z.boolean().optional(),
-    multi_turn_error_message: z.unknown().optional(),
-    rate_limit: z.unknown().optional(),
+    multi_turn_error_message: z.string().nullable().optional(),
+    rate_limit: z.number().int().nullable().optional(),
     rate_limit_enabled: z.boolean().optional(),
-    rate_limit_error_code: z.unknown().optional(),
-    rate_limit_error_json: z.unknown().optional(),
-    rate_limit_error_message: z.unknown().optional(),
+    rate_limit_error_code: z.number().int().nullable().optional(),
+    rate_limit_error_json: z.record(z.unknown()).nullable().optional(),
+    rate_limit_error_message: z.string().nullable().optional(),
     content_filter_enabled: z.boolean().optional(),
-    content_filter_error_code: z.unknown().optional(),
-    content_filter_error_json: z.unknown().optional(),
-    content_filter_error_message: z.unknown().optional(),
+    content_filter_error_code: z.number().int().nullable().optional(),
+    content_filter_error_json: z.record(z.unknown()).nullable().optional(),
+    content_filter_error_message: z.string().nullable().optional(),
     probe_message: z.string().optional(),
     request_timeout: z.number().optional(),
   })
   .passthrough();
 export type TargetMetadata = z.infer<typeof TargetMetadataSchema>;
+
+// ---------------------------------------------------------------------------
+// Multi-turn configuration schemas
+// ---------------------------------------------------------------------------
+
+export const MultiTurnStatefulConfigSchema = z
+  .object({
+    type: z.string().default('stateful'),
+    response_id_field: z.string(),
+    request_id_field: z.string(),
+  })
+  .passthrough();
+export type MultiTurnStatefulConfig = z.infer<typeof MultiTurnStatefulConfigSchema>;
+
+export const MultiTurnStatelessConfigSchema = z
+  .object({
+    type: z.string().default('stateless'),
+    assistant_role: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type MultiTurnStatelessConfig = z.infer<typeof MultiTurnStatelessConfigSchema>;
+
+// ---------------------------------------------------------------------------
+// Provider-specific connection parameter schemas
+// ---------------------------------------------------------------------------
+
+export const OpenAIConnectionParamsSchema = z
+  .object({
+    api_key: z.string(),
+    model_name: z.string(),
+  })
+  .passthrough();
+export type OpenAIConnectionParams = z.infer<typeof OpenAIConnectionParamsSchema>;
+
+export const HuggingfaceConnectionParamsSchema = z
+  .object({
+    api_key: z.string(),
+    model_name: z.string(),
+  })
+  .passthrough();
+export type HuggingfaceConnectionParams = z.infer<typeof HuggingfaceConnectionParamsSchema>;
+
+export const DatabricksConnectionParamsSchema = z
+  .object({
+    auth_type: z.string(),
+    workspace_url: z.string(),
+    model_name: z.string(),
+    access_token: z.string().nullable().optional(),
+    client_id: z.string().nullable().optional(),
+    secret: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type DatabricksConnectionParams = z.infer<typeof DatabricksConnectionParamsSchema>;
+
+export const BedrockAccessConnectionParamsSchema = z
+  .object({
+    access_id: z.string(),
+    access_secret: z.string(),
+    region: z.string(),
+    model_id: z.string(),
+    session_token: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type BedrockAccessConnectionParams = z.infer<typeof BedrockAccessConnectionParamsSchema>;
+
+// ---------------------------------------------------------------------------
+// Connection parameter schemas (REST & Streaming)
+// ---------------------------------------------------------------------------
+
+export const RestConnectionParamsSchema = z
+  .object({
+    api_endpoint: z.string().nullable().optional(),
+    request_headers: z.record(z.unknown()).nullable().optional(),
+    request_json: z.record(z.unknown()).nullable().optional(),
+    response_json: z.record(z.unknown()).nullable().optional(),
+    response_key: z.string().nullable().optional(),
+    target_connection_config: z.unknown().nullable().optional(),
+    curl: z.string().nullable().optional(),
+    multi_turn_config: z.unknown().nullable().optional(),
+  })
+  .passthrough();
+export type RestConnectionParams = z.infer<typeof RestConnectionParamsSchema>;
+
+export const StreamingConnectionParamsSchema = RestConnectionParamsSchema.extend({
+  response_stop_key: z.string(),
+  response_stop_value: z.string(),
+}).passthrough();
+export type StreamingConnectionParams = z.infer<typeof StreamingConnectionParamsSchema>;
+
+/** Union of REST and Streaming connection params. */
+export const ConnectionParamsSchema = z.union([
+  StreamingConnectionParamsSchema,
+  RestConnectionParamsSchema,
+]);
+export type ConnectionParams = z.infer<typeof ConnectionParamsSchema>;
 
 // ---------------------------------------------------------------------------
 // DataPlane — Job / Scan schemas
@@ -1119,9 +1214,9 @@ export const CustomPromptSetVersionInfoSchema = z
     uuid: z.string(),
     status: z.string(),
     is_latest: z.boolean(),
-    version: z.unknown().optional(),
-    stats: z.unknown().optional(),
-    snapshot_created_at: z.unknown().optional(),
+    version: z.string().nullable().optional(),
+    stats: PromptSetStatsSchema.nullable().optional(),
+    snapshot_created_at: z.string().nullable().optional(),
   })
   .passthrough();
 export type CustomPromptSetVersionInfo = z.infer<typeof CustomPromptSetVersionInfoSchema>;

--- a/src/red-team/custom-attacks-client.ts
+++ b/src/red-team/custom-attacks-client.ts
@@ -1,4 +1,4 @@
-import { RED_TEAM_CUSTOM_ATTACK_PATH } from '../constants.js';
+import { RED_TEAM_CUSTOM_ATTACK_PATH, USER_AGENT } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { isValidUuid } from '../utils.js';
 import { managementHttpRequest } from '../management/management-http-client.js';
@@ -201,6 +201,40 @@ export class RedTeamCustomAttacksClient {
       numRetries: this.numRetries,
     });
     return res.data;
+  }
+
+  /** Upload a CSV file of custom prompts for a prompt set. */
+  async uploadPromptsCsv(promptSetUuid: string, file: Blob): Promise<BaseResponse> {
+    validateUuid(promptSetUuid, 'prompt set uuid');
+
+    const token = await this.oauthClient.getToken();
+    const url = new URL(
+      `${this.baseUrl.replace(/\/+$/, '')}${RED_TEAM_CUSTOM_ATTACK_PATH}/upload-custom-prompts-csv`,
+    );
+    url.searchParams.set('prompt_set_uuid', promptSetUuid);
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'User-Agent': USER_AGENT,
+      },
+      body: formData,
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      throw new AISecSDKException(
+        `Upload failed (${response.status}): ${text}`,
+        ErrorType.SERVER_SIDE_ERROR,
+      );
+    }
+    return text
+      ? (JSON.parse(text) as BaseResponse)
+      : ({ message: 'ok', status: 201 } as BaseResponse);
   }
 
   // -----------------------------------------------------------------------

--- a/src/red-team/index.ts
+++ b/src/red-team/index.ts
@@ -10,7 +10,11 @@ export {
   type GoalListOptions,
 } from './reports-client.js';
 export { RedTeamCustomAttackReportsClient } from './custom-attack-reports-client.js';
-export { RedTeamTargetsClient, type TargetListOptions } from './targets-client.js';
+export {
+  RedTeamTargetsClient,
+  type TargetListOptions,
+  type TargetOperationOptions,
+} from './targets-client.js';
 export {
   RedTeamCustomAttacksClient,
   type PromptSetListOptions,

--- a/src/red-team/targets-client.ts
+++ b/src/red-team/targets-client.ts
@@ -22,6 +22,12 @@ export interface TargetListOptions extends RedTeamListOptions {
   active?: boolean;
 }
 
+/** Options for target create/update operations. */
+export interface TargetOperationOptions {
+  /** Validate the target connection before saving. */
+  validate?: boolean;
+}
+
 /** @internal */
 export interface RedTeamTargetsClientOptions {
   baseUrl: string;
@@ -52,12 +58,19 @@ export class RedTeamTargetsClient {
   }
 
   /** Create a new target. */
-  async create(request: TargetCreateRequest): Promise<TargetResponse> {
+  async create(
+    request: TargetCreateRequest,
+    opts?: TargetOperationOptions,
+  ): Promise<TargetResponse> {
+    const params: Record<string, string> = {};
+    if (opts?.validate !== undefined) params.validate = String(opts.validate);
+
     const res = await managementHttpRequest<TargetResponse>({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: RED_TEAM_TARGET_PATH,
       body: request,
+      params: Object.keys(params).length > 0 ? params : undefined,
       oauthClient: this.oauthClient,
       numRetries: this.numRetries,
     });
@@ -102,7 +115,11 @@ export class RedTeamTargetsClient {
   }
 
   /** Update a target. */
-  async update(uuid: string, request: TargetUpdateRequest): Promise<TargetResponse> {
+  async update(
+    uuid: string,
+    request: TargetUpdateRequest,
+    opts?: TargetOperationOptions,
+  ): Promise<TargetResponse> {
     if (!isValidUuid(uuid)) {
       throw new AISecSDKException(
         `Invalid target uuid: ${uuid}`,
@@ -110,11 +127,15 @@ export class RedTeamTargetsClient {
       );
     }
 
+    const params: Record<string, string> = {};
+    if (opts?.validate !== undefined) params.validate = String(opts.validate);
+
     const res = await managementHttpRequest<TargetResponse>({
       method: 'PUT',
       baseUrl: this.baseUrl,
       path: `${RED_TEAM_TARGET_PATH}/${uuid}`,
       body: request,
+      params: Object.keys(params).length > 0 ? params : undefined,
       oauthClient: this.oauthClient,
       numRetries: this.numRetries,
     });

--- a/test/models/red-team-connection-schemas.spec.ts
+++ b/test/models/red-team-connection-schemas.spec.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MultiTurnStatefulConfigSchema,
+  MultiTurnStatelessConfigSchema,
+  OpenAIConnectionParamsSchema,
+  HuggingfaceConnectionParamsSchema,
+  DatabricksConnectionParamsSchema,
+  BedrockAccessConnectionParamsSchema,
+  RestConnectionParamsSchema,
+  StreamingConnectionParamsSchema,
+  ConnectionParamsSchema,
+} from '../../src/models/red-team.js';
+
+// ---------------------------------------------------------------------------
+// MultiTurnStatefulConfig
+// ---------------------------------------------------------------------------
+
+describe('MultiTurnStatefulConfigSchema', () => {
+  it('parses valid stateful config', () => {
+    const input = {
+      type: 'stateful',
+      response_id_field: 'id',
+      request_id_field: 'previous_response_id',
+    };
+    const result = MultiTurnStatefulConfigSchema.parse(input);
+    expect(result.type).toBe('stateful');
+    expect(result.response_id_field).toBe('id');
+    expect(result.request_id_field).toBe('previous_response_id');
+  });
+
+  it('defaults type to stateful', () => {
+    const input = {
+      response_id_field: 'conversation_id',
+      request_id_field: 'session_id',
+    };
+    const result = MultiTurnStatefulConfigSchema.parse(input);
+    expect(result.type).toBe('stateful');
+  });
+
+  it('passes through unknown fields', () => {
+    const input = {
+      type: 'stateful',
+      response_id_field: 'id',
+      request_id_field: 'prev_id',
+      future_field: true,
+    };
+    const result = MultiTurnStatefulConfigSchema.parse(input);
+    expect((result as Record<string, unknown>).future_field).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MultiTurnStatelessConfig
+// ---------------------------------------------------------------------------
+
+describe('MultiTurnStatelessConfigSchema', () => {
+  it('parses valid stateless config', () => {
+    const input = { type: 'stateless', assistant_role: 'assistant' };
+    const result = MultiTurnStatelessConfigSchema.parse(input);
+    expect(result.type).toBe('stateless');
+    expect(result.assistant_role).toBe('assistant');
+  });
+
+  it('defaults type to stateless', () => {
+    const result = MultiTurnStatelessConfigSchema.parse({});
+    expect(result.type).toBe('stateless');
+  });
+
+  it('accepts null assistant_role', () => {
+    const result = MultiTurnStatelessConfigSchema.parse({
+      type: 'stateless',
+      assistant_role: null,
+    });
+    expect(result.assistant_role).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider-specific connection params
+// ---------------------------------------------------------------------------
+
+describe('OpenAIConnectionParamsSchema', () => {
+  it('parses valid OpenAI params', () => {
+    const input = { api_key: 'sk-abc', model_name: 'gpt-4.1-nano' };
+    const result = OpenAIConnectionParamsSchema.parse(input);
+    expect(result.api_key).toBe('sk-abc');
+    expect(result.model_name).toBe('gpt-4.1-nano');
+  });
+
+  it('passes through unknown fields', () => {
+    const input = { api_key: 'sk-abc', model_name: 'gpt-4', extra: true };
+    const result = OpenAIConnectionParamsSchema.parse(input);
+    expect((result as Record<string, unknown>).extra).toBe(true);
+  });
+});
+
+describe('HuggingfaceConnectionParamsSchema', () => {
+  it('parses valid Huggingface params', () => {
+    const input = { api_key: 'hf-abc', model_name: 'llama-3' };
+    const result = HuggingfaceConnectionParamsSchema.parse(input);
+    expect(result.api_key).toBe('hf-abc');
+    expect(result.model_name).toBe('llama-3');
+  });
+});
+
+describe('DatabricksConnectionParamsSchema', () => {
+  it('parses valid Databricks params', () => {
+    const input = {
+      auth_type: 'OAUTH',
+      workspace_url: 'https://db.example.com',
+      model_name: 'my-model',
+      client_id: 'cid',
+      secret: 'sec',
+    };
+    const result = DatabricksConnectionParamsSchema.parse(input);
+    expect(result.auth_type).toBe('OAUTH');
+    expect(result.workspace_url).toBe('https://db.example.com');
+  });
+
+  it('accepts ACCESS_TOKEN auth type', () => {
+    const input = {
+      auth_type: 'ACCESS_TOKEN',
+      workspace_url: 'https://db.example.com',
+      model_name: 'model',
+      access_token: 'tok',
+    };
+    const result = DatabricksConnectionParamsSchema.parse(input);
+    expect(result.auth_type).toBe('ACCESS_TOKEN');
+    expect(result.access_token).toBe('tok');
+  });
+});
+
+describe('BedrockAccessConnectionParamsSchema', () => {
+  it('parses valid Bedrock params', () => {
+    const input = {
+      access_id: 'AKIA...',
+      access_secret: 'secret',
+      region: 'us-east-1',
+      model_id: 'anthropic.claude-3',
+    };
+    const result = BedrockAccessConnectionParamsSchema.parse(input);
+    expect(result.access_id).toBe('AKIA...');
+    expect(result.region).toBe('us-east-1');
+  });
+
+  it('accepts optional session_token', () => {
+    const input = {
+      access_id: 'AKIA...',
+      access_secret: 'secret',
+      region: 'us-east-1',
+      model_id: 'model',
+      session_token: 'sess-tok',
+    };
+    const result = BedrockAccessConnectionParamsSchema.parse(input);
+    expect(result.session_token).toBe('sess-tok');
+  });
+
+  it('accepts null session_token', () => {
+    const input = {
+      access_id: 'AKIA...',
+      access_secret: 'secret',
+      region: 'us-east-1',
+      model_id: 'model',
+      session_token: null,
+    };
+    const result = BedrockAccessConnectionParamsSchema.parse(input);
+    expect(result.session_token).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RestConnectionParams
+// ---------------------------------------------------------------------------
+
+describe('RestConnectionParamsSchema', () => {
+  it('parses minimal REST params', () => {
+    const input = {};
+    const result = RestConnectionParamsSchema.parse(input);
+    expect(result).toBeDefined();
+  });
+
+  it('parses full REST params', () => {
+    const input = {
+      api_endpoint: 'https://api.openai.com/v1/responses',
+      request_headers: { 'Content-Type': 'application/json' },
+      request_json: { model: 'gpt-4' },
+      response_json: { content: '{RESPONSE}' },
+      response_key: 'content',
+      curl: 'curl https://...',
+      target_connection_config: { api_key: 'sk-abc', model_name: 'gpt-4' },
+      multi_turn_config: {
+        type: 'stateful',
+        response_id_field: 'id',
+        request_id_field: 'prev_id',
+      },
+    };
+    const result = RestConnectionParamsSchema.parse(input);
+    expect(result.api_endpoint).toBe('https://api.openai.com/v1/responses');
+    expect(result.response_key).toBe('content');
+  });
+
+  it('accepts null fields', () => {
+    const input = {
+      api_endpoint: null,
+      curl: null,
+      target_connection_config: null,
+      multi_turn_config: null,
+    };
+    const result = RestConnectionParamsSchema.parse(input);
+    expect(result.api_endpoint).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StreamingConnectionParams
+// ---------------------------------------------------------------------------
+
+describe('StreamingConnectionParamsSchema', () => {
+  it('parses valid streaming params', () => {
+    const input = {
+      api_endpoint: 'https://api.openai.com/v1/responses',
+      response_stop_key: 'type',
+      response_stop_value: 'response.completed',
+    };
+    const result = StreamingConnectionParamsSchema.parse(input);
+    expect(result.response_stop_key).toBe('type');
+    expect(result.response_stop_value).toBe('response.completed');
+  });
+
+  it('requires response_stop_key and response_stop_value', () => {
+    expect(() => StreamingConnectionParamsSchema.parse({})).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ConnectionParams (union)
+// ---------------------------------------------------------------------------
+
+describe('ConnectionParamsSchema', () => {
+  it('parses REST connection params', () => {
+    const input = {
+      api_endpoint: 'https://example.com/api',
+      response_key: 'content',
+    };
+    const result = ConnectionParamsSchema.parse(input);
+    expect(result.api_endpoint).toBe('https://example.com/api');
+  });
+
+  it('parses streaming connection params', () => {
+    const input = {
+      api_endpoint: 'https://example.com/api',
+      response_stop_key: 'type',
+      response_stop_value: 'done',
+    };
+    const result = ConnectionParamsSchema.parse(input);
+    expect((result as Record<string, unknown>).response_stop_key).toBe('type');
+  });
+});

--- a/test/models/red-team.spec.ts
+++ b/test/models/red-team.spec.ts
@@ -20,13 +20,17 @@ import {
   TargetCreateRequestSchema,
   TargetResponseSchema,
   TargetListSchema,
+  TargetBackgroundSchema,
+  TargetAdditionalContextSchema,
   CustomPromptSetCreateRequestSchema,
   CustomPromptSetResponseSchema,
+  CustomPromptSetVersionInfoSchema,
   CustomPromptCreateRequestSchema,
   CustomPromptResponseSchema,
   PropertyNamesListResponseSchema,
   BaseResponseSchema,
   DashboardOverviewResponseSchema,
+  PromptSetStatsSchema,
 } from '../../src/models/red-team.js';
 
 // ---------------------------------------------------------------------------
@@ -957,5 +961,97 @@ describe('DashboardOverviewResponseSchema', () => {
   it('passes through unknown fields', () => {
     const res = DashboardOverviewResponseSchema.parse({ total_targets: 1, extra: 'field' });
     expect((res as Record<string, unknown>).extra).toBe('field');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Typed context schemas
+// ---------------------------------------------------------------------------
+
+describe('TargetBackgroundSchema (typed)', () => {
+  it('parses typed fields', () => {
+    const input = {
+      industry: 'Healthcare',
+      use_case: 'Patient Support',
+      competitors: ['CompetitorA', 'CompetitorB'],
+    };
+    const parsed = TargetBackgroundSchema.parse(input);
+    expect(parsed.industry).toBe('Healthcare');
+    expect(parsed.use_case).toBe('Patient Support');
+    expect(parsed.competitors).toEqual(['CompetitorA', 'CompetitorB']);
+  });
+
+  it('accepts null fields', () => {
+    const parsed = TargetBackgroundSchema.parse({
+      industry: null,
+      use_case: null,
+      competitors: null,
+    });
+    expect(parsed.industry).toBeNull();
+  });
+});
+
+describe('TargetAdditionalContextSchema (typed)', () => {
+  it('parses typed fields', () => {
+    const input = {
+      base_model: 'GPT-4',
+      system_prompt: 'You are helpful',
+      languages_supported: ['en', 'es'],
+      banned_keywords: ['hack'],
+      tools_accessible: ['search', 'code_exec'],
+    };
+    const parsed = TargetAdditionalContextSchema.parse(input);
+    expect(parsed.base_model).toBe('GPT-4');
+    expect(parsed.languages_supported).toEqual(['en', 'es']);
+  });
+});
+
+describe('CustomPromptSetVersionInfoSchema (typed stats)', () => {
+  it('parses with typed stats', () => {
+    const input = {
+      uuid: validUuid,
+      status: 'ready',
+      is_latest: true,
+      version: 'v1',
+      stats: {
+        total_prompts: 10,
+        active_prompts: 8,
+        inactive_prompts: 2,
+        failed_prompts: 0,
+        validation_prompts: 1,
+      },
+      snapshot_created_at: now,
+    };
+    const parsed = CustomPromptSetVersionInfoSchema.parse(input);
+    expect(parsed.stats?.total_prompts).toBe(10);
+    expect(parsed.stats?.active_prompts).toBe(8);
+  });
+
+  it('accepts null stats', () => {
+    const input = { uuid: validUuid, status: 'ready', is_latest: true, stats: null };
+    const parsed = CustomPromptSetVersionInfoSchema.parse(input);
+    expect(parsed.stats).toBeNull();
+  });
+});
+
+describe('PromptSetStatsSchema', () => {
+  it('parses valid stats', () => {
+    const input = {
+      total_prompts: 100,
+      active_prompts: 80,
+      inactive_prompts: 15,
+      failed_prompts: 3,
+      validation_prompts: 2,
+    };
+    const parsed = PromptSetStatsSchema.parse(input);
+    expect(parsed.total_prompts).toBe(100);
+    expect(parsed.active_prompts).toBe(80);
+    expect(parsed.failed_prompts).toBe(3);
+  });
+
+  it('accepts optional failed/validation fields', () => {
+    const input = { total_prompts: 10, active_prompts: 8, inactive_prompts: 2 };
+    const parsed = PromptSetStatsSchema.parse(input);
+    expect(parsed.failed_prompts).toBeUndefined();
   });
 });

--- a/test/red-team/custom-attacks-client.spec.ts
+++ b/test/red-team/custom-attacks-client.spec.ts
@@ -356,4 +356,29 @@ describe('RedTeamCustomAttacksClient', () => {
       expect(init.method).toBe('POST');
     });
   });
+
+  // -----------------------------------------------------------------------
+  // CSV upload
+  // -----------------------------------------------------------------------
+
+  describe('uploadPromptsCsv', () => {
+    it('POSTs multipart form data to upload endpoint', async () => {
+      mockFetch({ message: 'uploaded', status: 201 }, 201);
+      const csvContent = 'prompt,goal\n"test prompt","test goal"';
+      const file = new Blob([csvContent], { type: 'text/csv' });
+      const result = await client.uploadPromptsCsv(validUuid, file);
+
+      expect(result.message).toBe('uploaded');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/custom-attack/upload-custom-prompts-csv');
+      expect(url).toContain(`prompt_set_uuid=${validUuid}`);
+      expect(init.method).toBe('POST');
+      expect(init.body).toBeInstanceOf(FormData);
+    });
+
+    it('rejects invalid prompt set UUID', async () => {
+      const file = new Blob(['test'], { type: 'text/csv' });
+      await expect(client.uploadPromptsCsv('bad', file)).rejects.toThrow(AISecSDKException);
+    });
+  });
 });

--- a/test/red-team/targets-client.spec.ts
+++ b/test/red-team/targets-client.spec.ts
@@ -50,6 +50,30 @@ describe('RedTeamTargetsClient', () => {
       expect(url).toBe('https://mgmt.example.com/v1/target');
       expect(init.method).toBe('POST');
     });
+
+    it('passes validate query param when true', async () => {
+      mockFetch({ id: validUuid }, 201);
+      await client.create({ name: 'test' }, { validate: true });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('validate=true');
+    });
+
+    it('passes validate query param when false', async () => {
+      mockFetch({ id: validUuid }, 201);
+      await client.create({ name: 'test' }, { validate: false });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('validate=false');
+    });
+
+    it('omits validate param when not specified', async () => {
+      mockFetch({ id: validUuid }, 201);
+      await client.create({ name: 'test' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).not.toContain('validate');
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -121,6 +145,22 @@ describe('RedTeamTargetsClient', () => {
 
     it('rejects invalid UUID', async () => {
       await expect(client.update('bad', { name: 'x' })).rejects.toThrow(AISecSDKException);
+    });
+
+    it('passes validate query param when true', async () => {
+      mockFetch({ id: validUuid });
+      await client.update(validUuid, { name: 'test' }, { validate: true });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('validate=true');
+    });
+
+    it('passes validate query param when false', async () => {
+      mockFetch({ id: validUuid });
+      await client.update(validUuid, { name: 'test' }, { validate: false });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('validate=false');
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #25

- **Typed Zod schemas**: MultiTurnStateful/StatelessConfig, OpenAI/HuggingFace/Databricks/Bedrock connection params, REST/Streaming connection params, ConnectionParams union
- **Typed context schemas**: TargetBackground, AdditionalContext, TargetMetadata sub-fields replaced `z.unknown()` with proper types
- **`validate` query param**: `targets.create()` and `targets.update()` accept `{ validate: true }` for server-side connection validation
- **`customAttacks.uploadPromptsCsv()`**: Multipart CSV upload for custom prompt sets
- **`CustomPromptSetVersionInfo.stats`**: Uses typed `PromptSetStatsSchema` instead of `z.unknown()`
- 35 new tests (652 total), E2E validation script (37 assertions)
- Version bump to 0.6.0

## Test plan
- [x] 652 tests pass (31 test files)
- [x] Lint, format, typecheck all clean
- [x] E2E validation script passes (37/37 assertions)
- [ ] CI + Test workflows pass on GitHub
- [ ] Merge → release v0.6.0 → npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)