### PR TITLE
Align model security mgmt list params with OpenAPI spec

### DIFF
--- a/.changeset/0008-align-model-sec-mgmt-params.md
+++ b/.changeset/0008-align-model-sec-mgmt-params.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Align Model Security management plane list endpoints with OpenAPI spec: fix query param names (sort_field/sort_dir/search_query), add source_types/enabled_rules filters to security groups, source_type filter to security rules, and security_rule_uuid/state filters to rule instances.

--- a/docs/services/model-security-api.md
+++ b/docs/services/model-security-api.md
@@ -179,10 +179,23 @@ console.log(group.uuid);
 ### List
 
 ```ts
+// Basic pagination
 const result = await client.securityGroups.list({
   skip: 0,
   limit: 10,
-  search: 'production',
+  sort_field: 'created_at',
+  sort_dir: 'desc',
+});
+
+// Filter by source types and search
+const filtered = await client.securityGroups.list({
+  source_types: ['HUGGING_FACE', 'S3'],
+  search_query: 'production',
+});
+
+// Filter by groups with specific rules enabled
+const withRules = await client.securityGroups.list({
+  enabled_rules: ['rule-uuid-1', 'rule-uuid-2'],
 });
 ```
 
@@ -217,12 +230,23 @@ const instances = await client.securityGroups.listRuleInstances('group-uuid', {
   limit: 20,
 });
 
+// Filter by security rule UUID
+const filtered = await client.securityGroups.listRuleInstances('group-uuid', {
+  security_rule_uuid: 'rule-uuid',
+});
+
+// Filter by state
+const blocking = await client.securityGroups.listRuleInstances('group-uuid', {
+  state: 'BLOCKING',
+});
+
 // Get a single rule instance
 const instance = await client.securityGroups.getRuleInstance('group-uuid', 'rule-instance-uuid');
 
 // Update a rule instance
 const updated = await client.securityGroups.updateRuleInstance('group-uuid', 'rule-instance-uuid', {
-  enabled: true,
+  security_group_uuid: 'group-uuid',
+  state: 'ALLOWING',
 });
 ```
 
@@ -236,6 +260,16 @@ Read-only access to available security rules on the management plane.
 const rules = await client.securityRules.list({
   skip: 0,
   limit: 20,
+});
+
+// Filter by source type
+const hfRules = await client.securityRules.list({
+  source_type: 'HUGGING_FACE',
+});
+
+// Search by name or UUID
+const found = await client.securityRules.list({
+  search_query: 'pickle',
 });
 ```
 

--- a/examples/model-security-scans.ts
+++ b/examples/model-security-scans.ts
@@ -41,19 +41,59 @@ async function main() {
 
     // --- LIST SECURITY GROUPS ---
     console.log('\nListing security groups...');
-    const groups = await client.securityGroups.list();
+    const groups = await client.securityGroups.list({
+      limit: 10,
+      sort_field: 'created_at',
+      sort_dir: 'desc',
+    });
     console.log(`Found ${groups.pagination?.total_items ?? 0} security groups:`);
     for (const g of groups.security_groups) {
       console.log(`  - ${g.uuid}: ${g.name} [${g.state}]`);
     }
 
+    // --- LIST GROUPS WITH SOURCE TYPE FILTER ---
+    console.log('\nListing Hugging Face security groups...');
+    const hfGroups = await client.securityGroups.list({
+      source_types: ['HUGGING_FACE'],
+    });
+    console.log(`Found ${hfGroups.pagination?.total_items ?? 0} HF groups`);
+
+    // --- LIST RULE INSTANCES FOR A GROUP ---
+    if (groups.security_groups.length) {
+      const groupId = groups.security_groups[0].uuid;
+      console.log(`\nListing rule instances for group ${groupId}...`);
+      const instances = await client.securityGroups.listRuleInstances(groupId, {
+        limit: 20,
+      });
+      console.log(`  Found ${instances.pagination?.total_items ?? 0} rule instances`);
+      for (const ri of instances.rule_instances) {
+        console.log(`    - ${ri.uuid}: ${ri.rule.name} [${ri.state}]`);
+      }
+
+      // Filter by state
+      const blocking = await client.securityGroups.listRuleInstances(groupId, {
+        state: 'BLOCKING',
+      });
+      console.log(`  Blocking instances: ${blocking.rule_instances.length}`);
+    }
+
     // --- LIST SECURITY RULES ---
     console.log('\nListing security rules...');
-    const rules = await client.securityRules.list();
+    const rules = await client.securityRules.list({ limit: 20 });
     console.log(`Found ${rules.pagination?.total_items ?? 0} security rules:`);
     for (const r of rules.rules) {
-      console.log(`  - ${r.uuid}: ${r.name} [${r.type}]`);
+      console.log(`  - ${r.uuid}: ${r.name} [${r.rule_type}]`);
     }
+
+    // --- LIST RULES WITH SOURCE TYPE FILTER ---
+    console.log('\nListing Hugging Face rules...');
+    const hfRules = await client.securityRules.list({ source_type: 'HUGGING_FACE' });
+    console.log(`Found ${hfRules.pagination?.total_items ?? 0} HF rules`);
+
+    // --- SEARCH RULES ---
+    console.log('\nSearching rules for "pickle"...');
+    const pickleRules = await client.securityRules.list({ search_query: 'pickle' });
+    console.log(`Found ${pickleRules.pagination?.total_items ?? 0} matching rules`);
   } catch (error) {
     if (error instanceof AISecSDKException) {
       console.error('Error:', error.message);

--- a/src/management/management-http-client.ts
+++ b/src/management/management-http-client.ts
@@ -8,7 +8,7 @@ export interface MgmtHttpRequestOptions {
   baseUrl: string;
   path: string;
   body?: unknown;
-  params?: Record<string, string>;
+  params?: Record<string, string | string[]>;
   oauthClient: OAuthClient;
   numRetries: number;
 }
@@ -34,7 +34,13 @@ export async function managementHttpRequest<T>(
 
       if (params) {
         for (const [key, value] of Object.entries(params)) {
-          url.searchParams.set(key, value);
+          if (Array.isArray(value)) {
+            for (const v of value) {
+              url.searchParams.append(key, v);
+            }
+          } else {
+            url.searchParams.set(key, value);
+          }
         }
       }
 

--- a/src/model-security/index.ts
+++ b/src/model-security/index.ts
@@ -5,5 +5,12 @@ export {
   type ModelSecurityScanListOptions,
   type ModelSecurityFileListOptions,
 } from './scans-client.js';
-export { ModelSecurityGroupsClient } from './security-groups-client.js';
-export { ModelSecurityRulesClient } from './security-rules-client.js';
+export {
+  ModelSecurityGroupsClient,
+  type ModelSecurityGroupListOptions,
+  type ModelSecurityRuleInstanceListOptions,
+} from './security-groups-client.js';
+export {
+  ModelSecurityRulesClient,
+  type ModelSecurityRuleListOptions,
+} from './security-rules-client.js';

--- a/src/model-security/security-groups-client.ts
+++ b/src/model-security/security-groups-client.ts
@@ -3,7 +3,6 @@ import { AISecSDKException, ErrorType } from '../errors.js';
 import { isValidUuid } from '../utils.js';
 import { managementHttpRequest } from '../management/management-http-client.js';
 import type { OAuthClient } from '../management/oauth-client.js';
-import type { ModelSecurityListOptions } from './scans-client.js';
 import type {
   ModelSecurityGroupCreateRequest,
   ModelSecurityGroupResponse,
@@ -14,6 +13,36 @@ import type {
   ListModelSecurityRuleInstancesResponse,
 } from '../models/model-security.js';
 
+/** Options for listing security groups. */
+export interface ModelSecurityGroupListOptions {
+  /** Number of items to skip. */
+  skip?: number;
+  /** Maximum number of items to return (1-100). */
+  limit?: number;
+  /** Field to sort by: 'created_at' or 'updated_at'. */
+  sort_field?: string;
+  /** Sort direction: 'asc' or 'desc'. */
+  sort_dir?: string;
+  /** Filter by source types. */
+  source_types?: string[];
+  /** Search term (matches UUID or Name, 3-1000 chars). */
+  search_query?: string;
+  /** Filter by rule UUIDs with ALLOWING or BLOCKING state. */
+  enabled_rules?: string[];
+}
+
+/** Options for listing rule instances within a security group. */
+export interface ModelSecurityRuleInstanceListOptions {
+  /** Number of items to skip. */
+  skip?: number;
+  /** Maximum number of items to return. */
+  limit?: number;
+  /** Filter by security rule UUID. */
+  security_rule_uuid?: string;
+  /** Filter by rule state: 'DISABLED', 'ALLOWING', or 'BLOCKING'. */
+  state?: string;
+}
+
 /** @internal */
 export interface ModelSecurityGroupsClientOptions {
   baseUrl: string;
@@ -21,14 +50,30 @@ export interface ModelSecurityGroupsClientOptions {
   numRetries: number;
 }
 
-/** Build query params from list options. */
-function buildListParams(opts?: ModelSecurityListOptions): Record<string, string> {
+/** Build query params for security group list. */
+function buildGroupListParams(
+  opts?: ModelSecurityGroupListOptions,
+): Record<string, string | string[]> {
+  const params: Record<string, string | string[]> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.sort_field !== undefined) params.sort_field = opts.sort_field;
+  if (opts?.sort_dir !== undefined) params.sort_dir = opts.sort_dir;
+  if (opts?.source_types !== undefined) params.source_types = opts.source_types;
+  if (opts?.search_query !== undefined) params.search_query = opts.search_query;
+  if (opts?.enabled_rules !== undefined) params.enabled_rules = opts.enabled_rules;
+  return params;
+}
+
+/** Build query params for rule instance list. */
+function buildRuleInstanceListParams(
+  opts?: ModelSecurityRuleInstanceListOptions,
+): Record<string, string> {
   const params: Record<string, string> = {};
   if (opts?.skip !== undefined) params.skip = String(opts.skip);
   if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
-  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
-  if (opts?.search !== undefined) params.search = opts.search;
+  if (opts?.security_rule_uuid !== undefined) params.security_rule_uuid = opts.security_rule_uuid;
+  if (opts?.state !== undefined) params.state = opts.state;
   return params;
 }
 
@@ -66,12 +111,12 @@ export class ModelSecurityGroupsClient {
    * @param opts - Pagination and filter options.
    * @returns Paginated list of security groups.
    */
-  async list(opts?: ModelSecurityListOptions): Promise<ListModelSecurityGroupsResponse> {
+  async list(opts?: ModelSecurityGroupListOptions): Promise<ListModelSecurityGroupsResponse> {
     const res = await managementHttpRequest<ListModelSecurityGroupsResponse>({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: MODEL_SEC_SECURITY_GROUPS_PATH,
-      params: buildListParams(opts),
+      params: buildGroupListParams(opts),
       oauthClient: this.oauthClient,
       numRetries: this.numRetries,
     });
@@ -158,7 +203,7 @@ export class ModelSecurityGroupsClient {
    */
   async listRuleInstances(
     securityGroupUuid: string,
-    opts?: ModelSecurityListOptions,
+    opts?: ModelSecurityRuleInstanceListOptions,
   ): Promise<ListModelSecurityRuleInstancesResponse> {
     if (!isValidUuid(securityGroupUuid)) {
       throw new AISecSDKException(
@@ -171,7 +216,7 @@ export class ModelSecurityGroupsClient {
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${securityGroupUuid}/rule-instances`,
-      params: buildListParams(opts),
+      params: buildRuleInstanceListParams(opts),
       oauthClient: this.oauthClient,
       numRetries: this.numRetries,
     });

--- a/src/model-security/security-rules-client.ts
+++ b/src/model-security/security-rules-client.ts
@@ -3,11 +3,22 @@ import { AISecSDKException, ErrorType } from '../errors.js';
 import { isValidUuid } from '../utils.js';
 import { managementHttpRequest } from '../management/management-http-client.js';
 import type { OAuthClient } from '../management/oauth-client.js';
-import type { ModelSecurityListOptions } from './scans-client.js';
 import type {
   ListModelSecurityRulesResponse,
   ModelSecurityRuleResponse,
 } from '../models/model-security.js';
+
+/** Options for listing security rules. */
+export interface ModelSecurityRuleListOptions {
+  /** Number of items to skip. */
+  skip?: number;
+  /** Maximum number of items to return. */
+  limit?: number;
+  /** Filter by source type. */
+  source_type?: string;
+  /** Search term (matches UUID or Name, 3-1000 chars). */
+  search_query?: string;
+}
 
 /** @internal */
 export interface ModelSecurityRulesClientOptions {
@@ -16,14 +27,13 @@ export interface ModelSecurityRulesClientOptions {
   numRetries: number;
 }
 
-/** Build query params from list options. */
-function buildListParams(opts?: ModelSecurityListOptions): Record<string, string> {
+/** Build query params for security rules list. */
+function buildRuleListParams(opts?: ModelSecurityRuleListOptions): Record<string, string> {
   const params: Record<string, string> = {};
   if (opts?.skip !== undefined) params.skip = String(opts.skip);
   if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
-  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
-  if (opts?.search !== undefined) params.search = opts.search;
+  if (opts?.source_type !== undefined) params.source_type = opts.source_type;
+  if (opts?.search_query !== undefined) params.search_query = opts.search_query;
   return params;
 }
 
@@ -44,12 +54,12 @@ export class ModelSecurityRulesClient {
    * @param opts - Pagination options.
    * @returns Paginated list of security rules.
    */
-  async list(opts?: ModelSecurityListOptions): Promise<ListModelSecurityRulesResponse> {
+  async list(opts?: ModelSecurityRuleListOptions): Promise<ListModelSecurityRulesResponse> {
     const res = await managementHttpRequest<ListModelSecurityRulesResponse>({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: MODEL_SEC_SECURITY_RULES_PATH,
-      params: buildListParams(opts),
+      params: buildRuleListParams(opts),
       oauthClient: this.oauthClient,
       numRetries: this.numRetries,
     });

--- a/test/model-security/security-groups-client.spec.ts
+++ b/test/model-security/security-groups-client.spec.ts
@@ -102,6 +102,44 @@ describe('ModelSecurityGroupsClient', () => {
       expect(url).toContain('skip=5');
       expect(url).toContain('limit=10');
     });
+
+    it('sends sort_field and sort_dir params per spec', async () => {
+      mockFetch({ pagination: { total_items: 0 }, security_groups: [] });
+      await client.list({ sort_field: 'created_at', sort_dir: 'desc' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('sort_field=created_at');
+      expect(url).toContain('sort_dir=desc');
+      expect(url).not.toContain('sort_by');
+      expect(url).not.toContain('sort_direction');
+    });
+
+    it('sends search_query param per spec', async () => {
+      mockFetch({ pagination: { total_items: 0 }, security_groups: [] });
+      await client.list({ search_query: 'production' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('search_query=production');
+      expect(url).not.toContain('search=production');
+    });
+
+    it('sends source_types as repeated query params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, security_groups: [] });
+      await client.list({ source_types: ['LOCAL', 'HUGGING_FACE'] });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('source_types=LOCAL');
+      expect(url).toContain('source_types=HUGGING_FACE');
+    });
+
+    it('sends enabled_rules as repeated query params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, security_groups: [] });
+      await client.list({ enabled_rules: [validUuid, validUuid2] });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`enabled_rules=${encodeURIComponent(validUuid)}`);
+      expect(url).toContain(`enabled_rules=${encodeURIComponent(validUuid2)}`);
+    });
   });
 
   describe('get', () => {
@@ -166,6 +204,34 @@ describe('ModelSecurityGroupsClient', () => {
 
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('limit=20');
+    });
+
+    it('sends security_rule_uuid filter', async () => {
+      mockFetch({ pagination: { total_items: 0 }, rule_instances: [] });
+      await client.listRuleInstances(validUuid, { security_rule_uuid: validUuid2 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain(`security_rule_uuid=${encodeURIComponent(validUuid2)}`);
+    });
+
+    it('sends state filter', async () => {
+      mockFetch({ pagination: { total_items: 0 }, rule_instances: [] });
+      await client.listRuleInstances(validUuid, { state: 'BLOCKING' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('state=BLOCKING');
+    });
+
+    it('does not send sort or search params', async () => {
+      mockFetch({ pagination: { total_items: 0 }, rule_instances: [] });
+      await client.listRuleInstances(validUuid, { skip: 0, limit: 10 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).not.toContain('sort_by');
+      expect(url).not.toContain('sort_field');
+      expect(url).not.toContain('sort_direction');
+      expect(url).not.toContain('sort_dir');
+      expect(url).not.toContain('search');
     });
 
     it('rejects invalid UUID', async () => {

--- a/test/model-security/security-rules-client.spec.ts
+++ b/test/model-security/security-rules-client.spec.ts
@@ -62,20 +62,38 @@ describe('ModelSecurityRulesClient', () => {
 
     it('passes pagination params', async () => {
       mockFetch({ pagination: { total_items: 0 }, rules: [] });
-      await client.list({ skip: 0, limit: 25, sort_by: 'created_at', sort_direction: 'asc' });
+      await client.list({ skip: 0, limit: 25 });
 
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('limit=25');
-      expect(url).toContain('sort_by=created_at');
-      expect(url).toContain('sort_direction=asc');
     });
 
-    it('passes search param', async () => {
+    it('sends search_query param per spec', async () => {
       mockFetch({ pagination: { total_items: 0 }, rules: [] });
-      await client.list({ search: 'pickle' });
+      await client.list({ search_query: 'pickle' });
 
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(url).toContain('search=pickle');
+      expect(url).toContain('search_query=pickle');
+      expect(url).not.toContain('search=pickle');
+    });
+
+    it('sends source_type filter', async () => {
+      mockFetch({ pagination: { total_items: 0 }, rules: [] });
+      await client.list({ source_type: 'HUGGING_FACE' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('source_type=HUGGING_FACE');
+    });
+
+    it('does not send sort params (not in spec)', async () => {
+      mockFetch({ pagination: { total_items: 0 }, rules: [] });
+      await client.list({ skip: 0, limit: 10 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).not.toContain('sort_by');
+      expect(url).not.toContain('sort_field');
+      expect(url).not.toContain('sort_direction');
+      expect(url).not.toContain('sort_dir');
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix query param names for management plane list endpoints to match `AIRS-Model-Security-Management.yaml` OpenAPI spec
- Add missing `source_types` and `enabled_rules` filters to security groups `list()`
- Add missing `source_type` filter to security rules `list()`
- Add missing `security_rule_uuid` and `state` filters to rule instances `listRuleInstances()`
- Support array query params in management HTTP client
- Create dedicated options interfaces: `ModelSecurityGroupListOptions`, `ModelSecurityRuleListOptions`, `ModelSecurityRuleInstanceListOptions`

## Test plan
- [x] 661 tests passing (32 model-security mgmt tests including 9 new)
- [x] Typecheck, lint, format all pass
- [x] Docs updated with new param names and filter examples
- [x] E2E example updated to demonstrate new filters

Closes #27, closes #28, closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)