### PR TITLE
feat: align Management API with OpenAPI spec

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -95,6 +95,12 @@ class ManagementClient {
   constructor(opts?: ManagementClientOptions);
   readonly profiles: ProfilesClient;
   readonly topics: TopicsClient;
+  readonly apiKeys: ApiKeysClient;
+  readonly customerApps: CustomerAppsClient;
+  readonly dlpProfiles: DlpProfilesClient;
+  readonly deploymentProfiles: DeploymentProfilesClient;
+  readonly scanLogs: ScanLogsClient;
+  readonly oauth: OAuthManagementClient;
 }
 ```
 
@@ -143,6 +149,7 @@ class ProfilesClient {
   list(opts?: PaginationOptions): Promise<SecurityProfileListResponse>;
   update(profileId: string, request: CreateSecurityProfileRequest): Promise<SecurityProfile>;
   delete(profileId: string): Promise<DeleteProfileResponse>;
+  forceDelete(profileId: string, updatedBy: string): Promise<DeleteProfileResponse>;
 }
 ```
 
@@ -154,7 +161,81 @@ class TopicsClient {
   list(opts?: PaginationOptions): Promise<CustomTopicListResponse>;
   update(topicId: string, request: CreateCustomTopicRequest): Promise<CustomTopic>;
   delete(topicId: string): Promise<DeleteTopicResponse>;
-  forceDelete(topicId: string): Promise<DeleteTopicResponse>;
+  forceDelete(topicId: string, updatedBy?: string): Promise<DeleteTopicResponse>;
+}
+```
+
+### `ApiKeysClient`
+
+```ts
+class ApiKeysClient {
+  create(request: ApiKeyCreateRequest): Promise<ApiKey>;
+  list(opts?: PaginationOptions): Promise<ApiKeyListResponse>;
+  delete(apiKeyName: string, updatedBy: string): Promise<ApiKeyDeleteResponse>;
+  regenerate(apiKeyId: string, request: ApiKeyRegenerateRequest): Promise<ApiKey>;
+}
+```
+
+### `CustomerAppsClient`
+
+```ts
+class CustomerAppsClient {
+  get(appName: string): Promise<CustomerApp>;
+  list(opts?: PaginationOptions): Promise<CustomerAppListResponse>;
+  update(customerAppId: string, request: CustomerApp): Promise<CustomerApp>;
+  delete(appName: string, updatedBy: string): Promise<CustomerApp>;
+}
+```
+
+### `DlpProfilesClient`
+
+```ts
+class DlpProfilesClient {
+  list(): Promise<DlpProfileListResponse>;
+}
+```
+
+### `DeploymentProfilesClient`
+
+```ts
+interface DeploymentProfileListOptions {
+  unactivated?: boolean; // include unactivated profiles
+}
+
+class DeploymentProfilesClient {
+  list(opts?: DeploymentProfileListOptions): Promise<DeploymentProfilesResponse>;
+}
+```
+
+### `ScanLogsClient`
+
+```ts
+interface ScanLogQueryOptions {
+  time_interval: number; // time range value
+  time_unit: string; // e.g. 'hour', 'day'
+  pageNumber: number; // 1-based page number
+  pageSize: number; // records per page
+  filter: string; // 'all', 'benign', or 'threat'
+  page_token?: string; // encrypted pagination token
+}
+
+class ScanLogsClient {
+  query(opts: ScanLogQueryOptions): Promise<PaginatedScanResults>;
+}
+```
+
+### `OAuthManagementClient`
+
+```ts
+interface GetTokenOptions {
+  body: ClientIdAndCustomerApp;
+  tokenTtlInterval?: number;
+  tokenTtlUnit?: string;
+}
+
+class OAuthManagementClient {
+  invalidateToken(token: string, body: ClientIdAndCustomerApp): Promise<string>;
+  getAccessToken(opts: GetTokenOptions): Promise<Oauth2Token>;
 }
 ```
 
@@ -249,6 +330,149 @@ interface DeleteProfileConflict {
 interface DeleteTopicConflict {
   message: string;
   payload: { profile_id: string; profile_name: string; revision: number }[];
+}
+```
+
+#### API Key Types
+
+```ts
+interface ApiKey {
+  api_key_id?: string;
+  api_key_last8?: string;
+  auth_code?: string;
+  expiration?: string;
+  revoked?: boolean;
+  [key: string]: unknown;
+}
+
+interface ApiKeyCreateRequest {
+  auth_code: string;
+  cust_app: string;
+  revoked: boolean;
+  created_by: string;
+  api_key_name: string;
+  rotation_time_interval: number;
+  rotation_time_unit: string;
+  [key: string]: unknown;
+}
+
+interface ApiKeyRegenerateRequest {
+  rotation_time_interval: number;
+  rotation_time_unit: string;
+  [key: string]: unknown;
+}
+
+interface ApiKeyListResponse {
+  api_keys?: ApiKey[];
+  next_offset?: number;
+}
+
+interface ApiKeyDeleteResponse {
+  message?: string;
+  [key: string]: unknown;
+}
+```
+
+#### Customer App Types
+
+```ts
+interface CustomerApp {
+  tsg_id?: string;
+  app_name?: string;
+  cloud_provider?: string;
+  environment?: string;
+  [key: string]: unknown;
+}
+
+interface CustomerAppWithKeys {
+  customer_appId?: string;
+  tsg_id?: string;
+  app_name?: string;
+  cloud_provider?: string;
+  environment?: string;
+  api_keys_dp_info?: ApiKeyDPInfo[];
+  [key: string]: unknown;
+}
+
+interface CustomerAppListResponse {
+  customer_apps?: CustomerAppWithKeys[];
+  next_offset?: number;
+}
+```
+
+#### DLP Profile Types
+
+```ts
+interface DlpDataProfile {
+  name: string;
+  uuid: string;
+  rule1?: { action?: string; [key: string]: unknown };
+  rule2?: { action?: string; [key: string]: unknown };
+  'log-severity'?: string;
+  [key: string]: unknown;
+}
+
+interface DlpProfileListResponse {
+  dlp_profiles?: DlpDataProfile[];
+}
+```
+
+#### Deployment Profile Types
+
+```ts
+interface DeploymentProfileEntry {
+  dp_name?: string;
+  auth_code?: string;
+  [key: string]: unknown;
+}
+
+interface DeploymentProfilesResponse {
+  deployment_profiles?: DeploymentProfileEntry[];
+  [key: string]: unknown;
+}
+```
+
+#### Scan Log Types
+
+```ts
+interface ScanResultEntry {
+  csp_id?: string;
+  tsg_id?: string;
+  scan_id?: string;
+  scan_sub_req_id?: number;
+  api_key_name?: string;
+  app_name?: string;
+  tokens?: number;
+  text_records?: number;
+  verdict?: string;
+  action?: string;
+  // ... 30+ optional fields for detection verdicts, metadata
+  [key: string]: unknown;
+}
+
+interface PaginatedScanResults {
+  total_pages?: number;
+  page_number?: number;
+  page_size?: number;
+  page_token?: string;
+  scan_results?: ScanResultEntry[];
+  [key: string]: unknown;
+}
+```
+
+#### OAuth Types
+
+```ts
+interface ClientIdAndCustomerApp {
+  client_id: string;
+  customer_app: string;
+}
+
+interface Oauth2Token {
+  access_token: string;
+  expires_in?: string;
+  token_type?: string;
+  [key: string]: unknown;
 }
 ```
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -73,6 +73,15 @@ export const MGMT_PROFILES_TSG_PATH = '/v1/mgmt/profiles/tsg';
 export const MGMT_TOPIC_PATH = '/v1/mgmt/topic';
 export const MGMT_TOPICS_TSG_PATH = '/v1/mgmt/topics/tsg';
 export const MGMT_TOPIC_FORCE_PATH = '/v1/mgmt/topic/force';
+export const MGMT_API_KEY_PATH = '/v1/mgmt/apikey';
+export const MGMT_API_KEYS_TSG_PATH = '/v1/mgmt/apikeys/tsg';
+export const MGMT_DLP_PROFILES_PATH = '/v1/mgmt/dlpprofiles';
+export const MGMT_DEPLOYMENT_PROFILES_PATH = '/v1/mgmt/deploymentprofiles';
+export const MGMT_SCAN_LOGS_PATH = '/v1/mgmt/scanlogs';
+export const MGMT_CUSTOMER_APP_PATH = '/v1/mgmt/customerapp';
+export const MGMT_CUSTOMER_APPS_TSG_PATH = '/v1/mgmt/customerapp/tsg';
+export const MGMT_OAUTH_INVALIDATE_PATH = '/v1/mgmt/oauth/invalidateToken';
+export const MGMT_OAUTH_TOKEN_PATH = '/v1/mgmt/oauth/client_credential/accesstoken';
 
 // Model Security API defaults
 export const DEFAULT_MODEL_SEC_DATA_ENDPOINT = 'https://api.sase.paloaltonetworks.com/aims/data';

--- a/src/management/api-keys.ts
+++ b/src/management/api-keys.ts
@@ -1,0 +1,109 @@
+import { MGMT_API_KEY_PATH, MGMT_API_KEYS_TSG_PATH } from '../constants.js';
+import { managementHttpRequest } from './management-http-client.js';
+import type { OAuthClient } from './oauth-client.js';
+import type { PaginationOptions } from './profiles.js';
+import type {
+  ApiKey,
+  ApiKeyCreateRequest,
+  ApiKeyRegenerateRequest,
+  ApiKeyListResponse,
+  ApiKeyDeleteResponse,
+} from '../models/mgmt-api-key.js';
+
+/** @internal */
+export interface ApiKeysClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  tsgId: string;
+  numRetries: number;
+}
+
+/** Client for AIRS API key management operations. */
+export class ApiKeysClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly tsgId: string;
+  private readonly numRetries: number;
+
+  constructor(opts: ApiKeysClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.tsgId = opts.tsgId;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * Create a new API key.
+   * @param request - API key creation request.
+   * @returns The created API key.
+   */
+  async create(request: ApiKeyCreateRequest): Promise<ApiKey> {
+    const res = await managementHttpRequest<ApiKey>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: MGMT_API_KEY_PATH,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * List API keys for the TSG.
+   * @param opts - Pagination options.
+   * @returns Paginated list of API keys.
+   */
+  async list(opts?: PaginationOptions): Promise<ApiKeyListResponse> {
+    const params: Record<string, string> = {
+      offset: String(opts?.offset ?? 0),
+      limit: String(opts?.limit ?? 100),
+    };
+
+    const res = await managementHttpRequest<ApiKeyListResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MGMT_API_KEYS_TSG_PATH}/${this.tsgId}`,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Delete an API key by name.
+   * @param apiKeyName - Name of the API key to delete.
+   * @param updatedBy - Email of user performing the deletion.
+   * @returns Deletion confirmation.
+   */
+  async delete(apiKeyName: string, updatedBy: string): Promise<ApiKeyDeleteResponse> {
+    const res = await managementHttpRequest<ApiKeyDeleteResponse>({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${MGMT_API_KEY_PATH}/delete/${encodeURIComponent(apiKeyName)}`,
+      params: { updated_by: updatedBy },
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Regenerate an API key.
+   * @param apiKeyId - UUID of the API key to regenerate.
+   * @param request - Regeneration request with rotation config.
+   * @returns The regenerated API key.
+   */
+  async regenerate(apiKeyId: string, request: ApiKeyRegenerateRequest): Promise<ApiKey> {
+    const res = await managementHttpRequest<ApiKey>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: `${MGMT_API_KEY_PATH}/regenerate/${encodeURIComponent(apiKeyId)}`,
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/management/client.ts
+++ b/src/management/client.ts
@@ -11,6 +11,12 @@ import { AISecSDKException, ErrorType } from '../errors.js';
 import { OAuthClient } from './oauth-client.js';
 import { ProfilesClient } from './profiles.js';
 import { TopicsClient } from './topics.js';
+import { ApiKeysClient } from './api-keys.js';
+import { CustomerAppsClient } from './customer-apps.js';
+import { DlpProfilesClient } from './dlp-profiles.js';
+import { DeploymentProfilesClient } from './deployment-profiles.js';
+import { ScanLogsClient } from './scan-logs.js';
+import { OAuthManagementClient } from './oauth-management.js';
 
 /** Options for constructing a {@link ManagementClient}. */
 export interface ManagementClientOptions {
@@ -29,12 +35,18 @@ export interface ManagementClientOptions {
 }
 
 /**
- * Client for AIRS management API operations (profiles and topics CRUD).
+ * Client for AIRS management API operations.
  * Authenticates via OAuth2 client_credentials flow.
  */
 export class ManagementClient {
   public readonly profiles: ProfilesClient;
   public readonly topics: TopicsClient;
+  public readonly apiKeys: ApiKeysClient;
+  public readonly customerApps: CustomerAppsClient;
+  public readonly dlpProfiles: DlpProfilesClient;
+  public readonly deploymentProfiles: DeploymentProfilesClient;
+  public readonly scanLogs: ScanLogsClient;
+  public readonly oauth: OAuthManagementClient;
 
   constructor(opts: ManagementClientOptions = {}) {
     const clientId = opts.clientId ?? process.env[MGMT_CLIENT_ID];
@@ -84,6 +96,44 @@ export class ManagementClient {
       baseUrl: apiEndpoint,
       oauthClient,
       tsgId,
+      numRetries,
+    });
+
+    this.apiKeys = new ApiKeysClient({
+      baseUrl: apiEndpoint,
+      oauthClient,
+      tsgId,
+      numRetries,
+    });
+
+    this.customerApps = new CustomerAppsClient({
+      baseUrl: apiEndpoint,
+      oauthClient,
+      tsgId,
+      numRetries,
+    });
+
+    this.dlpProfiles = new DlpProfilesClient({
+      baseUrl: apiEndpoint,
+      oauthClient,
+      numRetries,
+    });
+
+    this.deploymentProfiles = new DeploymentProfilesClient({
+      baseUrl: apiEndpoint,
+      oauthClient,
+      numRetries,
+    });
+
+    this.scanLogs = new ScanLogsClient({
+      baseUrl: apiEndpoint,
+      oauthClient,
+      numRetries,
+    });
+
+    this.oauth = new OAuthManagementClient({
+      baseUrl: apiEndpoint,
+      oauthClient,
       numRetries,
     });
   }

--- a/src/management/customer-apps.ts
+++ b/src/management/customer-apps.ts
@@ -1,0 +1,104 @@
+import { MGMT_CUSTOMER_APP_PATH, MGMT_CUSTOMER_APPS_TSG_PATH } from '../constants.js';
+import { managementHttpRequest } from './management-http-client.js';
+import type { OAuthClient } from './oauth-client.js';
+import type { PaginationOptions } from './profiles.js';
+import type { CustomerApp, CustomerAppListResponse } from '../models/mgmt-customer-app.js';
+
+/** @internal */
+export interface CustomerAppsClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  tsgId: string;
+  numRetries: number;
+}
+
+/** Client for AIRS customer application management operations. */
+export class CustomerAppsClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly tsgId: string;
+  private readonly numRetries: number;
+
+  constructor(opts: CustomerAppsClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.tsgId = opts.tsgId;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * Get a customer app by name.
+   * @param appName - Name of the customer app.
+   * @returns The customer app.
+   */
+  async get(appName: string): Promise<CustomerApp> {
+    const res = await managementHttpRequest<CustomerApp>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: MGMT_CUSTOMER_APP_PATH,
+      params: { app_name: appName },
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * List customer apps for the TSG.
+   * @param opts - Pagination options.
+   * @returns Paginated list of customer apps.
+   */
+  async list(opts?: PaginationOptions): Promise<CustomerAppListResponse> {
+    const params: Record<string, string> = {
+      offset: String(opts?.offset ?? 0),
+      limit: String(opts?.limit ?? 100),
+    };
+
+    const res = await managementHttpRequest<CustomerAppListResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MGMT_CUSTOMER_APPS_TSG_PATH}/${this.tsgId}`,
+      params,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Update a customer app.
+   * @param customerAppId - UUID of the customer app to update.
+   * @param request - Updated customer app data.
+   * @returns The updated customer app.
+   */
+  async update(customerAppId: string, request: CustomerApp): Promise<CustomerApp> {
+    const res = await managementHttpRequest<CustomerApp>({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: MGMT_CUSTOMER_APP_PATH,
+      params: { customer_app_id: customerAppId },
+      body: request,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Delete a customer app.
+   * @param appName - Name of the customer app to delete.
+   * @param updatedBy - Email of user performing the deletion.
+   * @returns The deleted customer app.
+   */
+  async delete(appName: string, updatedBy: string): Promise<CustomerApp> {
+    const res = await managementHttpRequest<CustomerApp>({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: MGMT_CUSTOMER_APP_PATH,
+      params: { app_name: appName, updated_by: updatedBy },
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/management/deployment-profiles.ts
+++ b/src/management/deployment-profiles.ts
@@ -1,0 +1,50 @@
+import { MGMT_DEPLOYMENT_PROFILES_PATH } from '../constants.js';
+import { managementHttpRequest } from './management-http-client.js';
+import type { OAuthClient } from './oauth-client.js';
+import type { DeploymentProfilesResponse } from '../models/mgmt-deployment-profile.js';
+
+/** @internal */
+export interface DeploymentProfilesClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+/** Options for listing deployment profiles. */
+export interface DeploymentProfileListOptions {
+  /** Include unactivated deployment profiles. */
+  unactivated?: boolean;
+}
+
+/** Client for listing deployment profiles. */
+export class DeploymentProfilesClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: DeploymentProfilesClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List deployment profiles for the TSG.
+   * @param opts - Optional filter options.
+   * @returns Deployment profiles response.
+   */
+  async list(opts?: DeploymentProfileListOptions): Promise<DeploymentProfilesResponse> {
+    const params: Record<string, string> = {};
+    if (opts?.unactivated !== undefined) params.unactivated = String(opts.unactivated);
+
+    const res = await managementHttpRequest<DeploymentProfilesResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: MGMT_DEPLOYMENT_PROFILES_PATH,
+      params: Object.keys(params).length > 0 ? params : undefined,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/management/dlp-profiles.ts
+++ b/src/management/dlp-profiles.ts
@@ -1,0 +1,39 @@
+import { MGMT_DLP_PROFILES_PATH } from '../constants.js';
+import { managementHttpRequest } from './management-http-client.js';
+import type { OAuthClient } from './oauth-client.js';
+import type { DlpProfileListResponse } from '../models/mgmt-dlp-profile.js';
+
+/** @internal */
+export interface DlpProfilesClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+/** Client for listing DLP profiles. */
+export class DlpProfilesClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: DlpProfilesClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List all DLP profiles for the TSG.
+   * @returns List of DLP profiles.
+   */
+  async list(): Promise<DlpProfileListResponse> {
+    const res = await managementHttpRequest<DlpProfileListResponse>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: MGMT_DLP_PROFILES_PATH,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/management/index.ts
+++ b/src/management/index.ts
@@ -2,3 +2,12 @@ export { ManagementClient, type ManagementClientOptions } from './client.js';
 export { OAuthClient, type OAuthClientOptions, type TokenInfo } from './oauth-client.js';
 export { ProfilesClient, type PaginationOptions } from './profiles.js';
 export { TopicsClient } from './topics.js';
+export { ApiKeysClient } from './api-keys.js';
+export { CustomerAppsClient } from './customer-apps.js';
+export { DlpProfilesClient } from './dlp-profiles.js';
+export {
+  DeploymentProfilesClient,
+  type DeploymentProfileListOptions,
+} from './deployment-profiles.js';
+export { ScanLogsClient, type ScanLogQueryOptions } from './scan-logs.js';
+export { OAuthManagementClient, type GetTokenOptions } from './oauth-management.js';

--- a/src/management/oauth-management.ts
+++ b/src/management/oauth-management.ts
@@ -1,0 +1,76 @@
+import { MGMT_OAUTH_INVALIDATE_PATH, MGMT_OAUTH_TOKEN_PATH } from '../constants.js';
+import { managementHttpRequest } from './management-http-client.js';
+import type { OAuthClient } from './oauth-client.js';
+import type { ClientIdAndCustomerApp, Oauth2Token } from '../models/mgmt-oauth.js';
+
+/** @internal */
+export interface OAuthManagementClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+/** Options for getting an OAuth token. */
+export interface GetTokenOptions {
+  /** Client ID and customer app. */
+  body: ClientIdAndCustomerApp;
+  /** Token TTL interval. */
+  tokenTtlInterval?: number;
+  /** Token TTL unit (e.g. 'hours'). */
+  tokenTtlUnit?: string;
+}
+
+/** Client for OAuth token management operations. */
+export class OAuthManagementClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: OAuthManagementClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * Invalidate an OAuth token.
+   * @param token - The OAuth token to invalidate.
+   * @param body - Client ID and customer app.
+   * @returns Confirmation string.
+   */
+  async invalidateToken(token: string, body: ClientIdAndCustomerApp): Promise<string> {
+    const res = await managementHttpRequest<string>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: MGMT_OAUTH_INVALIDATE_PATH,
+      params: { token },
+      body,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get an OAuth token for client credentials.
+   * @param opts - Token request options.
+   * @returns OAuth2 token response.
+   */
+  async getAccessToken(opts: GetTokenOptions): Promise<Oauth2Token> {
+    const params: Record<string, string> = {};
+    if (opts.tokenTtlInterval !== undefined)
+      params.tokenTtlInterval = String(opts.tokenTtlInterval);
+    if (opts.tokenTtlUnit !== undefined) params.tokenTtlUnit = opts.tokenTtlUnit;
+
+    const res = await managementHttpRequest<Oauth2Token>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: MGMT_OAUTH_TOKEN_PATH,
+      params: Object.keys(params).length > 0 ? params : undefined,
+      body: opts.body,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/management/profiles.ts
+++ b/src/management/profiles.ts
@@ -126,4 +126,29 @@ export class ProfilesClient {
     });
     return res.data;
   }
+
+  /**
+   * Force-delete a security profile, bypassing safety checks.
+   * @param profileId - UUID of the profile to force-delete.
+   * @param updatedBy - Email of the user performing the deletion.
+   * @returns Deletion confirmation message.
+   */
+  async forceDelete(profileId: string, updatedBy: string): Promise<DeleteProfileResponse> {
+    if (!isValidUuid(profileId)) {
+      throw new AISecSDKException(
+        `Invalid profile_id: ${profileId}`,
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+
+    const res = await managementHttpRequest<DeleteProfileResponse>({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${MGMT_PROFILE_PATH}/${profileId}/force`,
+      params: { updated_by: updatedBy },
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
 }

--- a/src/management/scan-logs.ts
+++ b/src/management/scan-logs.ts
@@ -1,0 +1,68 @@
+import { MGMT_SCAN_LOGS_PATH } from '../constants.js';
+import { managementHttpRequest } from './management-http-client.js';
+import type { OAuthClient } from './oauth-client.js';
+import type { PaginatedScanResults } from '../models/mgmt-scan-log.js';
+
+/** @internal */
+export interface ScanLogsClientOptions {
+  baseUrl: string;
+  oauthClient: OAuthClient;
+  numRetries: number;
+}
+
+/** Options for querying scan logs. */
+export interface ScanLogQueryOptions {
+  /** Time interval value. */
+  time_interval: number;
+  /** Time unit (e.g. 'hour', 'day'). */
+  time_unit: string;
+  /** Page number (1-based). */
+  pageNumber: number;
+  /** Number of records per page. */
+  pageSize: number;
+  /** Filter: 'all', 'benign', or 'threat'. */
+  filter: string;
+  /** Encrypted page token for pagination continuation. */
+  page_token?: string;
+}
+
+/** Client for retrieving scan logs. */
+export class ScanLogsClient {
+  private readonly baseUrl: string;
+  private readonly oauthClient: OAuthClient;
+  private readonly numRetries: number;
+
+  constructor(opts: ScanLogsClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.oauthClient = opts.oauthClient;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * Retrieve scan logs by time interval.
+   * @param opts - Query options including time range, pagination, and filter.
+   * @returns Paginated scan results.
+   */
+  async query(opts: ScanLogQueryOptions): Promise<PaginatedScanResults> {
+    const params: Record<string, string> = {
+      time_interval: String(opts.time_interval),
+      time_unit: opts.time_unit,
+      pageNumber: String(opts.pageNumber),
+      pageSize: String(opts.pageSize),
+      filter: opts.filter,
+    };
+
+    const body = opts.page_token ? { page_token: opts.page_token } : undefined;
+
+    const res = await managementHttpRequest<PaginatedScanResults>({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: MGMT_SCAN_LOGS_PATH,
+      params,
+      body,
+      oauthClient: this.oauthClient,
+      numRetries: this.numRetries,
+    });
+    return res.data;
+  }
+}

--- a/src/management/topics.ts
+++ b/src/management/topics.ts
@@ -123,9 +123,10 @@ export class TopicsClient {
   /**
    * Force-delete a custom topic, removing it from any referencing profiles.
    * @param topicId - UUID of the topic to force-delete.
+   * @param updatedBy - Email of the user performing the deletion.
    * @returns Deletion confirmation message.
    */
-  async forceDelete(topicId: string): Promise<DeleteTopicResponse> {
+  async forceDelete(topicId: string, updatedBy?: string): Promise<DeleteTopicResponse> {
     if (!isValidUuid(topicId)) {
       throw new AISecSDKException(
         `Invalid topic_id: ${topicId}`,
@@ -133,10 +134,15 @@ export class TopicsClient {
       );
     }
 
+    const params: Record<string, string> | undefined = updatedBy
+      ? { updated_by: updatedBy }
+      : undefined;
+
     const res = await managementHttpRequest<DeleteTopicResponse>({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: `${MGMT_TOPIC_FORCE_PATH}/${topicId}`,
+      params,
       oauthClient: this.oauthClient,
       numRetries: this.numRetries,
     });

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -131,6 +131,54 @@ export {
   DeleteTopicConflictSchema,
   type DeleteTopicConflict,
 } from './mgmt-custom-topic.js';
+export {
+  ApiKeySchema,
+  type ApiKey,
+  ApiKeyCreateRequestSchema,
+  type ApiKeyCreateRequest,
+  ApiKeyRegenerateRequestSchema,
+  type ApiKeyRegenerateRequest,
+  ApiKeyListResponseSchema,
+  type ApiKeyListResponse,
+  ApiKeyDeleteResponseSchema,
+  type ApiKeyDeleteResponse,
+} from './mgmt-api-key.js';
+export {
+  ApiKeyDPInfoSchema,
+  type ApiKeyDPInfo,
+  CustomerAppSchema,
+  type CustomerApp,
+  CustomerAppWithKeysSchema,
+  type CustomerAppWithKeys,
+  CustomerAppListResponseSchema,
+  type CustomerAppListResponse,
+} from './mgmt-customer-app.js';
+export {
+  DeploymentProfileEntrySchema,
+  type DeploymentProfileEntry,
+  DeploymentProfilesResponseSchema,
+  type DeploymentProfilesResponse,
+} from './mgmt-deployment-profile.js';
+export {
+  DlpDataProfileSchema,
+  type DlpDataProfile,
+  DlpProfileListResponseSchema,
+  type DlpProfileListResponse,
+} from './mgmt-dlp-profile.js';
+export {
+  ScanResultEntrySchema,
+  type ScanResultEntry,
+  ScanResultForDashboardSchema,
+  type ScanResultForDashboard,
+  PaginatedScanResultsSchema,
+  type PaginatedScanResults,
+} from './mgmt-scan-log.js';
+export {
+  ClientIdAndCustomerAppSchema,
+  type ClientIdAndCustomerApp,
+  Oauth2TokenSchema,
+  type Oauth2Token,
+} from './mgmt-oauth.js';
 export * from './model-security-enums.js';
 export * from './model-security.js';
 export * from './red-team-enums.js';

--- a/src/models/mgmt-api-key.ts
+++ b/src/models/mgmt-api-key.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+
+/** Zod schema for an API key object. */
+export const ApiKeySchema = z
+  .object({
+    api_key_id: z.string(),
+    api_key_last8: z.string(),
+    api_key_name: z.string().optional(),
+    auth_code: z.string(),
+    csp_id: z.string().optional(),
+    tsg_id: z.string().optional(),
+    expiration: z.string(),
+    revoked: z.boolean(),
+    revoke_reason: z.string().optional(),
+    cust_app: z.string().optional(),
+    cust_env: z.string().optional(),
+    cust_ai_agent_framework: z.string().optional(),
+    cust_cloud_provider: z.string().optional(),
+    created_by: z.string().optional(),
+    updated_by: z.string().optional(),
+    last_modified_ts: z.string().optional(),
+    rotation_time_interval: z.number().optional(),
+    rotation_time_unit: z.string().optional(),
+    dp_name: z.string().optional(),
+    status: z.string().optional(),
+    api_key: z.string().optional(),
+    lic_expiration: z.string().optional(),
+    avg_text_records: z.number().optional(),
+    creation_ts: z.string().optional(),
+    customer_appId: z.string().optional(),
+  })
+  .passthrough();
+
+/** API key object. */
+export type ApiKey = z.infer<typeof ApiKeySchema>;
+
+/** Zod schema for API key creation request. */
+export const ApiKeyCreateRequestSchema = z.object({
+  dp_name: z.string().optional(),
+  auth_code: z.string(),
+  cust_app: z.string(),
+  cust_env: z.string().optional(),
+  cust_cloud_provider: z.string().optional(),
+  cust_ai_agent_framework: z.string().optional(),
+  revoked: z.boolean(),
+  created_by: z.string(),
+  api_key_name: z.string(),
+  rotation_time_interval: z.number(),
+  rotation_time_unit: z.string(),
+});
+
+/** API key creation request. */
+export type ApiKeyCreateRequest = z.infer<typeof ApiKeyCreateRequestSchema>;
+
+/** Zod schema for API key regeneration request. */
+export const ApiKeyRegenerateRequestSchema = z.object({
+  rotation_time_interval: z.number(),
+  rotation_time_unit: z.string(),
+  updated_by: z.string().optional(),
+});
+
+/** API key regeneration request. */
+export type ApiKeyRegenerateRequest = z.infer<typeof ApiKeyRegenerateRequestSchema>;
+
+/** Zod schema for paginated API key list response. */
+export const ApiKeyListResponseSchema = z
+  .object({
+    api_keys: z.array(ApiKeySchema).optional(),
+    next_offset: z.number().optional(),
+  })
+  .passthrough();
+
+/** Paginated API key list response. */
+export type ApiKeyListResponse = z.infer<typeof ApiKeyListResponseSchema>;
+
+/** Zod schema for API key delete response. */
+export const ApiKeyDeleteResponseSchema = z
+  .object({
+    message: z.string().optional(),
+  })
+  .passthrough();
+
+/** API key delete response. */
+export type ApiKeyDeleteResponse = z.infer<typeof ApiKeyDeleteResponseSchema>;

--- a/src/models/mgmt-customer-app.ts
+++ b/src/models/mgmt-customer-app.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+
+/** Zod schema for API key + deployment profile info. */
+export const ApiKeyDPInfoSchema = z
+  .object({
+    api_key_name: z.string(),
+    dp_name: z.string(),
+    auth_code: z.string(),
+  })
+  .passthrough();
+
+/** API key and deployment profile association. */
+export type ApiKeyDPInfo = z.infer<typeof ApiKeyDPInfoSchema>;
+
+/** Zod schema for a customer app. */
+export const CustomerAppSchema = z
+  .object({
+    customer_appId: z.string().optional(),
+    tsg_id: z.string(),
+    app_name: z.string(),
+    model_name: z.string().optional(),
+    cloud_provider: z.string(),
+    environment: z.string(),
+    status: z.string().optional(),
+    created_by: z.string().optional(),
+    updated_by: z.string().optional(),
+    ai_agent_framework: z.string().optional(),
+  })
+  .passthrough();
+
+/** Customer application object. */
+export type CustomerApp = z.infer<typeof CustomerAppSchema>;
+
+/** Zod schema for customer app with API key and DP info (used in list response). */
+export const CustomerAppWithKeysSchema = z
+  .object({
+    customer_appId: z.string(),
+    tsg_id: z.string(),
+    app_name: z.string(),
+    model_name: z.string().optional(),
+    cloud_provider: z.string(),
+    environment: z.string(),
+    ai_agent_framework: z.string().optional(),
+    api_keys_dp_info: z.array(ApiKeyDPInfoSchema).optional(),
+  })
+  .passthrough();
+
+/** Customer app with API key and deployment profile info. */
+export type CustomerAppWithKeys = z.infer<typeof CustomerAppWithKeysSchema>;
+
+/** Zod schema for paginated customer app list response. */
+export const CustomerAppListResponseSchema = z
+  .object({
+    customer_apps: z.array(CustomerAppWithKeysSchema).optional(),
+    next_offset: z.number().optional(),
+  })
+  .passthrough();
+
+/** Paginated customer app list response. */
+export type CustomerAppListResponse = z.infer<typeof CustomerAppListResponseSchema>;

--- a/src/models/mgmt-deployment-profile.ts
+++ b/src/models/mgmt-deployment-profile.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+/** Zod schema for a deployment profile entry. */
+export const DeploymentProfileEntrySchema = z
+  .object({
+    dp_name: z.string(),
+    auth_code: z.string(),
+    tsg_id: z.string().optional(),
+    status: z.string().optional(),
+    expiration_date: z.string().optional(),
+    ave_text_records: z.number().optional(),
+  })
+  .passthrough();
+
+/** Deployment profile entry. */
+export type DeploymentProfileEntry = z.infer<typeof DeploymentProfileEntrySchema>;
+
+/** Zod schema for deployment profiles response. */
+export const DeploymentProfilesResponseSchema = z
+  .object({
+    deployment_profiles: z.array(DeploymentProfileEntrySchema),
+    status: z.string(),
+  })
+  .passthrough();
+
+/** Deployment profiles response. */
+export type DeploymentProfilesResponse = z.infer<typeof DeploymentProfilesResponseSchema>;

--- a/src/models/mgmt-dlp-profile.ts
+++ b/src/models/mgmt-dlp-profile.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+/** Zod schema for DLP data profile (as returned by list endpoint). */
+export const DlpDataProfileSchema = z
+  .object({
+    name: z.string(),
+    uuid: z.string(),
+    id: z.string().optional(),
+    version: z.string().optional(),
+    rule1: z.object({ action: z.string().optional() }).passthrough().optional(),
+    rule2: z.object({ action: z.string().optional() }).passthrough().optional(),
+    'log-severity': z.string().optional(),
+    'non-file-based': z.string().optional(),
+    'file-based': z.string().optional(),
+  })
+  .passthrough();
+
+/** DLP data profile. */
+export type DlpDataProfile = z.infer<typeof DlpDataProfileSchema>;
+
+/** Zod schema for DLP profiles list response. */
+export const DlpProfileListResponseSchema = z
+  .object({
+    dlp_profiles: z.array(DlpDataProfileSchema).optional(),
+  })
+  .passthrough();
+
+/** DLP profiles list response. */
+export type DlpProfileListResponse = z.infer<typeof DlpProfileListResponseSchema>;

--- a/src/models/mgmt-oauth.ts
+++ b/src/models/mgmt-oauth.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+/** Zod schema for OAuth client_id + customer_app request body. */
+export const ClientIdAndCustomerAppSchema = z.object({
+  client_id: z.string(),
+  customer_app: z.string(),
+});
+
+/** OAuth client_id and customer_app request body. */
+export type ClientIdAndCustomerApp = z.infer<typeof ClientIdAndCustomerAppSchema>;
+
+/** Zod schema for OAuth2 token response. */
+export const Oauth2TokenSchema = z
+  .object({
+    token_type: z.string().optional(),
+    issued_at: z.string().optional(),
+    client_id: z.string().optional(),
+    access_token: z.string(),
+    expires_in: z.string().optional(),
+    status: z.string().optional(),
+  })
+  .passthrough();
+
+/** OAuth2 token response. */
+export type Oauth2Token = z.infer<typeof Oauth2TokenSchema>;

--- a/src/models/mgmt-scan-log.ts
+++ b/src/models/mgmt-scan-log.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+
+/** Zod schema for a scan result entry from the scan logs view. */
+export const ScanResultEntrySchema = z
+  .object({
+    csp_id: z.string(),
+    tsg_id: z.string(),
+    scan_id: z.string(),
+    scan_sub_req_id: z.number(),
+    api_key_name: z.string(),
+    app_name: z.string(),
+    tokens: z.number(),
+    text_records: z.number(),
+    transaction_id: z.string().optional(),
+    profile_id: z.string().optional(),
+    profile_name: z.string().optional(),
+    model_name: z.string().optional(),
+    user: z.string().optional(),
+    environment: z.string().optional(),
+    cloud_provider: z.string().optional(),
+    agent_framework: z.string().optional(),
+    report_id: z.string().optional(),
+    received_ts: z.string().optional(),
+    completed_ts: z.string().optional(),
+    status: z.string().optional(),
+    verdict: z.string().optional(),
+    action: z.string().optional(),
+    is_prompt: z.boolean().optional(),
+    is_response: z.boolean().optional(),
+    pi_final_verdict: z.string().optional(),
+    uf_final_verdict: z.string().optional(),
+    dlp_final_verdict: z.string().optional(),
+    dbs_final_verdict: z.string().optional(),
+    tc_final_verdict: z.string().optional(),
+    mc_final_verdict: z.string().optional(),
+    agent_final_verdict: z.string().optional(),
+    cg_final_verdict: z.string().optional(),
+    tg_final_verdict: z.string().optional(),
+    prompt_pi_verdict: z.string().optional(),
+    prompt_uf_verdict: z.string().optional(),
+    prompt_dlp_verdict: z.string().optional(),
+    prompt_tc_verdict: z.string().optional(),
+    prompt_mc_verdict: z.string().optional(),
+    prompt_agent_verdict: z.string().optional(),
+    prompt_tg_verdict: z.string().optional(),
+    prompt_verdict: z.string().optional(),
+    prompt_pi_action: z.string().optional(),
+    prompt_uf_action: z.string().optional(),
+    prompt_dlp_action: z.string().optional(),
+    prompt_tc_action: z.string().optional(),
+    prompt_mc_action: z.string().optional(),
+    prompt_agent_action: z.string().optional(),
+    prompt_tg_action: z.string().optional(),
+    response_uf_verdict: z.string().optional(),
+    response_dlp_verdict: z.string().optional(),
+    response_dbs_verdict: z.string().optional(),
+    response_tc_verdict: z.string().optional(),
+    response_mc_verdict: z.string().optional(),
+    response_agent_verdict: z.string().optional(),
+    response_cg_verdict: z.string().optional(),
+    response_tg_verdict: z.string().optional(),
+    response_uf_action: z.string().optional(),
+    response_dlp_action: z.string().optional(),
+    response_dbs_action: z.string().optional(),
+    response_tc_action: z.string().optional(),
+    response_mc_action: z.string().optional(),
+    response_agent_action: z.string().optional(),
+    response_cg_action: z.string().optional(),
+    response_tg_action: z.string().optional(),
+    response_verdict: z.string().optional(),
+    detection_service_flags: z.number().optional(),
+    content_masked: z.boolean().optional(),
+    user_ip: z.string().optional(),
+  })
+  .passthrough();
+
+/** Scan result entry from scan logs. */
+export type ScanResultEntry = z.infer<typeof ScanResultEntrySchema>;
+
+/** Zod schema for scan result dashboard data. */
+export const ScanResultForDashboardSchema = z
+  .object({
+    text_records_count: z.number().optional(),
+    api_calls_count: z.number().optional(),
+    threats_count: z.number().optional(),
+    all_transactions_count: z.number().optional(),
+    benign_transaction_count: z.number().optional(),
+    scan_result_entries: z.array(ScanResultEntrySchema).optional(),
+  })
+  .passthrough();
+
+/** Scan result dashboard summary. */
+export type ScanResultForDashboard = z.infer<typeof ScanResultForDashboardSchema>;
+
+/** Zod schema for paginated scan results response. */
+export const PaginatedScanResultsSchema = z
+  .object({
+    scan_result_for_dashboard: ScanResultForDashboardSchema.optional(),
+    total_pages: z.number().optional(),
+    page_number: z.number().optional(),
+    page_size: z.number().optional(),
+    page_token: z.string().optional(),
+    revision: z.number().optional(),
+  })
+  .passthrough();
+
+/** Paginated scan results response. */
+export type PaginatedScanResults = z.infer<typeof PaginatedScanResultsSchema>;

--- a/test/management/api-keys.spec.ts
+++ b/test/management/api-keys.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ApiKeysClient } from '../../src/management/api-keys.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('ApiKeysClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: ApiKeysClient;
+
+  beforeEach(() => {
+    client = new ApiKeysClient({
+      baseUrl: 'https://api.example.com',
+      oauthClient: createMockOAuth(),
+      tsgId: '123',
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('create', () => {
+    it('POSTs to /v1/mgmt/apikey', async () => {
+      const apiKey = {
+        api_key_id: 'k1',
+        api_key_last8: '12345678',
+        auth_code: 'ac',
+        expiration: '2025-12-31',
+        revoked: false,
+      };
+      mockFetch(apiKey);
+      const result = await client.create({
+        auth_code: 'ac',
+        cust_app: 'app1',
+        revoked: false,
+        created_by: 'user@test.com',
+        api_key_name: 'key1',
+        rotation_time_interval: 90,
+        rotation_time_unit: 'days',
+      });
+
+      expect(result.api_key_id).toBe('k1');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/apikey');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  describe('list', () => {
+    it('GETs /v1/mgmt/apikeys/tsg/:tsgId', async () => {
+      mockFetch({ api_keys: [], next_offset: 0 });
+      const result = await client.list();
+
+      expect(result.api_keys).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/apikeys/tsg/123');
+    });
+
+    it('passes pagination params', async () => {
+      mockFetch({ api_keys: [], next_offset: 10 });
+      await client.list({ offset: 10, limit: 5 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('offset=10');
+      expect(url).toContain('limit=5');
+    });
+  });
+
+  describe('delete', () => {
+    it('DELETEs /v1/mgmt/apikey/delete/:name with updated_by', async () => {
+      mockFetch({ message: 'deleted' });
+      const result = await client.delete('my-key', 'user@test.com');
+
+      expect(result.message).toBe('deleted');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/apikey/delete/my-key');
+      expect(url).toContain('updated_by=user');
+      expect(init.method).toBe('DELETE');
+    });
+  });
+
+  describe('regenerate', () => {
+    it('POSTs to /v1/mgmt/apikey/regenerate/:id', async () => {
+      const apiKey = {
+        api_key_id: 'k1',
+        api_key_last8: '87654321',
+        auth_code: 'ac',
+        expiration: '2026-06-30',
+        revoked: false,
+      };
+      mockFetch(apiKey);
+      const result = await client.regenerate('k1', {
+        rotation_time_interval: 30,
+        rotation_time_unit: 'days',
+      });
+
+      expect(result.api_key_id).toBe('k1');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/apikey/regenerate/k1');
+      expect(init.method).toBe('POST');
+    });
+  });
+});

--- a/test/management/client.spec.ts
+++ b/test/management/client.spec.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { ManagementClient } from '../../src/management/client.js';
 import { ProfilesClient } from '../../src/management/profiles.js';
 import { TopicsClient } from '../../src/management/topics.js';
+import { ApiKeysClient } from '../../src/management/api-keys.js';
+import { CustomerAppsClient } from '../../src/management/customer-apps.js';
+import { DlpProfilesClient } from '../../src/management/dlp-profiles.js';
+import { DeploymentProfilesClient } from '../../src/management/deployment-profiles.js';
+import { ScanLogsClient } from '../../src/management/scan-logs.js';
+import { OAuthManagementClient } from '../../src/management/oauth-management.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 describe('ManagementClient', () => {
@@ -20,6 +26,12 @@ describe('ManagementClient', () => {
 
     expect(client.profiles).toBeInstanceOf(ProfilesClient);
     expect(client.topics).toBeInstanceOf(TopicsClient);
+    expect(client.apiKeys).toBeInstanceOf(ApiKeysClient);
+    expect(client.customerApps).toBeInstanceOf(CustomerAppsClient);
+    expect(client.dlpProfiles).toBeInstanceOf(DlpProfilesClient);
+    expect(client.deploymentProfiles).toBeInstanceOf(DeploymentProfilesClient);
+    expect(client.scanLogs).toBeInstanceOf(ScanLogsClient);
+    expect(client.oauth).toBeInstanceOf(OAuthManagementClient);
   });
 
   it('reads credentials from env vars', () => {

--- a/test/management/customer-apps.spec.ts
+++ b/test/management/customer-apps.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { CustomerAppsClient } from '../../src/management/customer-apps.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('CustomerAppsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: CustomerAppsClient;
+
+  beforeEach(() => {
+    client = new CustomerAppsClient({
+      baseUrl: 'https://api.example.com',
+      oauthClient: createMockOAuth(),
+      tsgId: '123',
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('get', () => {
+    it('GETs /v1/mgmt/customerapp with app_name', async () => {
+      const app = { tsg_id: '123', app_name: 'myapp', cloud_provider: 'aws', environment: 'prod' };
+      mockFetch(app);
+      const result = await client.get('myapp');
+
+      expect(result.app_name).toBe('myapp');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/customerapp');
+      expect(url).toContain('app_name=myapp');
+    });
+  });
+
+  describe('list', () => {
+    it('GETs /v1/mgmt/customerapp/tsg/:tsgId', async () => {
+      mockFetch({ customer_apps: [], next_offset: 0 });
+      const result = await client.list();
+
+      expect(result.customer_apps).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/customerapp/tsg/123');
+    });
+  });
+
+  describe('update', () => {
+    it('PUTs to /v1/mgmt/customerapp with customer_app_id', async () => {
+      const app = { tsg_id: '123', app_name: 'myapp', cloud_provider: 'aws', environment: 'prod' };
+      mockFetch(app);
+      await client.update('uuid-1', app);
+
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/customerapp');
+      expect(url).toContain('customer_app_id=uuid-1');
+      expect(init.method).toBe('PUT');
+    });
+  });
+
+  describe('delete', () => {
+    it('DELETEs /v1/mgmt/customerapp with app_name and updated_by', async () => {
+      const app = { tsg_id: '123', app_name: 'myapp', cloud_provider: 'aws', environment: 'prod' };
+      mockFetch(app);
+      await client.delete('myapp', 'user@test.com');
+
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('app_name=myapp');
+      expect(url).toContain('updated_by=user');
+      expect(init.method).toBe('DELETE');
+    });
+  });
+});

--- a/test/management/deployment-profiles.spec.ts
+++ b/test/management/deployment-profiles.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DeploymentProfilesClient } from '../../src/management/deployment-profiles.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('DeploymentProfilesClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: DeploymentProfilesClient;
+
+  beforeEach(() => {
+    client = new DeploymentProfilesClient({
+      baseUrl: 'https://api.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('list', () => {
+    it('GETs /v1/mgmt/deploymentprofiles', async () => {
+      mockFetch({ deployment_profiles: [], status: 'ok' });
+      const result = await client.list();
+
+      expect(result.deployment_profiles).toEqual([]);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/deploymentprofiles');
+    });
+
+    it('passes unactivated filter', async () => {
+      mockFetch({ deployment_profiles: [], status: 'ok' });
+      await client.list({ unactivated: true });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('unactivated=true');
+    });
+  });
+});

--- a/test/management/dlp-profiles.spec.ts
+++ b/test/management/dlp-profiles.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DlpProfilesClient } from '../../src/management/dlp-profiles.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('DlpProfilesClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: DlpProfilesClient;
+
+  beforeEach(() => {
+    client = new DlpProfilesClient({
+      baseUrl: 'https://api.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('list', () => {
+    it('GETs /v1/mgmt/dlpprofiles', async () => {
+      mockFetch({ dlp_profiles: [{ name: 'p1', uuid: 'u1' }] });
+      const result = await client.list();
+
+      expect(result.dlp_profiles).toHaveLength(1);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/dlpprofiles');
+    });
+  });
+});

--- a/test/management/oauth-management.spec.ts
+++ b/test/management/oauth-management.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { OAuthManagementClient } from '../../src/management/oauth-management.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('OAuthManagementClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: OAuthManagementClient;
+
+  beforeEach(() => {
+    client = new OAuthManagementClient({
+      baseUrl: 'https://api.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('invalidateToken', () => {
+    it('POSTs to /v1/mgmt/oauth/invalidateToken', async () => {
+      mockFetch('token invalidated');
+      const result = await client.invalidateToken('old-token', {
+        client_id: 'cid',
+        customer_app: 'app1',
+      });
+
+      expect(result).toBeDefined();
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/oauth/invalidateToken');
+      expect(url).toContain('token=old-token');
+      expect(init.method).toBe('POST');
+    });
+  });
+
+  describe('getAccessToken', () => {
+    it('POSTs to /v1/mgmt/oauth/client_credential/accesstoken', async () => {
+      mockFetch({ access_token: 'new-token', expires_in: '86400' });
+      const result = await client.getAccessToken({
+        body: { client_id: 'cid', customer_app: 'app1' },
+      });
+
+      expect(result.access_token).toBe('new-token');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/oauth/client_credential/accesstoken');
+      expect(init.method).toBe('POST');
+    });
+
+    it('passes TTL params', async () => {
+      mockFetch({ access_token: 'tok' });
+      await client.getAccessToken({
+        body: { client_id: 'cid', customer_app: 'app1' },
+        tokenTtlInterval: 3,
+        tokenTtlUnit: 'hours',
+      });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('tokenTtlInterval=3');
+      expect(url).toContain('tokenTtlUnit=hours');
+    });
+  });
+});

--- a/test/management/profiles.spec.ts
+++ b/test/management/profiles.spec.ts
@@ -109,4 +109,24 @@ describe('ProfilesClient', () => {
       await expect(client.delete('bad')).rejects.toThrow(AISecSDKException);
     });
   });
+
+  describe('forceDelete', () => {
+    it('DELETEs /v1/mgmt/profile/:id/force with updated_by', async () => {
+      mockFetch({ message: 'force deleted' });
+      const result = await client.forceDelete(
+        '550e8400-e29b-41d4-a716-446655440000',
+        'admin@test.com',
+      );
+
+      expect(result.message).toBe('force deleted');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/profile/550e8400-e29b-41d4-a716-446655440000/force');
+      expect(url).toContain('updated_by=admin');
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.forceDelete('bad', 'user@test.com')).rejects.toThrow(AISecSDKException);
+    });
+  });
 });

--- a/test/management/scan-logs.spec.ts
+++ b/test/management/scan-logs.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ScanLogsClient } from '../../src/management/scan-logs.js';
+import { OAuthClient } from '../../src/management/oauth-client.js';
+
+function createMockOAuth(): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue('tok'),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('ScanLogsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: ScanLogsClient;
+
+  beforeEach(() => {
+    client = new ScanLogsClient({
+      baseUrl: 'https://api.example.com',
+      oauthClient: createMockOAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('query', () => {
+    it('POSTs to /v1/mgmt/scanlogs with required params', async () => {
+      mockFetch({ total_pages: 1, page_number: 1, page_size: 10 });
+      const result = await client.query({
+        time_interval: 24,
+        time_unit: 'hour',
+        pageNumber: 1,
+        pageSize: 10,
+        filter: 'all',
+      });
+
+      expect(result.total_pages).toBe(1);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/scanlogs');
+      expect(url).toContain('time_interval=24');
+      expect(url).toContain('time_unit=hour');
+      expect(url).toContain('pageNumber=1');
+      expect(url).toContain('pageSize=10');
+      expect(url).toContain('filter=all');
+      expect(init.method).toBe('POST');
+    });
+
+    it('sends page_token in body', async () => {
+      mockFetch({ total_pages: 2, page_number: 2 });
+      await client.query({
+        time_interval: 7,
+        time_unit: 'day',
+        pageNumber: 2,
+        pageSize: 50,
+        filter: 'threat',
+        page_token: 'encrypted-token',
+      });
+
+      const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const body = JSON.parse(init.body);
+      expect(body.page_token).toBe('encrypted-token');
+    });
+  });
+});

--- a/test/management/topics.spec.ts
+++ b/test/management/topics.spec.ts
@@ -119,6 +119,14 @@ describe('TopicsClient', () => {
       expect(init.method).toBe('DELETE');
     });
 
+    it('passes updated_by param', async () => {
+      mockFetch({ message: 'force deleted' });
+      await client.forceDelete('550e8400-e29b-41d4-a716-446655440000', 'admin@test.com');
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('updated_by=admin');
+    });
+
     it('rejects invalid UUID', async () => {
       await expect(client.forceDelete('bad')).rejects.toThrow(AISecSDKException);
     });

--- a/test/models/mgmt-schemas.spec.ts
+++ b/test/models/mgmt-schemas.spec.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ApiKeySchema,
+  ApiKeyCreateRequestSchema,
+  ApiKeyListResponseSchema,
+  CustomerAppSchema,
+  CustomerAppWithKeysSchema,
+  CustomerAppListResponseSchema,
+  DeploymentProfileEntrySchema,
+  DeploymentProfilesResponseSchema,
+  DlpDataProfileSchema,
+  DlpProfileListResponseSchema,
+  ScanResultEntrySchema,
+  PaginatedScanResultsSchema,
+  ClientIdAndCustomerAppSchema,
+  Oauth2TokenSchema,
+} from '../../src/models/index.js';
+
+describe('ApiKeySchema', () => {
+  it('parses valid API key', () => {
+    const r = ApiKeySchema.safeParse({
+      api_key_id: 'k1',
+      api_key_last8: '12345678',
+      auth_code: 'ac',
+      expiration: '2025-12-31T00:00:00Z',
+      revoked: false,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('passes through unknown fields', () => {
+    const r = ApiKeySchema.safeParse({
+      api_key_id: 'k1',
+      api_key_last8: '12345678',
+      auth_code: 'ac',
+      expiration: '2025-12-31',
+      revoked: false,
+      new_field: true,
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('ApiKeyCreateRequestSchema', () => {
+  it('validates required fields', () => {
+    const r = ApiKeyCreateRequestSchema.safeParse({
+      auth_code: 'ac',
+      cust_app: 'app1',
+      revoked: false,
+      created_by: 'user@test.com',
+      api_key_name: 'key1',
+      rotation_time_interval: 90,
+      rotation_time_unit: 'days',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects missing required fields', () => {
+    const r = ApiKeyCreateRequestSchema.safeParse({ auth_code: 'ac' });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('ApiKeyListResponseSchema', () => {
+  it('parses paginated response', () => {
+    const r = ApiKeyListResponseSchema.safeParse({
+      api_keys: [
+        {
+          api_key_id: 'k1',
+          api_key_last8: '12345678',
+          auth_code: 'ac',
+          expiration: '2025-12-31',
+          revoked: false,
+        },
+      ],
+      next_offset: 1,
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('CustomerAppSchema', () => {
+  it('parses valid customer app', () => {
+    const r = CustomerAppSchema.safeParse({
+      tsg_id: '123',
+      app_name: 'myapp',
+      cloud_provider: 'aws',
+      environment: 'prod',
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('CustomerAppWithKeysSchema', () => {
+  it('parses customer app with API key info', () => {
+    const r = CustomerAppWithKeysSchema.safeParse({
+      customer_appId: 'ca1',
+      tsg_id: '123',
+      app_name: 'myapp',
+      cloud_provider: 'aws',
+      environment: 'prod',
+      api_keys_dp_info: [{ api_key_name: 'k1', dp_name: 'dp1', auth_code: 'ac' }],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('CustomerAppListResponseSchema', () => {
+  it('parses paginated response', () => {
+    const r = CustomerAppListResponseSchema.safeParse({
+      customer_apps: [],
+      next_offset: 0,
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('DeploymentProfileEntrySchema', () => {
+  it('parses valid entry', () => {
+    const r = DeploymentProfileEntrySchema.safeParse({
+      dp_name: 'dp1',
+      auth_code: 'ac',
+      status: 'active',
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('DeploymentProfilesResponseSchema', () => {
+  it('parses response with entries', () => {
+    const r = DeploymentProfilesResponseSchema.safeParse({
+      deployment_profiles: [{ dp_name: 'dp1', auth_code: 'ac' }],
+      status: 'ok',
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('DlpDataProfileSchema', () => {
+  it('parses DLP profile with rules', () => {
+    const r = DlpDataProfileSchema.safeParse({
+      name: 'default',
+      uuid: 'u1',
+      rule1: { action: 'block' },
+      rule2: { action: 'alert' },
+      'log-severity': 'high',
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('DlpProfileListResponseSchema', () => {
+  it('parses list response', () => {
+    const r = DlpProfileListResponseSchema.safeParse({
+      dlp_profiles: [{ name: 'p1', uuid: 'u1' }],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('ScanResultEntrySchema', () => {
+  it('parses minimal entry', () => {
+    const r = ScanResultEntrySchema.safeParse({
+      csp_id: 'c1',
+      tsg_id: 't1',
+      scan_id: 's1',
+      scan_sub_req_id: 0,
+      api_key_name: 'k1',
+      app_name: 'app1',
+      tokens: 100,
+      text_records: 1,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('parses entry with verdict fields', () => {
+    const r = ScanResultEntrySchema.safeParse({
+      csp_id: 'c1',
+      tsg_id: 't1',
+      scan_id: 's1',
+      scan_sub_req_id: 0,
+      api_key_name: 'k1',
+      app_name: 'app1',
+      tokens: 100,
+      text_records: 1,
+      verdict: 'malicious',
+      action: 'block',
+      pi_final_verdict: 'malicious',
+      prompt_pi_verdict: 'malicious',
+      response_dlp_verdict: 'benign',
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('PaginatedScanResultsSchema', () => {
+  it('parses paginated results', () => {
+    const r = PaginatedScanResultsSchema.safeParse({
+      total_pages: 5,
+      page_number: 1,
+      page_size: 10,
+      page_token: 'tok',
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('ClientIdAndCustomerAppSchema', () => {
+  it('validates required fields', () => {
+    const r = ClientIdAndCustomerAppSchema.safeParse({
+      client_id: 'cid',
+      customer_app: 'app1',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects missing fields', () => {
+    const r = ClientIdAndCustomerAppSchema.safeParse({ client_id: 'cid' });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('Oauth2TokenSchema', () => {
+  it('parses token response', () => {
+    const r = Oauth2TokenSchema.safeParse({
+      access_token: 'tok123',
+      expires_in: '86400',
+      token_type: 'Bearer',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('requires access_token', () => {
+    const r = Oauth2TokenSchema.safeParse({ token_type: 'Bearer' });
+    expect(r.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 6 new management sub-clients: ApiKeysClient, CustomerAppsClient, DlpProfilesClient, DeploymentProfilesClient, ScanLogsClient, OAuthManagementClient
- Add `ProfilesClient.forceDelete()` and `TopicsClient.forceDelete(updatedBy?)` methods
- Add typed Zod schemas for all management model types (API keys, customer apps, DLP profiles, deployment profiles, scan logs, OAuth tokens)
- ManagementClient now exposes 8 sub-clients (profiles, topics, apiKeys, customerApps, dlpProfiles, deploymentProfiles, scanLogs, oauth)
- 9 new API path constants in constants.ts

## Test plan
- [x] 19 new schema validation tests (mgmt-schemas.spec.ts)
- [x] 17 new sub-client tests across 6 test files
- [x] Updated client.spec.ts to assert all 8 sub-client instances
- [x] Updated profiles/topics tests for forceDelete changes
- [x] All 733 tests pass
- [x] Typecheck, lint, format all clean

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)