### PR TITLE
fix: add .passthrough() to 22 scan-related Zod schemas

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 coverage
 .venv
 *.lock
+tsup.config.bundled_*

--- a/src/models/ai-profile.ts
+++ b/src/models/ai-profile.ts
@@ -7,6 +7,7 @@ export const AiProfileSchema = z
     profile_id: z.string().uuid().optional(),
     profile_name: z.string().max(MAX_AI_PROFILE_NAME_LENGTH).optional(),
   })
+  .passthrough()
   .refine((d) => d.profile_id || d.profile_name, {
     message: 'Either profile_id or profile_name must be provided',
   });

--- a/src/models/async-scan.ts
+++ b/src/models/async-scan.ts
@@ -2,21 +2,25 @@ import { z } from 'zod';
 import { ScanRequestSchema } from './scan-request.js';
 
 /** Zod schema for an async scan batch item. */
-export const AsyncScanObjectSchema = z.object({
-  req_id: z.number().int(),
-  scan_req: ScanRequestSchema,
-});
+export const AsyncScanObjectSchema = z
+  .object({
+    req_id: z.number().int(),
+    scan_req: ScanRequestSchema,
+  })
+  .passthrough();
 
 /** Async scan batch item containing a request ID and scan request. */
 export type AsyncScanObject = z.infer<typeof AsyncScanObjectSchema>;
 
 /** Zod schema for the async scan API response. */
-export const AsyncScanResponseSchema = z.object({
-  received: z.string(),
-  scan_id: z.string(),
-  report_id: z.string().optional(),
-  source: z.string().optional(),
-});
+export const AsyncScanResponseSchema = z
+  .object({
+    received: z.string(),
+    scan_id: z.string(),
+    report_id: z.string().optional(),
+    source: z.string().optional(),
+  })
+  .passthrough();
 
 /** Async scan API response with scan ID for later querying. */
 export type AsyncScanResponse = z.infer<typeof AsyncScanResponseSchema>;

--- a/src/models/detection.ts
+++ b/src/models/detection.ts
@@ -44,14 +44,16 @@ export const DSResultMetadataSchema = z
 export type DSResultMetadata = z.infer<typeof DSResultMetadataSchema>;
 
 /** Zod schema for an individual detection service result. */
-export const DetectionServiceResultSchema = z.object({
-  data_type: z.string().optional(),
-  detection_service: z.string().optional(),
-  verdict: z.string().optional(),
-  action: z.string().optional(),
-  metadata: DSResultMetadataSchema.optional(),
-  result_detail: DSDetailResultSchema.optional(),
-});
+export const DetectionServiceResultSchema = z
+  .object({
+    data_type: z.string().optional(),
+    detection_service: z.string().optional(),
+    verdict: z.string().optional(),
+    action: z.string().optional(),
+    metadata: DSResultMetadataSchema.optional(),
+    result_detail: DSDetailResultSchema.optional(),
+  })
+  .passthrough();
 
 /** Individual detection service result with verdict, action, and details. */
 export type DetectionServiceResult = z.infer<typeof DetectionServiceResultSchema>;

--- a/src/models/dlp-report.ts
+++ b/src/models/dlp-report.ts
@@ -2,15 +2,17 @@ import { z } from 'zod';
 import { DlpPatternDetectionSchema } from './detection-reports.js';
 
 /** Zod schema for a DLP (Data Loss Prevention) report. */
-export const DlpReportSchema = z.object({
-  dlp_report_id: z.string().optional(),
-  dlp_profile_name: z.string().optional(),
-  dlp_profile_id: z.string().optional(),
-  dlp_profile_version: z.number().optional(),
-  data_pattern_rule1_verdict: z.string().optional(),
-  data_pattern_rule2_verdict: z.string().optional(),
-  data_pattern_detection_offsets: z.array(DlpPatternDetectionSchema).optional(),
-});
+export const DlpReportSchema = z
+  .object({
+    dlp_report_id: z.string().optional(),
+    dlp_profile_name: z.string().optional(),
+    dlp_profile_id: z.string().optional(),
+    dlp_profile_version: z.number().optional(),
+    data_pattern_rule1_verdict: z.string().optional(),
+    data_pattern_rule2_verdict: z.string().optional(),
+    data_pattern_detection_offsets: z.array(DlpPatternDetectionSchema).optional(),
+  })
+  .passthrough();
 
 /** DLP report with profile info, rule verdicts, and pattern detection offsets. */
 export type DlpReport = z.infer<typeof DlpReportSchema>;

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -1,23 +1,27 @@
 import { z } from 'zod';
 
 /** Zod schema for AI agent metadata. */
-export const AgentMetaSchema = z.object({
-  agent_id: z.string().optional(),
-  agent_version: z.string().optional(),
-  agent_arn: z.string().optional(),
-});
+export const AgentMetaSchema = z
+  .object({
+    agent_id: z.string().optional(),
+    agent_version: z.string().optional(),
+    agent_arn: z.string().optional(),
+  })
+  .passthrough();
 
 /** AI agent metadata (agent ID, version, ARN). */
 export type AgentMeta = z.infer<typeof AgentMetaSchema>;
 
 /** Zod schema for scan request metadata. */
-export const MetadataSchema = z.object({
-  app_name: z.string().optional(),
-  app_user: z.string().optional(),
-  ai_model: z.string().optional(),
-  user_ip: z.string().optional(),
-  agent_meta: AgentMetaSchema.optional(),
-});
+export const MetadataSchema = z
+  .object({
+    app_name: z.string().optional(),
+    app_user: z.string().optional(),
+    ai_model: z.string().optional(),
+    user_ip: z.string().optional(),
+    agent_meta: AgentMetaSchema.optional(),
+  })
+  .passthrough();
 
 /** Application metadata attached to scan requests. */
 export type Metadata = z.infer<typeof MetadataSchema>;

--- a/src/models/oauth-token.ts
+++ b/src/models/oauth-token.ts
@@ -1,12 +1,14 @@
 import { z } from 'zod';
 
 /** Zod schema for an OAuth2 token response. */
-export const OAuthTokenResponseSchema = z.object({
-  access_token: z.string(),
-  token_type: z.string().optional(),
-  expires_in: z.number(),
-  scope: z.string().optional(),
-});
+export const OAuthTokenResponseSchema = z
+  .object({
+    access_token: z.string(),
+    token_type: z.string().optional(),
+    expires_in: z.number(),
+    scope: z.string().optional(),
+  })
+  .passthrough();
 
 /** OAuth2 token response with access token and expiry. */
 export type OAuthTokenResponse = z.infer<typeof OAuthTokenResponseSchema>;

--- a/src/models/prompt-detected.ts
+++ b/src/models/prompt-detected.ts
@@ -1,23 +1,27 @@
 import { z } from 'zod';
 
 /** Zod schema for prompt detection detail data. */
-export const PromptDetectionDetailsSchema = z.object({
-  topic_guardrails_details: z.record(z.unknown()).optional(),
-});
+export const PromptDetectionDetailsSchema = z
+  .object({
+    topic_guardrails_details: z.record(z.unknown()).optional(),
+  })
+  .passthrough();
 
 /** Prompt detection detail data including topic guardrails. */
 export type PromptDetectionDetails = z.infer<typeof PromptDetectionDetailsSchema>;
 
 /** Zod schema for prompt-side detection flags. */
-export const PromptDetectedSchema = z.object({
-  url_cats: z.boolean().optional(),
-  dlp: z.boolean().optional(),
-  injection: z.boolean().optional(),
-  toxic_content: z.boolean().optional(),
-  malicious_code: z.boolean().optional(),
-  agent: z.boolean().optional(),
-  topic_violation: z.boolean().optional(),
-});
+export const PromptDetectedSchema = z
+  .object({
+    url_cats: z.boolean().optional(),
+    dlp: z.boolean().optional(),
+    injection: z.boolean().optional(),
+    toxic_content: z.boolean().optional(),
+    malicious_code: z.boolean().optional(),
+    agent: z.boolean().optional(),
+    topic_violation: z.boolean().optional(),
+  })
+  .passthrough();
 
 /** Flags indicating which detection types triggered on the prompt. */
 export type PromptDetected = z.infer<typeof PromptDetectedSchema>;

--- a/src/models/response-detected.ts
+++ b/src/models/response-detected.ts
@@ -1,24 +1,28 @@
 import { z } from 'zod';
 
 /** Zod schema for response detection detail data. */
-export const ResponseDetectionDetailsSchema = z.object({
-  topic_guardrails_details: z.record(z.unknown()).optional(),
-});
+export const ResponseDetectionDetailsSchema = z
+  .object({
+    topic_guardrails_details: z.record(z.unknown()).optional(),
+  })
+  .passthrough();
 
 /** Response detection detail data including topic guardrails. */
 export type ResponseDetectionDetails = z.infer<typeof ResponseDetectionDetailsSchema>;
 
 /** Zod schema for response-side detection flags. */
-export const ResponseDetectedSchema = z.object({
-  url_cats: z.boolean().optional(),
-  dlp: z.boolean().optional(),
-  db_security: z.boolean().optional(),
-  toxic_content: z.boolean().optional(),
-  malicious_code: z.boolean().optional(),
-  agent: z.boolean().optional(),
-  ungrounded: z.boolean().optional(),
-  topic_violation: z.boolean().optional(),
-});
+export const ResponseDetectedSchema = z
+  .object({
+    url_cats: z.boolean().optional(),
+    dlp: z.boolean().optional(),
+    db_security: z.boolean().optional(),
+    toxic_content: z.boolean().optional(),
+    malicious_code: z.boolean().optional(),
+    agent: z.boolean().optional(),
+    ungrounded: z.boolean().optional(),
+    topic_violation: z.boolean().optional(),
+  })
+  .passthrough();
 
 /** Flags indicating which detection types triggered on the response. */
 export type ResponseDetected = z.infer<typeof ResponseDetectedSchema>;

--- a/src/models/scan-id-result.ts
+++ b/src/models/scan-id-result.ts
@@ -2,13 +2,15 @@ import { z } from 'zod';
 import { ScanResponseSchema } from './scan-response.js';
 
 /** Zod schema for a scan ID query result. */
-export const ScanIdResultSchema = z.object({
-  source: z.string().optional(),
-  req_id: z.number().optional(),
-  status: z.string().optional(),
-  scan_id: z.string().optional(),
-  result: ScanResponseSchema.optional(),
-});
+export const ScanIdResultSchema = z
+  .object({
+    source: z.string().optional(),
+    req_id: z.number().optional(),
+    status: z.string().optional(),
+    scan_id: z.string().optional(),
+    result: ScanResponseSchema.optional(),
+  })
+  .passthrough();
 
 /** Result of querying a scan by its scan ID, including status and full scan response. */
 export type ScanIdResult = z.infer<typeof ScanIdResultSchema>;

--- a/src/models/scan-request.ts
+++ b/src/models/scan-request.ts
@@ -5,26 +5,30 @@ import { MetadataSchema } from './metadata.js';
 import { ToolEventSchema } from './tool-event.js';
 
 /** Zod schema for a single content item within a scan request. */
-export const ScanRequestContentsInnerSchema = z.object({
-  prompt: z.string().optional(),
-  response: z.string().optional(),
-  code_prompt: z.string().optional(),
-  code_response: z.string().optional(),
-  context: z.string().optional(),
-  tool_event: ToolEventSchema.optional(),
-});
+export const ScanRequestContentsInnerSchema = z
+  .object({
+    prompt: z.string().optional(),
+    response: z.string().optional(),
+    code_prompt: z.string().optional(),
+    code_response: z.string().optional(),
+    context: z.string().optional(),
+    tool_event: ToolEventSchema.optional(),
+  })
+  .passthrough();
 
 /** Single content item within a scan request. */
 export type ScanRequestContentsInner = z.infer<typeof ScanRequestContentsInnerSchema>;
 
 /** Zod schema for a complete scan request payload. */
-export const ScanRequestSchema = z.object({
-  tr_id: z.string().max(MAX_TRANSACTION_ID_STR_LENGTH).optional(),
-  session_id: z.string().max(MAX_SESSION_ID_STR_LENGTH).optional(),
-  ai_profile: AiProfileSchema,
-  metadata: MetadataSchema.optional(),
-  contents: z.array(ScanRequestContentsInnerSchema).min(1),
-});
+export const ScanRequestSchema = z
+  .object({
+    tr_id: z.string().max(MAX_TRANSACTION_ID_STR_LENGTH).optional(),
+    session_id: z.string().max(MAX_SESSION_ID_STR_LENGTH).optional(),
+    ai_profile: AiProfileSchema,
+    metadata: MetadataSchema.optional(),
+    contents: z.array(ScanRequestContentsInnerSchema).min(1),
+  })
+  .passthrough();
 
 /** Complete scan request payload sent to the AIRS API. */
 export type ScanRequest = z.infer<typeof ScanRequestSchema>;

--- a/src/models/scan-response.ts
+++ b/src/models/scan-response.ts
@@ -5,10 +5,12 @@ import { ToolEventMetadataSchema } from './tool-event.js';
 import { PatternDetectionSchema, ContentErrorSchema } from './detection-reports.js';
 
 /** Zod schema for masked data in scan results. */
-export const MaskedDataSchema = z.object({
-  data: z.string().optional(),
-  pattern_detections: z.array(PatternDetectionSchema).optional(),
-});
+export const MaskedDataSchema = z
+  .object({
+    data: z.string().optional(),
+    pattern_detections: z.array(PatternDetectionSchema).optional(),
+  })
+  .passthrough();
 
 /** Masked data containing redacted content and pattern detections. */
 export type MaskedData = z.infer<typeof MaskedDataSchema>;
@@ -39,41 +41,45 @@ export const ScanSummarySchema = z
 export type ScanSummary = z.infer<typeof ScanSummarySchema>;
 
 /** Zod schema for tool/agent detection results. */
-export const ToolDetectedSchema = z.object({
-  verdict: z.string().optional(),
-  metadata: ToolEventMetadataSchema.optional(),
-  summary: ScanSummarySchema.optional(),
-  input_detected: IODetectedSchema.optional(),
-  output_detected: IODetectedSchema.optional(),
-});
+export const ToolDetectedSchema = z
+  .object({
+    verdict: z.string().optional(),
+    metadata: ToolEventMetadataSchema.optional(),
+    summary: ScanSummarySchema.optional(),
+    input_detected: IODetectedSchema.optional(),
+    output_detected: IODetectedSchema.optional(),
+  })
+  .passthrough();
 
 /** Detection results for tool/agent interactions. */
 export type ToolDetected = z.infer<typeof ToolDetectedSchema>;
 
 /** Zod schema for a complete scan response from the AIRS API. */
-export const ScanResponseSchema = z.object({
-  source: z.string().optional(),
-  report_id: z.string(),
-  scan_id: z.string(),
-  tr_id: z.string().optional(),
-  session_id: z.string().optional(),
-  profile_id: z.string().optional(),
-  profile_name: z.string().optional(),
-  category: z.string(),
-  action: z.string(),
-  timeout: z.boolean().optional(),
-  error: z.boolean().optional(),
-  errors: z.array(ContentErrorSchema).optional(),
-  prompt_detected: PromptDetectedSchema.optional(),
-  response_detected: ResponseDetectedSchema.optional(),
-  prompt_masked_data: MaskedDataSchema.optional(),
-  response_masked_data: MaskedDataSchema.optional(),
-  prompt_detection_details: PromptDetectionDetailsSchema.optional(),
-  response_detection_details: ResponseDetectionDetailsSchema.optional(),
-  tool_detected: ToolDetectedSchema.optional(),
-  created_at: z.string().optional(),
-  completed_at: z.string().optional(),
-});
+export const ScanResponseSchema = z
+  .object({
+    source: z.string().optional(),
+    report_id: z.string(),
+    scan_id: z.string(),
+    tr_id: z.string().optional(),
+    session_id: z.string().optional(),
+    profile_id: z.string().optional(),
+    profile_name: z.string().optional(),
+    category: z.string(),
+    action: z.string(),
+    timeout: z.boolean().optional(),
+    error: z.boolean().optional(),
+    errors: z.array(ContentErrorSchema).optional(),
+    prompt_detected: PromptDetectedSchema.optional(),
+    response_detected: ResponseDetectedSchema.optional(),
+    prompt_masked_data: MaskedDataSchema.optional(),
+    response_masked_data: MaskedDataSchema.optional(),
+    prompt_detection_details: PromptDetectionDetailsSchema.optional(),
+    response_detection_details: ResponseDetectionDetailsSchema.optional(),
+    tool_detected: ToolDetectedSchema.optional(),
+    created_at: z.string().optional(),
+    completed_at: z.string().optional(),
+  })
+  .passthrough();
 
 /** Complete scan response with verdict, action, and detection details. */
 export type ScanResponse = z.infer<typeof ScanResponseSchema>;

--- a/src/models/threat-report.ts
+++ b/src/models/threat-report.ts
@@ -2,15 +2,17 @@ import { z } from 'zod';
 import { DetectionServiceResultSchema } from './detection.js';
 
 /** Zod schema for a detailed threat scan report. */
-export const ThreatScanReportSchema = z.object({
-  source: z.string().optional(),
-  report_id: z.string().optional(),
-  scan_id: z.string().optional(),
-  req_id: z.number().optional(),
-  transaction_id: z.string().optional(),
-  session_id: z.string().optional(),
-  detection_results: z.array(DetectionServiceResultSchema).optional(),
-});
+export const ThreatScanReportSchema = z
+  .object({
+    source: z.string().optional(),
+    report_id: z.string().optional(),
+    scan_id: z.string().optional(),
+    req_id: z.number().optional(),
+    transaction_id: z.string().optional(),
+    session_id: z.string().optional(),
+    detection_results: z.array(DetectionServiceResultSchema).optional(),
+  })
+  .passthrough();
 
 /** Detailed threat scan report with per-service detection results. */
 export type ThreatScanReport = z.infer<typeof ThreatScanReportSchema>;

--- a/src/models/tool-event.ts
+++ b/src/models/tool-event.ts
@@ -1,22 +1,26 @@
 import { z } from 'zod';
 
 /** Zod schema for tool/function call event metadata. */
-export const ToolEventMetadataSchema = z.object({
-  ecosystem: z.string(),
-  method: z.string(),
-  server_name: z.string(),
-  tool_invoked: z.string().optional(),
-});
+export const ToolEventMetadataSchema = z
+  .object({
+    ecosystem: z.string(),
+    method: z.string(),
+    server_name: z.string(),
+    tool_invoked: z.string().optional(),
+  })
+  .passthrough();
 
 /** Tool/function call event metadata (ecosystem, method, server, tool). */
 export type ToolEventMetadata = z.infer<typeof ToolEventMetadataSchema>;
 
 /** Zod schema for a tool/function call event with input and output. */
-export const ToolEventSchema = z.object({
-  metadata: ToolEventMetadataSchema.optional(),
-  input: z.string().optional(),
-  output: z.string().optional(),
-});
+export const ToolEventSchema = z
+  .object({
+    metadata: ToolEventMetadataSchema.optional(),
+    input: z.string().optional(),
+    output: z.string().optional(),
+  })
+  .passthrough();
 
 /** Tool/function call event with optional input and output strings. */
 export type ToolEvent = z.infer<typeof ToolEventSchema>;

--- a/src/models/urlf-report.ts
+++ b/src/models/urlf-report.ts
@@ -1,12 +1,14 @@
 import { z } from 'zod';
 
 /** Zod schema for a URL filtering report entry. */
-export const UrlfEntrySchema = z.object({
-  url: z.string().optional(),
-  risk_level: z.string().optional(),
-  action: z.string().optional(),
-  categories: z.array(z.string()).optional(),
-});
+export const UrlfEntrySchema = z
+  .object({
+    url: z.string().optional(),
+    risk_level: z.string().optional(),
+    action: z.string().optional(),
+    categories: z.array(z.string()).optional(),
+  })
+  .passthrough();
 
 /** URL filtering report entry with URL, risk level, action, and categories. */
 export type UrlfEntry = z.infer<typeof UrlfEntrySchema>;

--- a/test/models/passthrough.spec.ts
+++ b/test/models/passthrough.spec.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AiProfileSchema,
+  AsyncScanObjectSchema,
+  AsyncScanResponseSchema,
+  AgentMetaSchema,
+  MetadataSchema,
+  PromptDetectionDetailsSchema,
+  PromptDetectedSchema,
+  ResponseDetectionDetailsSchema,
+  ResponseDetectedSchema,
+  ScanIdResultSchema,
+  ScanRequestContentsInnerSchema,
+  ScanRequestSchema,
+  ScanResponseSchema,
+  ThreatScanReportSchema,
+  ToolEventMetadataSchema,
+  ToolEventSchema,
+  DlpReportSchema,
+  UrlfEntrySchema,
+  MaskedDataSchema,
+  ToolDetectedSchema,
+  DetectionServiceResultSchema,
+} from '../../src/models/index.js';
+
+/**
+ * All Zod object schemas must use .passthrough() so that unknown fields
+ * from future API versions are preserved rather than stripped.
+ */
+describe('passthrough — scan-related schemas preserve unknown fields', () => {
+  it('AiProfileSchema', () => {
+    const r = AiProfileSchema.safeParse({ profile_name: 'p', _future: true });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', true);
+  });
+
+  it('AsyncScanObjectSchema', () => {
+    const r = AsyncScanObjectSchema.safeParse({
+      req_id: 1,
+      scan_req: {
+        ai_profile: { profile_name: 'p' },
+        contents: [{ prompt: 'hi' }],
+      },
+      _future: 42,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 42);
+  });
+
+  it('AsyncScanResponseSchema', () => {
+    const r = AsyncScanResponseSchema.safeParse({
+      received: 'now',
+      scan_id: 's1',
+      _future: 'x',
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 'x');
+  });
+
+  it('AgentMetaSchema', () => {
+    const r = AgentMetaSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('MetadataSchema', () => {
+    const r = MetadataSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('PromptDetectionDetailsSchema', () => {
+    const r = PromptDetectionDetailsSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('PromptDetectedSchema', () => {
+    const r = PromptDetectedSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ResponseDetectionDetailsSchema', () => {
+    const r = ResponseDetectionDetailsSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ResponseDetectedSchema', () => {
+    const r = ResponseDetectedSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ScanIdResultSchema', () => {
+    const r = ScanIdResultSchema.safeParse({
+      scan_id: 's1',
+      _future: 1,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ScanRequestContentsInnerSchema', () => {
+    const r = ScanRequestContentsInnerSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ScanRequestSchema', () => {
+    const r = ScanRequestSchema.safeParse({
+      ai_profile: { profile_name: 'p' },
+      contents: [{ prompt: 'hi' }],
+      _future: 1,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ScanResponseSchema', () => {
+    const r = ScanResponseSchema.safeParse({
+      report_id: 'r1',
+      scan_id: 's1',
+      category: 'benign',
+      action: 'allow',
+      _future: 1,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ThreatScanReportSchema', () => {
+    const r = ThreatScanReportSchema.safeParse({
+      report_id: 'r1',
+      _future: 1,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ToolEventMetadataSchema', () => {
+    const r = ToolEventMetadataSchema.safeParse({
+      ecosystem: 'mcp',
+      method: 'invoke',
+      server_name: 'srv',
+      _future: 1,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ToolEventSchema', () => {
+    const r = ToolEventSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('DlpReportSchema', () => {
+    const r = DlpReportSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('UrlfEntrySchema', () => {
+    const r = UrlfEntrySchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('MaskedDataSchema', () => {
+    const r = MaskedDataSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ToolDetectedSchema', () => {
+    const r = ToolDetectedSchema.safeParse({ _future: 1 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('DetectionServiceResultSchema', () => {
+    const r = DetectionServiceResultSchema.safeParse({
+      data_type: 'prompt',
+      _future: 1,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `.passthrough()` to 22 Zod object schemas in scan-related model files for forward compatibility
- Unknown API fields are now preserved instead of stripped during parsing
- Add tsup build artifacts to `.prettierignore`

## Test plan
- [x] 21 new passthrough tests verifying unknown fields are preserved
- [x] All 754 tests pass (733 existing + 21 new)
- [x] Typecheck, lint, format clean

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)