### PR TITLE
fix: align Red Team API params with OpenAPI spec (#37)

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -409,8 +409,6 @@ Data plane scan/job operations.
 interface RedTeamListOptions {
   skip?: number;
   limit?: number;
-  sort_by?: string;
-  sort_direction?: string;
   search?: string;
 }
 
@@ -496,7 +494,6 @@ Management plane target operations.
 interface TargetListOptions extends RedTeamListOptions {
   target_type?: string;
   status?: string;
-  active?: boolean;
 }
 
 interface TargetOperationOptions {
@@ -515,7 +512,7 @@ class RedTeamTargetsClient {
   delete(uuid: string): Promise<BaseResponse>;
   probe(request: TargetProbeRequest): Promise<TargetResponse>;
   getProfile(uuid: string): Promise<TargetProfileResponse>;
-  updateProfile(uuid: string, request: TargetContextUpdate): Promise<TargetProfileResponse>;
+  updateProfile(uuid: string, request: TargetContextUpdate): Promise<TargetResponse>;
 }
 ```
 
@@ -525,6 +522,7 @@ Management plane custom attack/prompt set operations.
 
 ```ts
 interface PromptSetListOptions extends RedTeamListOptions {
+  status?: string;
   active?: boolean;
   archive?: boolean;
 }

--- a/src/red-team/client.ts
+++ b/src/red-team/client.ts
@@ -60,8 +60,6 @@ function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
   const params: Record<string, string> = {};
   if (opts?.skip !== undefined) params.skip = String(opts.skip);
   if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
-  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
   if (opts?.search !== undefined) params.search = opts.search;
   return params;
 }

--- a/src/red-team/custom-attack-reports-client.ts
+++ b/src/red-team/custom-attack-reports-client.ts
@@ -23,8 +23,6 @@ function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
   const params: Record<string, string> = {};
   if (opts?.skip !== undefined) params.skip = String(opts.skip);
   if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
-  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
   if (opts?.search !== undefined) params.search = opts.search;
   return params;
 }

--- a/src/red-team/custom-attacks-client.ts
+++ b/src/red-team/custom-attacks-client.ts
@@ -27,6 +27,7 @@ import type {
 
 /** Prompt set list filter options. */
 export interface PromptSetListOptions extends RedTeamListOptions {
+  status?: string;
   active?: boolean;
   archive?: boolean;
 }
@@ -47,8 +48,6 @@ function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
   const params: Record<string, string> = {};
   if (opts?.skip !== undefined) params.skip = String(opts.skip);
   if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
-  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
   if (opts?.search !== undefined) params.search = opts.search;
   return params;
 }
@@ -91,6 +90,7 @@ export class RedTeamCustomAttacksClient {
   /** List custom prompt sets. */
   async listPromptSets(opts?: PromptSetListOptions): Promise<CustomPromptSetList> {
     const params = buildListParams(opts);
+    if (opts?.status !== undefined) params.status = opts.status;
     if (opts?.active !== undefined) params.active = String(opts.active);
     if (opts?.archive !== undefined) params.archive = String(opts.archive);
 

--- a/src/red-team/reports-client.ts
+++ b/src/red-team/reports-client.ts
@@ -45,8 +45,6 @@ function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
   const params: Record<string, string> = {};
   if (opts?.skip !== undefined) params.skip = String(opts.skip);
   if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
-  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
   if (opts?.search !== undefined) params.search = opts.search;
   return params;
 }

--- a/src/red-team/scans-client.ts
+++ b/src/red-team/scans-client.ts
@@ -15,8 +15,6 @@ import type {
 export interface RedTeamListOptions {
   skip?: number;
   limit?: number;
-  sort_by?: string;
-  sort_direction?: string;
   search?: string;
 }
 
@@ -38,8 +36,6 @@ function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
   const params: Record<string, string> = {};
   if (opts?.skip !== undefined) params.skip = String(opts.skip);
   if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
-  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
   if (opts?.search !== undefined) params.search = opts.search;
   return params;
 }

--- a/src/red-team/targets-client.ts
+++ b/src/red-team/targets-client.ts
@@ -19,7 +19,6 @@ import type {
 export interface TargetListOptions extends RedTeamListOptions {
   target_type?: string;
   status?: string;
-  active?: boolean;
 }
 
 /** Options for target create/update operations. */
@@ -39,8 +38,6 @@ function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
   const params: Record<string, string> = {};
   if (opts?.skip !== undefined) params.skip = String(opts.skip);
   if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
-  if (opts?.sort_direction !== undefined) params.sort_direction = opts.sort_direction;
   if (opts?.search !== undefined) params.search = opts.search;
   return params;
 }
@@ -82,7 +79,6 @@ export class RedTeamTargetsClient {
     const params = buildListParams(opts);
     if (opts?.target_type !== undefined) params.target_type = opts.target_type;
     if (opts?.status !== undefined) params.status = opts.status;
-    if (opts?.active !== undefined) params.active = String(opts.active);
 
     const res = await managementHttpRequest<TargetList>({
       method: 'GET',
@@ -194,7 +190,7 @@ export class RedTeamTargetsClient {
   }
 
   /** Update a target profile (background + additional context). */
-  async updateProfile(uuid: string, request: TargetContextUpdate): Promise<TargetProfileResponse> {
+  async updateProfile(uuid: string, request: TargetContextUpdate): Promise<TargetResponse> {
     if (!isValidUuid(uuid)) {
       throw new AISecSDKException(
         `Invalid target uuid: ${uuid}`,
@@ -202,7 +198,7 @@ export class RedTeamTargetsClient {
       );
     }
 
-    const res = await managementHttpRequest<TargetProfileResponse>({
+    const res = await managementHttpRequest<TargetResponse>({
       method: 'PUT',
       baseUrl: this.baseUrl,
       path: `${RED_TEAM_TARGET_PATH}/${uuid}/profile`,

--- a/test/red-team/custom-attacks-client.spec.ts
+++ b/test/red-team/custom-attacks-client.spec.ts
@@ -66,11 +66,21 @@ describe('RedTeamCustomAttacksClient', () => {
 
     it('passes filter params', async () => {
       mockFetch({ prompt_sets: [], total: 0 });
-      await client.listPromptSets({ active: true, archive: false });
+      await client.listPromptSets({ active: true, archive: false, status: 'READY' });
 
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('active=true');
       expect(url).toContain('archive=false');
+      expect(url).toContain('status=READY');
+    });
+
+    it('does not send sort params (not in spec)', async () => {
+      mockFetch({ prompt_sets: [], total: 0 });
+      await client.listPromptSets({ skip: 0 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).not.toContain('sort_by');
+      expect(url).not.toContain('sort_direction');
     });
   });
 

--- a/test/red-team/targets-client.spec.ts
+++ b/test/red-team/targets-client.spec.ts
@@ -91,12 +91,11 @@ describe('RedTeamTargetsClient', () => {
 
     it('passes filter params', async () => {
       mockFetch({ targets: [], total: 0 });
-      await client.list({ target_type: 'API', status: 'ACTIVE', active: true });
+      await client.list({ target_type: 'API', status: 'ACTIVE' });
 
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('target_type=API');
       expect(url).toContain('status=ACTIVE');
-      expect(url).toContain('active=true');
     });
 
     it('passes pagination params', async () => {
@@ -106,6 +105,15 @@ describe('RedTeamTargetsClient', () => {
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('skip=5');
       expect(url).toContain('limit=10');
+    });
+
+    it('does not send sort params (not in spec)', async () => {
+      mockFetch({ targets: [], total: 0 });
+      await client.list({ skip: 0 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).not.toContain('sort_by');
+      expect(url).not.toContain('sort_direction');
     });
   });
 
@@ -221,11 +229,12 @@ describe('RedTeamTargetsClient', () => {
   // updateProfile
   // -----------------------------------------------------------------------
   describe('updateProfile', () => {
-    it('PUTs to /v1/target/:uuid/profile', async () => {
-      mockFetch({ target_id: validUuid, background: 'updated' });
+    it('PUTs to /v1/target/:uuid/profile and returns TargetResponse', async () => {
+      mockFetch({ uuid: validUuid, name: 'my-target', target_type: 'API' });
       const result = await client.updateProfile(validUuid, { background: 'updated' });
 
-      expect(result.background).toBe('updated');
+      expect(result.uuid).toBe(validUuid);
+      expect(result.name).toBe('my-target');
       const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain(`/v1/target/${validUuid}/profile`);
       expect(init.method).toBe('PUT');


### PR DESCRIPTION
## Summary
- Remove `sort_by`/`sort_direction` from `RedTeamListOptions` — not in any Red Team OpenAPI spec
- Remove `active` filter from `TargetListOptions` — not in management spec
- Add `status` filter to `PromptSetListOptions` — present in spec but was missing
- Change `updateProfile` return type from `TargetProfileResponse` to `TargetResponse` — spec returns `TargetSchema`

## Testing
- 663 tests pass (2 new tests added for sort param removal and status filter)
- All quality gates pass (lint, format, typecheck)

## Checklist
- [x] Tests written first (TDD)
- [x] All tests passing
- [x] Linting clean
- [x] Formatting clean
- [x] Type checking clean
- [x] Documentation updated

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)