### PR TITLE
docs: add JSDoc to exported utility functions and enums

### DIFF
--- a/src/management/management-http-client.ts
+++ b/src/management/management-http-client.ts
@@ -19,6 +19,12 @@ export interface MgmtHttpResponse<T = unknown> {
   data: T;
 }
 
+/**
+ * @internal Execute an authenticated HTTP request against the management API.
+ * Handles OAuth token refresh on 401/403 and retries with exponential backoff.
+ * @param opts - Request options including method, path, body, and auth.
+ * @returns Typed response with HTTP status and parsed JSON body.
+ */
 export async function managementHttpRequest<T>(
   opts: MgmtHttpRequestOptions,
 ): Promise<MgmtHttpResponse<T>> {

--- a/src/model-security/scans-client.ts
+++ b/src/model-security/scans-client.ts
@@ -349,6 +349,7 @@ export class ModelSecurityScansClient {
    * Delete labels from a scan by key.
    * @param scanUuid - Scan UUID.
    * @param keys - Label keys to delete.
+   * @returns Resolves when the labels are deleted.
    */
   async deleteLabels(scanUuid: string, keys: string[]): Promise<void> {
     if (!isValidUuid(scanUuid)) {

--- a/src/red-team/scans-client.ts
+++ b/src/red-team/scans-client.ts
@@ -52,7 +52,11 @@ export class RedTeamScansClient {
     this.numRetries = opts.numRetries;
   }
 
-  /** Create a new red team scan job. */
+  /**
+   * Create a new red team scan job.
+   * @param request - Job creation request body.
+   * @returns The created job response.
+   */
   async create(request: JobCreateRequest): Promise<JobResponse> {
     const res = await managementHttpRequest<JobResponse>({
       method: 'POST',

--- a/src/red-team/targets-client.ts
+++ b/src/red-team/targets-client.ts
@@ -54,7 +54,12 @@ export class RedTeamTargetsClient {
     this.numRetries = opts.numRetries;
   }
 
-  /** Create a new target. */
+  /**
+   * Create a new target.
+   * @param request - Target creation request body.
+   * @param opts - Optional operation options (e.g. validate connection).
+   * @returns The created target response.
+   */
   async create(
     request: TargetCreateRequest,
     opts?: TargetOperationOptions,

--- a/src/scan/content.ts
+++ b/src/scan/content.ts
@@ -38,6 +38,11 @@ export class Content {
   private _codeResponse?: string;
   private _toolEvent?: ToolEvent;
 
+  /**
+   * Create a new Content instance.
+   * @param opts - Content fields; at least one of prompt, response, codePrompt, codeResponse, or toolEvent is required.
+   * @throws {AISecSDKException} If no content field is provided or a field exceeds its byte-length limit.
+   */
   constructor(opts: ContentOptions) {
     if (
       !opts.prompt &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,10 +4,21 @@ import { createHmac } from 'node:crypto';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/**
+ * Test whether a string is a valid RFC 4122 UUID.
+ * @param value - The string to validate.
+ * @returns `true` if the string matches the UUID format.
+ */
 export function isValidUuid(value: string): boolean {
   return UUID_RE.test(value);
 }
 
+/**
+ * Generate an HMAC-SHA256 hex digest for API key authentication.
+ * @param payload - The JSON payload string to sign.
+ * @param secret - The API key secret.
+ * @returns Hex-encoded HMAC-SHA256 hash.
+ */
 export function generatePayloadHash(payload: string, secret: string): string {
   return createHmac('sha256', secret).update(payload).digest('hex');
 }


### PR DESCRIPTION
## Summary
- Add JSDoc to `isValidUuid()` and `generatePayloadHash()` in `src/utils.ts`
- Add JSDoc to `managementHttpRequest()` in `src/management/management-http-client.ts`
- Expand incomplete JSDoc on `RedTeamScansClient.create()`, `Content` constructor, `RedTeamTargetsClient.create()`, and `ModelSecurityScansClient.deleteLabels()`
- Red-team enums already had JSDoc; no changes needed there

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)