### PR TITLE
feat: align Red Team Data Plane with OpenAPI spec (#36)

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -437,10 +437,14 @@ interface AttackListOptions extends RedTeamListOptions {
   severity?: string;
   category?: string;
   sub_category?: string;
+  attack_type?: string;
+  threat?: boolean;
 }
 
 interface GoalListOptions extends RedTeamListOptions {
   goal_type?: string;
+  status?: string;
+  count?: boolean;
 }
 
 class RedTeamReportsClient {
@@ -465,7 +469,7 @@ class RedTeamReportsClient {
 
   // Common
   getStreamDetail(streamId: string): Promise<StreamDetailResponse>;
-  downloadReport(jobId: string, format?: string): Promise<unknown>;
+  downloadReport(jobId: string, format: string): Promise<unknown>;
   generatePartialReport(jobId: string): Promise<unknown>;
 }
 ```
@@ -475,13 +479,30 @@ class RedTeamReportsClient {
 Data plane custom attack report operations.
 
 ```ts
+interface PromptsBySetListOptions extends RedTeamListOptions {
+  is_threat?: boolean;
+}
+
+interface CustomAttacksReportListOptions extends RedTeamListOptions {
+  threat?: boolean;
+  prompt_set_id?: string;
+  property_value?: string;
+}
+
 class RedTeamCustomAttackReportsClient {
   getReport(jobId: string): Promise<CustomAttackReportResponse>;
   getPromptSets(jobId: string): Promise<PromptSetsReportResponse>;
-  getPromptsBySet(jobId: string, promptSetId: string, opts?: RedTeamListOptions): Promise<unknown>;
+  getPromptsBySet(
+    jobId: string,
+    promptSetId: string,
+    opts?: PromptsBySetListOptions,
+  ): Promise<PromptDetailResponse[]>;
   getPromptDetail(jobId: string, promptId: string): Promise<PromptDetailResponse>;
-  listCustomAttacks(jobId: string, opts?: RedTeamListOptions): Promise<CustomAttacksListResponse>;
-  getAttackOutputs(jobId: string, attackId: string): Promise<unknown>;
+  listCustomAttacks(
+    jobId: string,
+    opts?: CustomAttacksReportListOptions,
+  ): Promise<CustomAttacksListResponse>;
+  getAttackOutputs(jobId: string, attackId: string): Promise<CustomAttackOutput[]>;
   getPropertyStats(jobId: string): Promise<PropertyStatistic[]>;
 }
 ```

--- a/src/red-team/custom-attack-reports-client.ts
+++ b/src/red-team/custom-attack-reports-client.ts
@@ -9,8 +9,21 @@ import type {
   PromptSetsReportResponse,
   PromptDetailResponse,
   CustomAttacksListResponse,
+  CustomAttackOutput,
   PropertyStatistic,
 } from '../models/red-team.js';
+
+/** Filter options for listing prompts by set in a report. */
+export interface PromptsBySetListOptions extends RedTeamListOptions {
+  is_threat?: boolean;
+}
+
+/** Filter options for listing custom attacks in a report. */
+export interface CustomAttacksReportListOptions extends RedTeamListOptions {
+  threat?: boolean;
+  prompt_set_id?: string;
+  property_value?: string;
+}
 
 /** @internal */
 export interface RedTeamCustomAttackReportsClientOptions {
@@ -75,8 +88,8 @@ export class RedTeamCustomAttackReportsClient {
   async getPromptsBySet(
     jobId: string,
     promptSetId: string,
-    opts?: RedTeamListOptions,
-  ): Promise<unknown> {
+    opts?: PromptsBySetListOptions,
+  ): Promise<PromptDetailResponse[]> {
     validateJobId(jobId);
     if (!isValidUuid(promptSetId)) {
       throw new AISecSDKException(
@@ -85,11 +98,14 @@ export class RedTeamCustomAttackReportsClient {
       );
     }
 
-    const res = await managementHttpRequest<unknown>({
+    const params = buildListParams(opts);
+    if (opts?.is_threat !== undefined) params.is_threat = String(opts.is_threat);
+
+    const res = await managementHttpRequest<PromptDetailResponse[]>({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH}/report/${jobId}/prompt-set/${promptSetId}/prompts`,
-      params: buildListParams(opts),
+      params,
       oauthClient: this.oauthClient,
       numRetries: this.numRetries,
     });
@@ -119,14 +135,19 @@ export class RedTeamCustomAttackReportsClient {
   /** List custom attacks for a scan. */
   async listCustomAttacks(
     jobId: string,
-    opts?: RedTeamListOptions,
+    opts?: CustomAttacksReportListOptions,
   ): Promise<CustomAttacksListResponse> {
     validateJobId(jobId);
+    const params = buildListParams(opts);
+    if (opts?.threat !== undefined) params.threat = String(opts.threat);
+    if (opts?.prompt_set_id !== undefined) params.prompt_set_id = opts.prompt_set_id;
+    if (opts?.property_value !== undefined) params.property_value = opts.property_value;
+
     const res = await managementHttpRequest<CustomAttacksListResponse>({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH}/job/${jobId}/list-custom-attacks`,
-      params: buildListParams(opts),
+      params,
       oauthClient: this.oauthClient,
       numRetries: this.numRetries,
     });
@@ -134,7 +155,7 @@ export class RedTeamCustomAttackReportsClient {
   }
 
   /** Get attack outputs for a custom attack. */
-  async getAttackOutputs(jobId: string, attackId: string): Promise<unknown> {
+  async getAttackOutputs(jobId: string, attackId: string): Promise<CustomAttackOutput[]> {
     validateJobId(jobId);
     if (!isValidUuid(attackId)) {
       throw new AISecSDKException(
@@ -143,7 +164,7 @@ export class RedTeamCustomAttackReportsClient {
       );
     }
 
-    const res = await managementHttpRequest<unknown>({
+    const res = await managementHttpRequest<CustomAttackOutput[]>({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH}/job/${jobId}/attack/${attackId}/list-outputs`,

--- a/src/red-team/index.ts
+++ b/src/red-team/index.ts
@@ -9,7 +9,11 @@ export {
   type AttackListOptions,
   type GoalListOptions,
 } from './reports-client.js';
-export { RedTeamCustomAttackReportsClient } from './custom-attack-reports-client.js';
+export {
+  RedTeamCustomAttackReportsClient,
+  type PromptsBySetListOptions,
+  type CustomAttacksReportListOptions,
+} from './custom-attack-reports-client.js';
 export {
   RedTeamTargetsClient,
   type TargetListOptions,

--- a/src/red-team/reports-client.ts
+++ b/src/red-team/reports-client.ts
@@ -27,11 +27,15 @@ export interface AttackListOptions extends RedTeamListOptions {
   severity?: string;
   category?: string;
   sub_category?: string;
+  attack_type?: string;
+  threat?: boolean;
 }
 
 /** Goal list filter options. */
 export interface GoalListOptions extends RedTeamListOptions {
   goal_type?: string;
+  status?: string;
+  count?: boolean;
 }
 
 /** @internal */
@@ -79,6 +83,8 @@ export class RedTeamReportsClient {
     if (opts?.severity !== undefined) params.severity = opts.severity;
     if (opts?.category !== undefined) params.category = opts.category;
     if (opts?.sub_category !== undefined) params.sub_category = opts.sub_category;
+    if (opts?.attack_type !== undefined) params.attack_type = opts.attack_type;
+    if (opts?.threat !== undefined) params.threat = String(opts.threat);
 
     const res = await managementHttpRequest<AttackListResponse>({
       method: 'GET',
@@ -221,6 +227,8 @@ export class RedTeamReportsClient {
     validateJobId(jobId);
     const params = buildListParams(opts);
     if (opts?.goal_type !== undefined) params.goal_type = opts.goal_type;
+    if (opts?.status !== undefined) params.status = opts.status;
+    if (opts?.count !== undefined) params.count = String(opts.count);
 
     const res = await managementHttpRequest<GoalListResponse>({
       method: 'GET',
@@ -282,10 +290,9 @@ export class RedTeamReportsClient {
   }
 
   /** Download a report in the specified format. */
-  async downloadReport(jobId: string, format?: string): Promise<unknown> {
+  async downloadReport(jobId: string, format: string): Promise<unknown> {
     validateJobId(jobId);
-    const params: Record<string, string> = {};
-    if (format !== undefined) params.file_format = format;
+    const params: Record<string, string> = { file_format: format };
 
     const res = await managementHttpRequest<unknown>({
       method: 'GET',

--- a/test/red-team/custom-attack-reports-client.spec.ts
+++ b/test/red-team/custom-attack-reports-client.spec.ts
@@ -95,6 +95,14 @@ describe('RedTeamCustomAttackReportsClient', () => {
     it('rejects invalid prompt set UUID', async () => {
       await expect(client.getPromptsBySet(validUuid, 'bad')).rejects.toThrow(AISecSDKException);
     });
+
+    it('passes is_threat filter', async () => {
+      mockFetch([]);
+      await client.getPromptsBySet(validUuid, validUuid2, { is_threat: true });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('is_threat=true');
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -130,6 +138,20 @@ describe('RedTeamCustomAttackReportsClient', () => {
       expect(result.attacks).toEqual([]);
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain(`/v1/custom-attacks/job/${validUuid}/list-custom-attacks`);
+    });
+
+    it('passes filter params', async () => {
+      mockFetch({ attacks: [], total: 0 });
+      await client.listCustomAttacks(validUuid, {
+        threat: true,
+        prompt_set_id: validUuid2,
+        property_value: '{"severity":"HIGH"}',
+      });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('threat=true');
+      expect(url).toContain(`prompt_set_id=${validUuid2}`);
+      expect(url).toContain('property_value=');
     });
 
     it('rejects invalid UUID', async () => {

--- a/test/red-team/reports-client.spec.ts
+++ b/test/red-team/reports-client.spec.ts
@@ -53,11 +53,18 @@ describe('RedTeamReportsClient', () => {
 
     it('passes filter params', async () => {
       mockFetch({ attacks: [], total: 0 });
-      await client.listAttacks(validUuid, { status: 'FAILED', severity: 'HIGH' });
+      await client.listAttacks(validUuid, {
+        status: 'FAILED',
+        severity: 'HIGH',
+        attack_type: 'JAILBREAK',
+        threat: true,
+      });
 
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('status=FAILED');
       expect(url).toContain('severity=HIGH');
+      expect(url).toContain('attack_type=JAILBREAK');
+      expect(url).toContain('threat=true');
     });
 
     it('rejects invalid UUID', async () => {
@@ -213,10 +220,16 @@ describe('RedTeamReportsClient', () => {
 
     it('passes goal_type filter', async () => {
       mockFetch({ goals: [], total: 0 });
-      await client.listGoals(validUuid, { goal_type: 'JAILBREAK' });
+      await client.listGoals(validUuid, {
+        goal_type: 'JAILBREAK',
+        status: 'SUCCESSFUL',
+        count: false,
+      });
 
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('goal_type=JAILBREAK');
+      expect(url).toContain('status=SUCCESSFUL');
+      expect(url).toContain('count=false');
     });
 
     it('rejects invalid UUID', async () => {
@@ -263,25 +276,18 @@ describe('RedTeamReportsClient', () => {
   });
 
   describe('downloadReport', () => {
-    it('GETs /v1/report/:jobId/download', async () => {
-      mockFetch({ url: 'https://download.example.com/report.pdf' });
-      const result = await client.downloadReport(validUuid);
+    it('GETs /v1/report/:jobId/download with file_format', async () => {
+      mockFetch({ url: 'https://download.example.com/report.csv' });
+      const result = await client.downloadReport(validUuid, 'CSV');
 
       expect(result).toBeDefined();
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain(`/v1/report/${validUuid}/download`);
-    });
-
-    it('passes format param', async () => {
-      mockFetch({ url: 'https://download.example.com/report.csv' });
-      await client.downloadReport(validUuid, 'csv');
-
-      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(url).toContain('file_format=csv');
+      expect(url).toContain('file_format=CSV');
     });
 
     it('rejects invalid UUID', async () => {
-      await expect(client.downloadReport('bad')).rejects.toThrow(AISecSDKException);
+      await expect(client.downloadReport('bad', 'CSV')).rejects.toThrow(AISecSDKException);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add missing query param filters across 4 report endpoints (attack_type, threat, is_threat, status, count, prompt_set_id, property_value)
- Type `getPromptsBySet` return as `PromptDetailResponse[]` (was `unknown`)
- Type `getAttackOutputs` return as `CustomAttackOutput[]` (was `unknown`)
- Make `downloadReport` format parameter required (spec: `required: true`)
- Export new option types: `PromptsBySetListOptions`, `CustomAttacksReportListOptions`

## Testing
- 664 tests pass (2 new tests for filter params)
- All quality gates pass (lint, format, typecheck)

## Checklist
- [x] All tests passing
- [x] Linting clean
- [x] Formatting clean
- [x] Type checking clean
- [x] Documentation updated

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)