### PR TITLE
test: improve content.ts coverage

### DIFF
--- a/test/scan/content.spec.ts
+++ b/test/scan/content.spec.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { Content } from '../../src/scan/content.js';
 import { AISecSDKException } from '../../src/errors.js';
 
@@ -60,6 +63,105 @@ describe('Content', () => {
     });
   });
 
+  describe('setter validation', () => {
+    it('sets prompt via setter', () => {
+      const c = new Content({ prompt: 'a' });
+      c.prompt = 'updated';
+      expect(c.prompt).toBe('updated');
+    });
+
+    it('clears prompt by setting undefined', () => {
+      const c = new Content({ prompt: 'a', response: 'b' });
+      c.prompt = undefined;
+      expect(c.prompt).toBeUndefined();
+    });
+
+    it('throws if codePrompt exceeds max via setter', () => {
+      const c = new Content({ prompt: 'ok' });
+      expect(() => {
+        c.codePrompt = 'x'.repeat(3 * 1024 * 1024);
+      }).toThrow(/codePrompt exceeds/);
+    });
+
+    it('throws if codeResponse exceeds max via setter', () => {
+      const c = new Content({ prompt: 'ok' });
+      expect(() => {
+        c.codeResponse = 'x'.repeat(3 * 1024 * 1024);
+      }).toThrow(/codeResponse exceeds/);
+    });
+
+    it('throws if context exceeds max via setter', () => {
+      const c = new Content({ prompt: 'ok' });
+      expect(() => {
+        c.context = 'x'.repeat(101 * 1024 * 1024);
+      }).toThrow(/context exceeds/);
+    });
+
+    it('sets valid codePrompt via setter', () => {
+      const c = new Content({ prompt: 'ok' });
+      c.codePrompt = 'code';
+      expect(c.codePrompt).toBe('code');
+    });
+
+    it('sets valid codeResponse via setter', () => {
+      const c = new Content({ prompt: 'ok' });
+      c.codeResponse = 'result';
+      expect(c.codeResponse).toBe('result');
+    });
+
+    it('sets valid context via setter', () => {
+      const c = new Content({ prompt: 'ok' });
+      c.context = 'ctx';
+      expect(c.context).toBe('ctx');
+    });
+
+    it('sets and gets toolEvent via setter', () => {
+      const c = new Content({ prompt: 'ok' });
+      const te = { metadata: { ecosystem: 'mcp', method: 'x', server_name: 's' } };
+      c.toolEvent = te;
+      expect(c.toolEvent).toBe(te);
+      c.toolEvent = undefined;
+      expect(c.toolEvent).toBeUndefined();
+    });
+  });
+
+  describe('length', () => {
+    it('includes codePrompt and codeResponse in length', () => {
+      const c = new Content({ codePrompt: 'ab', codeResponse: 'cd' });
+      expect(c.length).toBe(4);
+    });
+
+    it('includes context in length', () => {
+      const c = new Content({ prompt: 'a', context: 'bbb' });
+      expect(c.length).toBe(4);
+    });
+
+    it('returns 0 for toolEvent-only content', () => {
+      const c = new Content({
+        toolEvent: { metadata: { ecosystem: 'mcp', method: 'x', server_name: 's' } },
+      });
+      expect(c.length).toBe(0);
+    });
+  });
+
+  describe('toJSON', () => {
+    it('serializes codeResponse as code_response', () => {
+      const c = new Content({ codeResponse: 'out' });
+      expect(c.toJSON()).toEqual({ code_response: 'out' });
+    });
+
+    it('serializes toolEvent as tool_event', () => {
+      const te = { metadata: { ecosystem: 'mcp', method: 'x', server_name: 's' }, input: '{}' };
+      const c = new Content({ toolEvent: te });
+      expect(c.toJSON().tool_event).toEqual(te);
+    });
+
+    it('serializes context', () => {
+      const c = new Content({ prompt: 'p', context: 'ctx' });
+      expect(c.toJSON()).toEqual({ prompt: 'p', context: 'ctx' });
+    });
+  });
+
   describe('fromJSON', () => {
     it('round-trips through toJSON/fromJSON', () => {
       const original = new Content({ prompt: 'p', response: 'r', context: 'ctx' });
@@ -67,6 +169,44 @@ describe('Content', () => {
       expect(restored.prompt).toBe('p');
       expect(restored.response).toBe('r');
       expect(restored.context).toBe('ctx');
+    });
+
+    it('restores codePrompt and codeResponse', () => {
+      const c = Content.fromJSON({ code_prompt: 'cp', code_response: 'cr' });
+      expect(c.codePrompt).toBe('cp');
+      expect(c.codeResponse).toBe('cr');
+    });
+
+    it('restores toolEvent', () => {
+      const te = { metadata: { ecosystem: 'mcp', method: 'x', server_name: 's' } };
+      const c = Content.fromJSON({ tool_event: te });
+      expect(c.toolEvent).toEqual(te);
+    });
+  });
+
+  describe('fromJSONFile', () => {
+    it('loads content from a JSON file', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'content-test-'));
+      const filePath = join(dir, 'content.json');
+      writeFileSync(filePath, JSON.stringify({ prompt: 'from file', response: 'resp' }));
+
+      const c = Content.fromJSONFile(filePath);
+      expect(c.prompt).toBe('from file');
+      expect(c.response).toBe('resp');
+
+      rmSync(dir, { recursive: true });
+    });
+
+    it('loads content with code fields from file', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'content-test-'));
+      const filePath = join(dir, 'code.json');
+      writeFileSync(filePath, JSON.stringify({ code_prompt: 'cp', code_response: 'cr' }));
+
+      const c = Content.fromJSONFile(filePath);
+      expect(c.codePrompt).toBe('cp');
+      expect(c.codeResponse).toBe('cr');
+
+      rmSync(dir, { recursive: true });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Added 19 new tests for Content class covering setter validation, length computation, toJSON serialization, fromJSON deserialization, and fromJSONFile
- Coverage gaps addressed: codePrompt/codeResponse/context overflow via setters, undefined assignments, toolEvent serialization, fromJSONFile loading

Closes #57

## Test plan

- [x] 30 content tests passing (was 11)
- [x] Full suite: 813 tests passing
- [x] All quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)