### PR TITLE
fix: schema passthrough + backoff jitter + dedup buildListParams

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.6.5
+
+### Reliability & Code Quality
+
+- **Zod passthrough**: Added `.passthrough()` to final 4 schemas (`ApiKeyCreateRequestSchema`, `ApiKeyRegenerateRequestSchema`, `ClientIdAndCustomerAppSchema`, `ErrorResponseSchema.retry_after`)
+- **Backoff jitter**: Exponential backoff now uses full jitter strategy (`uniform [0, 2^attempt × 1000ms]`) to prevent thundering herd
+- **Dedup**: Extracted `buildRedTeamListParams()` shared utility, removing 6× identical `buildListParams()` functions across red-team sub-clients
+
+---
+
 ## v0.6.4
 
 ### Schema Forward Compatibility & Doc Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.6.4';
+export const SDK_VERSION = '0.6.5';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/http-retry.ts
+++ b/src/http-retry.ts
@@ -12,12 +12,14 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Calculate exponential backoff delay for the given attempt.
+ * Calculate exponential backoff delay with full jitter for the given attempt.
+ * Uses the "full jitter" strategy: uniform random in [0, 2^attempt * 1000].
  * @param attempt - Zero-based attempt number.
  * @returns Delay in milliseconds.
  */
 export function backoffDelay(attempt: number): number {
-  return Math.pow(2, attempt) * 1000;
+  const maxDelay = Math.pow(2, attempt) * 1000;
+  return Math.floor(Math.random() * (maxDelay + 1));
 }
 
 /**

--- a/src/models/error-response.ts
+++ b/src/models/error-response.ts
@@ -16,6 +16,7 @@ export const ErrorResponseSchema = z
         interval: z.number().optional(),
         unit: z.string().optional(),
       })
+      .passthrough()
       .optional(),
   })
   .passthrough();

--- a/src/models/mgmt-api-key.ts
+++ b/src/models/mgmt-api-key.ts
@@ -35,29 +35,33 @@ export const ApiKeySchema = z
 export type ApiKey = z.infer<typeof ApiKeySchema>;
 
 /** Zod schema for API key creation request. */
-export const ApiKeyCreateRequestSchema = z.object({
-  dp_name: z.string().optional(),
-  auth_code: z.string(),
-  cust_app: z.string(),
-  cust_env: z.string().optional(),
-  cust_cloud_provider: z.string().optional(),
-  cust_ai_agent_framework: z.string().optional(),
-  revoked: z.boolean(),
-  created_by: z.string(),
-  api_key_name: z.string(),
-  rotation_time_interval: z.number(),
-  rotation_time_unit: z.string(),
-});
+export const ApiKeyCreateRequestSchema = z
+  .object({
+    dp_name: z.string().optional(),
+    auth_code: z.string(),
+    cust_app: z.string(),
+    cust_env: z.string().optional(),
+    cust_cloud_provider: z.string().optional(),
+    cust_ai_agent_framework: z.string().optional(),
+    revoked: z.boolean(),
+    created_by: z.string(),
+    api_key_name: z.string(),
+    rotation_time_interval: z.number(),
+    rotation_time_unit: z.string(),
+  })
+  .passthrough();
 
 /** API key creation request. */
 export type ApiKeyCreateRequest = z.infer<typeof ApiKeyCreateRequestSchema>;
 
 /** Zod schema for API key regeneration request. */
-export const ApiKeyRegenerateRequestSchema = z.object({
-  rotation_time_interval: z.number(),
-  rotation_time_unit: z.string(),
-  updated_by: z.string().optional(),
-});
+export const ApiKeyRegenerateRequestSchema = z
+  .object({
+    rotation_time_interval: z.number(),
+    rotation_time_unit: z.string(),
+    updated_by: z.string().optional(),
+  })
+  .passthrough();
 
 /** API key regeneration request. */
 export type ApiKeyRegenerateRequest = z.infer<typeof ApiKeyRegenerateRequestSchema>;

--- a/src/models/mgmt-oauth.ts
+++ b/src/models/mgmt-oauth.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
 
 /** Zod schema for OAuth client_id + customer_app request body. */
-export const ClientIdAndCustomerAppSchema = z.object({
-  client_id: z.string(),
-  customer_app: z.string(),
-});
+export const ClientIdAndCustomerAppSchema = z
+  .object({
+    client_id: z.string(),
+    customer_app: z.string(),
+  })
+  .passthrough();
 
 /** OAuth client_id and customer_app request body. */
 export type ClientIdAndCustomerApp = z.infer<typeof ClientIdAndCustomerAppSchema>;

--- a/src/red-team/client.ts
+++ b/src/red-team/client.ts
@@ -28,6 +28,7 @@ import { RedTeamCustomAttackReportsClient } from './custom-attack-reports-client
 import { RedTeamTargetsClient } from './targets-client.js';
 import { RedTeamCustomAttacksClient } from './custom-attacks-client.js';
 import type { RedTeamListOptions } from './scans-client.js';
+import { buildRedTeamListParams } from './list-params.js';
 import type {
   ScanStatisticsResponse,
   ScoreTrendResponse,
@@ -54,14 +55,6 @@ export interface RedTeamClientOptions {
   tokenEndpoint?: string;
   /** Max retry attempts (0-5). Defaults to 5. */
   numRetries?: number;
-}
-
-function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.search !== undefined) params.search = opts.search;
-  return params;
 }
 
 /**
@@ -223,7 +216,7 @@ export class RedTeamClient {
       method: 'GET',
       baseUrl: this.dataEndpoint,
       path: `${RED_TEAM_ERROR_LOG_PATH}/${jobId}`,
-      params: buildListParams(opts),
+      params: buildRedTeamListParams(opts),
       oauthClient: this.oauthClient,
       numRetries: this.numRetries,
     });

--- a/src/red-team/custom-attack-reports-client.ts
+++ b/src/red-team/custom-attack-reports-client.ts
@@ -2,6 +2,7 @@ import { RED_TEAM_CUSTOM_ATTACKS_REPORT_PATH } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { isValidUuid } from '../utils.js';
 import { managementHttpRequest } from '../management/management-http-client.js';
+import { buildRedTeamListParams } from './list-params.js';
 import type { OAuthClient } from '../management/oauth-client.js';
 import type { RedTeamListOptions } from './scans-client.js';
 import type {
@@ -30,14 +31,6 @@ export interface RedTeamCustomAttackReportsClientOptions {
   baseUrl: string;
   oauthClient: OAuthClient;
   numRetries: number;
-}
-
-function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.search !== undefined) params.search = opts.search;
-  return params;
 }
 
 function validateJobId(jobId: string): void {
@@ -98,7 +91,7 @@ export class RedTeamCustomAttackReportsClient {
       );
     }
 
-    const params = buildListParams(opts);
+    const params = buildRedTeamListParams(opts);
     if (opts?.is_threat !== undefined) params.is_threat = String(opts.is_threat);
 
     const res = await managementHttpRequest<PromptDetailResponse[]>({
@@ -138,7 +131,7 @@ export class RedTeamCustomAttackReportsClient {
     opts?: CustomAttacksReportListOptions,
   ): Promise<CustomAttacksListResponse> {
     validateJobId(jobId);
-    const params = buildListParams(opts);
+    const params = buildRedTeamListParams(opts);
     if (opts?.threat !== undefined) params.threat = String(opts.threat);
     if (opts?.prompt_set_id !== undefined) params.prompt_set_id = opts.prompt_set_id;
     if (opts?.property_value !== undefined) params.property_value = opts.property_value;

--- a/src/red-team/custom-attacks-client.ts
+++ b/src/red-team/custom-attacks-client.ts
@@ -2,6 +2,7 @@ import { RED_TEAM_CUSTOM_ATTACK_PATH, USER_AGENT } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { isValidUuid } from '../utils.js';
 import { managementHttpRequest } from '../management/management-http-client.js';
+import { buildRedTeamListParams } from './list-params.js';
 import type { OAuthClient } from '../management/oauth-client.js';
 import type { RedTeamListOptions } from './scans-client.js';
 import type {
@@ -44,14 +45,6 @@ export interface RedTeamCustomAttacksClientOptions {
   numRetries: number;
 }
 
-function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.search !== undefined) params.search = opts.search;
-  return params;
-}
-
 function validateUuid(uuid: string, label: string): void {
   if (!isValidUuid(uuid)) {
     throw new AISecSDKException(`Invalid ${label}: ${uuid}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
@@ -89,7 +82,7 @@ export class RedTeamCustomAttacksClient {
 
   /** List custom prompt sets. */
   async listPromptSets(opts?: PromptSetListOptions): Promise<CustomPromptSetList> {
-    const params = buildListParams(opts);
+    const params = buildRedTeamListParams(opts);
     if (opts?.status !== undefined) params.status = opts.status;
     if (opts?.active !== undefined) params.active = String(opts.active);
     if (opts?.archive !== undefined) params.archive = String(opts.archive);
@@ -257,7 +250,7 @@ export class RedTeamCustomAttacksClient {
   /** List prompts in a prompt set. */
   async listPrompts(promptSetUuid: string, opts?: PromptListOptions): Promise<CustomPromptList> {
     validateUuid(promptSetUuid, 'prompt set uuid');
-    const params = buildListParams(opts);
+    const params = buildRedTeamListParams(opts);
     if (opts?.active !== undefined) params.active = String(opts.active);
 
     const res = await managementHttpRequest<CustomPromptList>({

--- a/src/red-team/list-params.ts
+++ b/src/red-team/list-params.ts
@@ -1,0 +1,14 @@
+import type { RedTeamListOptions } from './scans-client.js';
+
+/**
+ * Convert Red Team list options into a string-keyed params record for query strings.
+ * @param opts - Optional pagination and search options.
+ * @returns Record of string key-value pairs.
+ */
+export function buildRedTeamListParams(opts?: RedTeamListOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}

--- a/src/red-team/reports-client.ts
+++ b/src/red-team/reports-client.ts
@@ -6,6 +6,7 @@ import {
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { isValidUuid } from '../utils.js';
 import { managementHttpRequest } from '../management/management-http-client.js';
+import { buildRedTeamListParams } from './list-params.js';
 import type { OAuthClient } from '../management/oauth-client.js';
 import type { RedTeamListOptions } from './scans-client.js';
 import type {
@@ -45,14 +46,6 @@ export interface RedTeamReportsClientOptions {
   numRetries: number;
 }
 
-function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.search !== undefined) params.search = opts.search;
-  return params;
-}
-
 function validateJobId(jobId: string): void {
   if (!isValidUuid(jobId)) {
     throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
@@ -78,7 +71,7 @@ export class RedTeamReportsClient {
   /** List attacks for a static scan. */
   async listAttacks(jobId: string, opts?: AttackListOptions): Promise<AttackListResponse> {
     validateJobId(jobId);
-    const params = buildListParams(opts);
+    const params = buildRedTeamListParams(opts);
     if (opts?.status !== undefined) params.status = opts.status;
     if (opts?.severity !== undefined) params.severity = opts.severity;
     if (opts?.category !== undefined) params.category = opts.category;
@@ -225,7 +218,7 @@ export class RedTeamReportsClient {
   /** List goals for a dynamic scan. */
   async listGoals(jobId: string, opts?: GoalListOptions): Promise<GoalListResponse> {
     validateJobId(jobId);
-    const params = buildListParams(opts);
+    const params = buildRedTeamListParams(opts);
     if (opts?.goal_type !== undefined) params.goal_type = opts.goal_type;
     if (opts?.status !== undefined) params.status = opts.status;
     if (opts?.count !== undefined) params.count = String(opts.count);
@@ -259,7 +252,7 @@ export class RedTeamReportsClient {
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${RED_TEAM_REPORT_DYNAMIC_PATH}/${jobId}/goal/${goalId}/list-streams`,
-      params: buildListParams(opts),
+      params: buildRedTeamListParams(opts),
       oauthClient: this.oauthClient,
       numRetries: this.numRetries,
     });

--- a/src/red-team/scans-client.ts
+++ b/src/red-team/scans-client.ts
@@ -2,6 +2,7 @@ import { RED_TEAM_SCAN_PATH, RED_TEAM_CATEGORIES_PATH } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { isValidUuid } from '../utils.js';
 import { managementHttpRequest } from '../management/management-http-client.js';
+import { buildRedTeamListParams } from './list-params.js';
 import type { OAuthClient } from '../management/oauth-client.js';
 import type {
   JobCreateRequest,
@@ -30,14 +31,6 @@ export interface RedTeamScansClientOptions {
   baseUrl: string;
   oauthClient: OAuthClient;
   numRetries: number;
-}
-
-function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.search !== undefined) params.search = opts.search;
-  return params;
 }
 
 /** Client for Red Team data plane scan operations. */
@@ -71,7 +64,7 @@ export class RedTeamScansClient {
 
   /** List red team scan jobs with optional filters. */
   async list(opts?: RedTeamScanListOptions): Promise<JobListResponse> {
-    const params = buildListParams(opts);
+    const params = buildRedTeamListParams(opts);
     if (opts?.status !== undefined) params.status = opts.status;
     if (opts?.job_type !== undefined) params.job_type = opts.job_type;
     if (opts?.target_id !== undefined) params.target_id = opts.target_id;

--- a/src/red-team/targets-client.ts
+++ b/src/red-team/targets-client.ts
@@ -2,6 +2,7 @@ import { RED_TEAM_TARGET_PATH } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { isValidUuid } from '../utils.js';
 import { managementHttpRequest } from '../management/management-http-client.js';
+import { buildRedTeamListParams } from './list-params.js';
 import type { OAuthClient } from '../management/oauth-client.js';
 import type { RedTeamListOptions } from './scans-client.js';
 import type {
@@ -32,14 +33,6 @@ export interface RedTeamTargetsClientOptions {
   baseUrl: string;
   oauthClient: OAuthClient;
   numRetries: number;
-}
-
-function buildListParams(opts?: RedTeamListOptions): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.search !== undefined) params.search = opts.search;
-  return params;
 }
 
 /** Client for Red Team management plane target operations. */
@@ -81,7 +74,7 @@ export class RedTeamTargetsClient {
 
   /** List targets with optional filters. */
   async list(opts?: TargetListOptions): Promise<TargetList> {
-    const params = buildListParams(opts);
+    const params = buildRedTeamListParams(opts);
     if (opts?.target_type !== undefined) params.target_type = opts.target_type;
     if (opts?.status !== undefined) params.status = opts.status;
 

--- a/test/http-retry.spec.ts
+++ b/test/http-retry.spec.ts
@@ -18,11 +18,22 @@ describe('sleep', () => {
 });
 
 describe('backoffDelay', () => {
-  it('returns exponential delays', () => {
-    expect(backoffDelay(0)).toBe(1000);
-    expect(backoffDelay(1)).toBe(2000);
-    expect(backoffDelay(2)).toBe(4000);
-    expect(backoffDelay(3)).toBe(8000);
+  it('returns delays within jittered range', () => {
+    // With jitter, delay should be between 0 and 2^attempt * 1000
+    for (let attempt = 0; attempt < 4; attempt++) {
+      const max = Math.pow(2, attempt) * 1000;
+      const delay = backoffDelay(attempt);
+      expect(delay).toBeGreaterThanOrEqual(0);
+      expect(delay).toBeLessThanOrEqual(max);
+    }
+  });
+
+  it('produces varying delays (jitter)', () => {
+    // Run multiple times — with jitter, we should get different values
+    const delays = Array.from({ length: 20 }, () => backoffDelay(3));
+    const unique = new Set(delays);
+    // With true randomness over 20 samples, we should get >1 unique value
+    expect(unique.size).toBeGreaterThan(1);
   });
 });
 

--- a/test/models/passthrough.spec.ts
+++ b/test/models/passthrough.spec.ts
@@ -50,6 +50,9 @@ import {
   PropertyNameCreateRequestSchema,
   PropertyValueCreateRequestSchema,
   PropertyDefinitionSchema,
+  ApiKeyCreateRequestSchema,
+  ApiKeyRegenerateRequestSchema,
+  ClientIdAndCustomerAppSchema,
 } from '../../src/models/index.js';
 
 /**
@@ -499,5 +502,53 @@ describe('passthrough — red-team schemas preserve unknown fields', () => {
     });
     expect(r.success).toBe(true);
     if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+});
+
+describe('passthrough — management schemas preserve unknown fields', () => {
+  it('ApiKeyCreateRequestSchema', () => {
+    const r = ApiKeyCreateRequestSchema.safeParse({
+      auth_code: 'ac',
+      cust_app: 'app',
+      revoked: false,
+      created_by: 'user',
+      api_key_name: 'key1',
+      rotation_time_interval: 30,
+      rotation_time_unit: 'days',
+      _future: 1,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ApiKeyRegenerateRequestSchema', () => {
+    const r = ApiKeyRegenerateRequestSchema.safeParse({
+      rotation_time_interval: 30,
+      rotation_time_unit: 'days',
+      _future: 1,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ClientIdAndCustomerAppSchema', () => {
+    const r = ClientIdAndCustomerAppSchema.safeParse({
+      client_id: 'cid',
+      customer_app: 'app',
+      _future: 1,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('_future', 1);
+  });
+
+  it('ErrorResponseSchema retry_after preserves unknown fields', () => {
+    const r = ErrorResponseSchema.safeParse({
+      retry_after: { interval: 5, unit: 'seconds', _future: 1 },
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const retryAfter = r.data.retry_after as Record<string, unknown>;
+      expect(retryAfter).toHaveProperty('_future', 1);
+    }
   });
 });

--- a/test/red-team/build-list-params.spec.ts
+++ b/test/red-team/build-list-params.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { buildRedTeamListParams } from '../../src/red-team/list-params.js';
+
+describe('buildRedTeamListParams', () => {
+  it('returns empty object when no options', () => {
+    expect(buildRedTeamListParams()).toEqual({});
+    expect(buildRedTeamListParams(undefined)).toEqual({});
+  });
+
+  it('converts skip to string', () => {
+    expect(buildRedTeamListParams({ skip: 0 })).toEqual({ skip: '0' });
+    expect(buildRedTeamListParams({ skip: 10 })).toEqual({ skip: '10' });
+  });
+
+  it('converts limit to string', () => {
+    expect(buildRedTeamListParams({ limit: 50 })).toEqual({ limit: '50' });
+  });
+
+  it('passes search as-is', () => {
+    expect(buildRedTeamListParams({ search: 'test' })).toEqual({ search: 'test' });
+  });
+
+  it('includes all options together', () => {
+    expect(buildRedTeamListParams({ skip: 5, limit: 10, search: 'q' })).toEqual({
+      skip: '5',
+      limit: '10',
+      search: 'q',
+    });
+  });
+
+  it('ignores undefined values', () => {
+    expect(buildRedTeamListParams({ skip: undefined, limit: 10 })).toEqual({ limit: '10' });
+  });
+});


### PR DESCRIPTION
## Summary

- Added `.passthrough()` to 4 remaining Zod schemas (ApiKeyCreateRequest, ApiKeyRegenerateRequest, ClientIdAndCustomerApp, ErrorResponse retry_after)
- Added full jitter to exponential backoff (`uniform [0, 2^attempt × 1000ms]`) to prevent thundering herd
- Extracted `buildRedTeamListParams()` shared utility, removing 6× identical `buildListParams()` functions
- Bumped version to 0.6.5

Closes #56

## Test plan

- [x] 4 new passthrough tests + 1 retry_after nested test
- [x] 2 jitter tests (range validation + randomness)
- [x] 6 buildRedTeamListParams unit tests
- [x] Full suite: 794 tests passing
- [x] Lint, typecheck, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)