### PR TITLE
Bump version to 0.6.2

### DIFF
--- a/.changeset/0000-docs-accuracy-fix.md
+++ b/.changeset/0000-docs-accuracy-fix.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Fix documentation inaccuracies and add missing management sub-client docs. Correct model security scan list parameter names, add 6 new management sub-client sections, and add missing type definitions to API reference.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.6.1';
+export const SDK_VERSION = '0.6.2';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
## Summary
- Bump version to 0.6.2 (hotfix for docs accuracy)
- Update SDK_VERSION in constants.ts
- Add changeset

## Test plan
- [x] All 733 tests pass
- [x] All quality gates clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)