### PR TITLE
docs: add @param/@returns JSDoc to ~60 exported methods

### DIFF
--- a/src/management/oauth-client.ts
+++ b/src/management/oauth-client.ts
@@ -81,13 +81,19 @@ export class OAuthClient {
     return this.pendingFetch;
   }
 
-  /** Clear the cached token, forcing a fresh fetch on next call. */
+  /**
+   * Clear the cached token, forcing a fresh fetch on next call.
+   * @returns Nothing.
+   */
   clearToken(): void {
     this.accessToken = null;
     this.expiresAt = 0;
   }
 
-  /** Check if the current token has passed its expiry time. Returns true if no token exists. */
+  /**
+   * Check if the current token has passed its expiry time. Returns true if no token exists.
+   * @returns Whether the token is expired.
+   */
   isTokenExpired(): boolean {
     if (!this.accessToken) return true;
     return Date.now() >= this.expiresAt;
@@ -97,6 +103,7 @@ export class OAuthClient {
    * Check if the token is within the pre-expiry buffer window.
    * Returns true if no token exists.
    * @param bufferMs - Custom buffer in ms. Defaults to the configured `tokenBufferMs`.
+   * @returns Whether the token is expiring soon.
    */
   isTokenExpiringSoon(bufferMs?: number): boolean {
     if (!this.accessToken) return true;

--- a/src/model-security/security-groups-client.ts
+++ b/src/model-security/security-groups-client.ts
@@ -177,6 +177,7 @@ export class ModelSecurityGroupsClient {
   /**
    * Delete a security group.
    * @param uuid - Security group UUID.
+   * @returns Resolves when the security group is deleted.
    */
   async delete(uuid: string): Promise<void> {
     if (!isValidUuid(uuid)) {

--- a/src/red-team/client.ts
+++ b/src/red-team/client.ts
@@ -156,7 +156,11 @@ export class RedTeamClient {
   // Data plane convenience methods
   // -----------------------------------------------------------------------
 
-  /** Get scan statistics and risk profile (data plane dashboard). */
+  /**
+   * Get scan statistics and risk profile (data plane dashboard).
+   * @param params - Optional date range and target ID filters.
+   * @returns The scan statistics response.
+   */
   async getScanStatistics(params?: {
     date_range?: string;
     target_id?: string;
@@ -176,7 +180,11 @@ export class RedTeamClient {
     return res.data;
   }
 
-  /** Get score trend for a target (data plane dashboard). */
+  /**
+   * Get score trend for a target (data plane dashboard).
+   * @param targetId - The target UUID.
+   * @returns The score trend response.
+   */
   async getScoreTrend(targetId: string): Promise<ScoreTrendResponse> {
     if (!isValidUuid(targetId)) {
       throw new AISecSDKException(
@@ -195,7 +203,10 @@ export class RedTeamClient {
     return res.data;
   }
 
-  /** Get quota summary. */
+  /**
+   * Get quota summary.
+   * @returns The quota summary.
+   */
   async getQuota(): Promise<QuotaSummary> {
     const res = await managementHttpRequest<QuotaSummary>({
       method: 'POST',
@@ -207,7 +218,12 @@ export class RedTeamClient {
     return res.data;
   }
 
-  /** List error logs for a scan job. */
+  /**
+   * List error logs for a scan job.
+   * @param jobId - The job UUID.
+   * @param opts - Optional pagination and search options.
+   * @returns The paginated list of error logs.
+   */
   async getErrorLogs(jobId: string, opts?: RedTeamListOptions): Promise<ErrorLogListResponse> {
     if (!isValidUuid(jobId)) {
       throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
@@ -223,7 +239,11 @@ export class RedTeamClient {
     return res.data;
   }
 
-  /** Update sentiment for a scan report. */
+  /**
+   * Update sentiment for a scan report.
+   * @param request - The sentiment request body.
+   * @returns The sentiment response.
+   */
   async updateSentiment(request: SentimentRequest): Promise<SentimentResponse> {
     const res = await managementHttpRequest<SentimentResponse>({
       method: 'POST',
@@ -236,7 +256,11 @@ export class RedTeamClient {
     return res.data;
   }
 
-  /** Get sentiment for a scan report. */
+  /**
+   * Get sentiment for a scan report.
+   * @param jobId - The job UUID.
+   * @returns The sentiment response.
+   */
   async getSentiment(jobId: string): Promise<SentimentResponse> {
     if (!isValidUuid(jobId)) {
       throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
@@ -255,7 +279,10 @@ export class RedTeamClient {
   // Management plane convenience methods
   // -----------------------------------------------------------------------
 
-  /** Get management dashboard overview. */
+  /**
+   * Get management dashboard overview.
+   * @returns The dashboard overview response.
+   */
   async getDashboardOverview(): Promise<DashboardOverviewResponse> {
     const res = await managementHttpRequest<DashboardOverviewResponse>({
       method: 'GET',

--- a/src/red-team/custom-attack-reports-client.ts
+++ b/src/red-team/custom-attack-reports-client.ts
@@ -51,7 +51,11 @@ export class RedTeamCustomAttackReportsClient {
     this.numRetries = opts.numRetries;
   }
 
-  /** Get custom attack report for a scan. */
+  /**
+   * Get custom attack report for a scan.
+   * @param jobId - The job UUID.
+   * @returns The custom attack report response.
+   */
   async getReport(jobId: string): Promise<CustomAttackReportResponse> {
     validateJobId(jobId);
     const res = await managementHttpRequest<CustomAttackReportResponse>({
@@ -64,7 +68,11 @@ export class RedTeamCustomAttackReportsClient {
     return res.data;
   }
 
-  /** Get prompt sets for a custom attack scan. */
+  /**
+   * Get prompt sets for a custom attack scan.
+   * @param jobId - The job UUID.
+   * @returns The prompt sets report response.
+   */
   async getPromptSets(jobId: string): Promise<PromptSetsReportResponse> {
     validateJobId(jobId);
     const res = await managementHttpRequest<PromptSetsReportResponse>({
@@ -77,7 +85,13 @@ export class RedTeamCustomAttackReportsClient {
     return res.data;
   }
 
-  /** Get prompts for a specific prompt set in a scan. */
+  /**
+   * Get prompts for a specific prompt set in a scan.
+   * @param jobId - The job UUID.
+   * @param promptSetId - The prompt set UUID.
+   * @param opts - Optional pagination, search, and filter options.
+   * @returns The list of prompt detail responses.
+   */
   async getPromptsBySet(
     jobId: string,
     promptSetId: string,
@@ -105,7 +119,12 @@ export class RedTeamCustomAttackReportsClient {
     return res.data;
   }
 
-  /** Get details for a specific prompt. */
+  /**
+   * Get details for a specific prompt.
+   * @param jobId - The job UUID.
+   * @param promptId - The prompt UUID.
+   * @returns The prompt detail response.
+   */
   async getPromptDetail(jobId: string, promptId: string): Promise<PromptDetailResponse> {
     validateJobId(jobId);
     if (!isValidUuid(promptId)) {
@@ -125,7 +144,12 @@ export class RedTeamCustomAttackReportsClient {
     return res.data;
   }
 
-  /** List custom attacks for a scan. */
+  /**
+   * List custom attacks for a scan.
+   * @param jobId - The job UUID.
+   * @param opts - Optional pagination, search, and filter options.
+   * @returns The paginated list of custom attacks.
+   */
   async listCustomAttacks(
     jobId: string,
     opts?: CustomAttacksReportListOptions,
@@ -147,7 +171,12 @@ export class RedTeamCustomAttackReportsClient {
     return res.data;
   }
 
-  /** Get attack outputs for a custom attack. */
+  /**
+   * Get attack outputs for a custom attack.
+   * @param jobId - The job UUID.
+   * @param attackId - The attack UUID.
+   * @returns The list of attack outputs.
+   */
   async getAttackOutputs(jobId: string, attackId: string): Promise<CustomAttackOutput[]> {
     validateJobId(jobId);
     if (!isValidUuid(attackId)) {
@@ -167,7 +196,11 @@ export class RedTeamCustomAttackReportsClient {
     return res.data;
   }
 
-  /** Get property statistics for a custom attack scan. */
+  /**
+   * Get property statistics for a custom attack scan.
+   * @param jobId - The job UUID.
+   * @returns The list of property statistics.
+   */
   async getPropertyStats(jobId: string): Promise<PropertyStatistic[]> {
     validateJobId(jobId);
     const res = await managementHttpRequest<PropertyStatistic[]>({

--- a/src/red-team/custom-attacks-client.ts
+++ b/src/red-team/custom-attacks-client.ts
@@ -67,7 +67,11 @@ export class RedTeamCustomAttacksClient {
   // Prompt Set operations
   // -----------------------------------------------------------------------
 
-  /** Create a new custom prompt set. */
+  /**
+   * Create a new custom prompt set.
+   * @param request - Prompt set creation request body.
+   * @returns The created prompt set response.
+   */
   async createPromptSet(request: CustomPromptSetCreateRequest): Promise<CustomPromptSetResponse> {
     const res = await managementHttpRequest<CustomPromptSetResponse>({
       method: 'POST',
@@ -80,7 +84,11 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** List custom prompt sets. */
+  /**
+   * List custom prompt sets.
+   * @param opts - Optional pagination, search, and filter options.
+   * @returns The paginated list of prompt sets.
+   */
   async listPromptSets(opts?: PromptSetListOptions): Promise<CustomPromptSetList> {
     const params = buildRedTeamListParams(opts);
     if (opts?.status !== undefined) params.status = opts.status;
@@ -98,7 +106,11 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Get a prompt set by UUID. */
+  /**
+   * Get a prompt set by UUID.
+   * @param uuid - The prompt set UUID.
+   * @returns The prompt set response.
+   */
   async getPromptSet(uuid: string): Promise<CustomPromptSetResponse> {
     validateUuid(uuid, 'prompt set uuid');
     const res = await managementHttpRequest<CustomPromptSetResponse>({
@@ -111,7 +123,12 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Update a prompt set. */
+  /**
+   * Update a prompt set.
+   * @param uuid - The prompt set UUID.
+   * @param request - Prompt set update request body.
+   * @returns The updated prompt set response.
+   */
   async updatePromptSet(
     uuid: string,
     request: CustomPromptSetUpdateRequest,
@@ -128,7 +145,12 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Archive or unarchive a prompt set. */
+  /**
+   * Archive or unarchive a prompt set.
+   * @param uuid - The prompt set UUID.
+   * @param request - Archive request body.
+   * @returns The updated prompt set response.
+   */
   async archivePromptSet(
     uuid: string,
     request: CustomPromptSetArchiveRequest,
@@ -145,7 +167,11 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Resolve a prompt set reference for data plane consumption. */
+  /**
+   * Resolve a prompt set reference for data plane consumption.
+   * @param uuid - The prompt set UUID.
+   * @returns The prompt set reference.
+   */
   async getPromptSetReference(uuid: string): Promise<CustomPromptSetReference> {
     validateUuid(uuid, 'prompt set uuid');
     const res = await managementHttpRequest<CustomPromptSetReference>({
@@ -158,7 +184,11 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Get version information for a prompt set. */
+  /**
+   * Get version information for a prompt set.
+   * @param uuid - The prompt set UUID.
+   * @returns The prompt set version info.
+   */
   async getPromptSetVersionInfo(uuid: string): Promise<CustomPromptSetVersionInfo> {
     validateUuid(uuid, 'prompt set uuid');
     const res = await managementHttpRequest<CustomPromptSetVersionInfo>({
@@ -171,7 +201,10 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** List active prompt sets (for data plane). */
+  /**
+   * List active prompt sets (for data plane).
+   * @returns The list of active prompt sets.
+   */
   async listActivePromptSets(): Promise<CustomPromptSetListActive> {
     const res = await managementHttpRequest<CustomPromptSetListActive>({
       method: 'GET',
@@ -183,7 +216,11 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Download CSV template for a prompt set. */
+  /**
+   * Download CSV template for a prompt set.
+   * @param uuid - The prompt set UUID.
+   * @returns The CSV template data.
+   */
   async downloadTemplate(uuid: string): Promise<unknown> {
     validateUuid(uuid, 'prompt set uuid');
     const res = await managementHttpRequest<unknown>({
@@ -196,7 +233,12 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Upload a CSV file of custom prompts for a prompt set. */
+  /**
+   * Upload a CSV file of custom prompts for a prompt set.
+   * @param promptSetUuid - The prompt set UUID.
+   * @param file - The CSV file blob.
+   * @returns The upload response.
+   */
   async uploadPromptsCsv(promptSetUuid: string, file: Blob): Promise<BaseResponse> {
     validateUuid(promptSetUuid, 'prompt set uuid');
 
@@ -234,7 +276,11 @@ export class RedTeamCustomAttacksClient {
   // Prompt operations
   // -----------------------------------------------------------------------
 
-  /** Create a new custom prompt. */
+  /**
+   * Create a new custom prompt.
+   * @param request - Prompt creation request body.
+   * @returns The created prompt response.
+   */
   async createPrompt(request: CustomPromptCreateRequest): Promise<CustomPromptResponse> {
     const res = await managementHttpRequest<CustomPromptResponse>({
       method: 'POST',
@@ -247,7 +293,12 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** List prompts in a prompt set. */
+  /**
+   * List prompts in a prompt set.
+   * @param promptSetUuid - The prompt set UUID.
+   * @param opts - Optional pagination, search, and filter options.
+   * @returns The paginated list of prompts.
+   */
   async listPrompts(promptSetUuid: string, opts?: PromptListOptions): Promise<CustomPromptList> {
     validateUuid(promptSetUuid, 'prompt set uuid');
     const params = buildRedTeamListParams(opts);
@@ -264,7 +315,12 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Get a prompt by UUID. */
+  /**
+   * Get a prompt by UUID.
+   * @param promptSetUuid - The prompt set UUID.
+   * @param promptUuid - The prompt UUID.
+   * @returns The prompt response.
+   */
   async getPrompt(promptSetUuid: string, promptUuid: string): Promise<CustomPromptResponse> {
     validateUuid(promptSetUuid, 'prompt set uuid');
     validateUuid(promptUuid, 'prompt uuid');
@@ -278,7 +334,13 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Update a prompt. */
+  /**
+   * Update a prompt.
+   * @param promptSetUuid - The prompt set UUID.
+   * @param promptUuid - The prompt UUID.
+   * @param request - Prompt update request body.
+   * @returns The updated prompt response.
+   */
   async updatePrompt(
     promptSetUuid: string,
     promptUuid: string,
@@ -297,7 +359,12 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Delete a prompt. */
+  /**
+   * Delete a prompt.
+   * @param promptSetUuid - The prompt set UUID.
+   * @param promptUuid - The prompt UUID.
+   * @returns The delete response.
+   */
   async deletePrompt(promptSetUuid: string, promptUuid: string): Promise<BaseResponse> {
     validateUuid(promptSetUuid, 'prompt set uuid');
     validateUuid(promptUuid, 'prompt uuid');
@@ -315,7 +382,10 @@ export class RedTeamCustomAttacksClient {
   // Property operations
   // -----------------------------------------------------------------------
 
-  /** Get all property names. */
+  /**
+   * Get all property names.
+   * @returns The list of property names.
+   */
   async getPropertyNames(): Promise<PropertyNamesListResponse> {
     const res = await managementHttpRequest<PropertyNamesListResponse>({
       method: 'GET',
@@ -327,7 +397,11 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Create a new property name. */
+  /**
+   * Create a new property name.
+   * @param request - Property name creation request body.
+   * @returns The creation response.
+   */
   async createPropertyName(request: PropertyNameCreateRequest): Promise<BaseResponse> {
     const res = await managementHttpRequest<BaseResponse>({
       method: 'POST',
@@ -340,7 +414,11 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Get values for a property name. */
+  /**
+   * Get values for a property name.
+   * @param propertyName - The property name to look up.
+   * @returns The property values response.
+   */
   async getPropertyValues(propertyName: string): Promise<PropertyValuesResponse> {
     const res = await managementHttpRequest<PropertyValuesResponse>({
       method: 'GET',
@@ -352,7 +430,11 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Get values for multiple property names. */
+  /**
+   * Get values for multiple property names.
+   * @param propertyNames - Array of property names to look up.
+   * @returns The property values for all requested names.
+   */
   async getPropertyValuesMultiple(
     propertyNames: string[],
   ): Promise<PropertyValuesMultipleResponse> {
@@ -373,7 +455,11 @@ export class RedTeamCustomAttacksClient {
     return res.data;
   }
 
-  /** Create a property value. */
+  /**
+   * Create a property value.
+   * @param request - Property value creation request body.
+   * @returns The creation response.
+   */
   async createPropertyValue(request: PropertyValueCreateRequest): Promise<BaseResponse> {
     const res = await managementHttpRequest<BaseResponse>({
       method: 'POST',

--- a/src/red-team/reports-client.ts
+++ b/src/red-team/reports-client.ts
@@ -68,7 +68,12 @@ export class RedTeamReportsClient {
   // Static (attack library) report endpoints
   // -----------------------------------------------------------------------
 
-  /** List attacks for a static scan. */
+  /**
+   * List attacks for a static scan.
+   * @param jobId - The job UUID.
+   * @param opts - Optional pagination, search, and filter options.
+   * @returns The paginated list of attacks.
+   */
   async listAttacks(jobId: string, opts?: AttackListOptions): Promise<AttackListResponse> {
     validateJobId(jobId);
     const params = buildRedTeamListParams(opts);
@@ -90,7 +95,12 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** Get attack details for a static scan. */
+  /**
+   * Get attack details for a static scan.
+   * @param jobId - The job UUID.
+   * @param attackId - The attack UUID.
+   * @returns The attack detail response.
+   */
   async getAttackDetail(jobId: string, attackId: string): Promise<AttackDetailResponse> {
     validateJobId(jobId);
     if (!isValidUuid(attackId)) {
@@ -110,7 +120,12 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** Get multi-turn attack details for a static scan. */
+  /**
+   * Get multi-turn attack details for a static scan.
+   * @param jobId - The job UUID.
+   * @param attackId - The attack UUID.
+   * @returns The multi-turn attack detail response.
+   */
   async getMultiTurnAttackDetail(
     jobId: string,
     attackId: string,
@@ -133,7 +148,11 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** Get the attack library report for a static scan. */
+  /**
+   * Get the attack library report for a static scan.
+   * @param jobId - The job UUID.
+   * @returns The static job report.
+   */
   async getStaticReport(jobId: string): Promise<StaticJobReport> {
     validateJobId(jobId);
     const res = await managementHttpRequest<StaticJobReport>({
@@ -146,7 +165,11 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** Get remediation recommendations for a static scan. */
+  /**
+   * Get remediation recommendations for a static scan.
+   * @param jobId - The job UUID.
+   * @returns The remediation response.
+   */
   async getStaticRemediation(jobId: string): Promise<RemediationResponse> {
     validateJobId(jobId);
     const res = await managementHttpRequest<RemediationResponse>({
@@ -159,7 +182,11 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** Get runtime security profile config for a static scan. */
+  /**
+   * Get runtime security profile config for a static scan.
+   * @param jobId - The job UUID.
+   * @returns The runtime security profile response.
+   */
   async getStaticRuntimePolicy(jobId: string): Promise<RuntimeSecurityProfileResponse> {
     validateJobId(jobId);
     const res = await managementHttpRequest<RuntimeSecurityProfileResponse>({
@@ -176,7 +203,11 @@ export class RedTeamReportsClient {
   // Dynamic (agent) report endpoints
   // -----------------------------------------------------------------------
 
-  /** Get the agent scan report for a dynamic scan. */
+  /**
+   * Get the agent scan report for a dynamic scan.
+   * @param jobId - The job UUID.
+   * @returns The dynamic job report.
+   */
   async getDynamicReport(jobId: string): Promise<DynamicJobReport> {
     validateJobId(jobId);
     const res = await managementHttpRequest<DynamicJobReport>({
@@ -189,7 +220,11 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** Get remediation recommendations for a dynamic scan. */
+  /**
+   * Get remediation recommendations for a dynamic scan.
+   * @param jobId - The job UUID.
+   * @returns The remediation response.
+   */
   async getDynamicRemediation(jobId: string): Promise<RemediationResponse> {
     validateJobId(jobId);
     const res = await managementHttpRequest<RemediationResponse>({
@@ -202,7 +237,11 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** Get runtime security profile config for a dynamic scan. */
+  /**
+   * Get runtime security profile config for a dynamic scan.
+   * @param jobId - The job UUID.
+   * @returns The runtime security profile response.
+   */
   async getDynamicRuntimePolicy(jobId: string): Promise<RuntimeSecurityProfileResponse> {
     validateJobId(jobId);
     const res = await managementHttpRequest<RuntimeSecurityProfileResponse>({
@@ -215,7 +254,12 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** List goals for a dynamic scan. */
+  /**
+   * List goals for a dynamic scan.
+   * @param jobId - The job UUID.
+   * @param opts - Optional pagination, search, and filter options.
+   * @returns The paginated list of goals.
+   */
   async listGoals(jobId: string, opts?: GoalListOptions): Promise<GoalListResponse> {
     validateJobId(jobId);
     const params = buildRedTeamListParams(opts);
@@ -234,7 +278,13 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** List streams for a goal in a dynamic scan. */
+  /**
+   * List streams for a goal in a dynamic scan.
+   * @param jobId - The job UUID.
+   * @param goalId - The goal UUID.
+   * @param opts - Optional pagination and search options.
+   * @returns The paginated list of streams.
+   */
   async listGoalStreams(
     jobId: string,
     goalId: string,
@@ -263,7 +313,11 @@ export class RedTeamReportsClient {
   // Common report endpoints
   // -----------------------------------------------------------------------
 
-  /** Get stream details by stream ID. */
+  /**
+   * Get stream details by stream ID.
+   * @param streamId - The stream UUID.
+   * @returns The stream detail response.
+   */
   async getStreamDetail(streamId: string): Promise<StreamDetailResponse> {
     if (!isValidUuid(streamId)) {
       throw new AISecSDKException(
@@ -282,7 +336,12 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** Download a report in the specified format. */
+  /**
+   * Download a report in the specified format.
+   * @param jobId - The job UUID.
+   * @param format - The file format (e.g. "pdf", "csv").
+   * @returns The downloaded report data.
+   */
   async downloadReport(jobId: string, format: string): Promise<unknown> {
     validateJobId(jobId);
     const params: Record<string, string> = { file_format: format };
@@ -298,7 +357,11 @@ export class RedTeamReportsClient {
     return res.data;
   }
 
-  /** Generate a partial report for a running scan. */
+  /**
+   * Generate a partial report for a running scan.
+   * @param jobId - The job UUID.
+   * @returns The partial report data.
+   */
   async generatePartialReport(jobId: string): Promise<unknown> {
     validateJobId(jobId);
     const res = await managementHttpRequest<unknown>({

--- a/src/red-team/scans-client.ts
+++ b/src/red-team/scans-client.ts
@@ -62,7 +62,11 @@ export class RedTeamScansClient {
     return res.data;
   }
 
-  /** List red team scan jobs with optional filters. */
+  /**
+   * List red team scan jobs with optional filters.
+   * @param opts - Optional pagination, search, and filter options.
+   * @returns The paginated list of scan jobs.
+   */
   async list(opts?: RedTeamScanListOptions): Promise<JobListResponse> {
     const params = buildRedTeamListParams(opts);
     if (opts?.status !== undefined) params.status = opts.status;
@@ -80,7 +84,11 @@ export class RedTeamScansClient {
     return res.data;
   }
 
-  /** Get a single scan job by ID. */
+  /**
+   * Get a single scan job by ID.
+   * @param jobId - The job UUID.
+   * @returns The job response.
+   */
   async get(jobId: string): Promise<JobResponse> {
     if (!isValidUuid(jobId)) {
       throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
@@ -96,7 +104,11 @@ export class RedTeamScansClient {
     return res.data;
   }
 
-  /** Abort a running scan job. */
+  /**
+   * Abort a running scan job.
+   * @param jobId - The job UUID.
+   * @returns The abort response.
+   */
   async abort(jobId: string): Promise<JobAbortResponse> {
     if (!isValidUuid(jobId)) {
       throw new AISecSDKException(`Invalid job id: ${jobId}`, ErrorType.USER_REQUEST_PAYLOAD_ERROR);
@@ -112,7 +124,10 @@ export class RedTeamScansClient {
     return res.data;
   }
 
-  /** Get all categories with subcategories. */
+  /**
+   * Get all categories with subcategories.
+   * @returns The list of category models.
+   */
   async getCategories(): Promise<CategoryModel[]> {
     const res = await managementHttpRequest<CategoryModel[]>({
       method: 'GET',

--- a/src/red-team/targets-client.ts
+++ b/src/red-team/targets-client.ts
@@ -72,7 +72,11 @@ export class RedTeamTargetsClient {
     return res.data;
   }
 
-  /** List targets with optional filters. */
+  /**
+   * List targets with optional filters.
+   * @param opts - Optional pagination, search, and filter options.
+   * @returns The paginated list of targets.
+   */
   async list(opts?: TargetListOptions): Promise<TargetList> {
     const params = buildRedTeamListParams(opts);
     if (opts?.target_type !== undefined) params.target_type = opts.target_type;
@@ -89,7 +93,11 @@ export class RedTeamTargetsClient {
     return res.data;
   }
 
-  /** Get a target by UUID. */
+  /**
+   * Get a target by UUID.
+   * @param uuid - The target UUID.
+   * @returns The target response.
+   */
   async get(uuid: string): Promise<TargetResponse> {
     if (!isValidUuid(uuid)) {
       throw new AISecSDKException(
@@ -108,7 +116,13 @@ export class RedTeamTargetsClient {
     return res.data;
   }
 
-  /** Update a target. */
+  /**
+   * Update a target.
+   * @param uuid - The target UUID.
+   * @param request - Target update request body.
+   * @param opts - Optional operation options (e.g. validate connection).
+   * @returns The updated target response.
+   */
   async update(
     uuid: string,
     request: TargetUpdateRequest,
@@ -136,7 +150,11 @@ export class RedTeamTargetsClient {
     return res.data;
   }
 
-  /** Delete a target. */
+  /**
+   * Delete a target.
+   * @param uuid - The target UUID.
+   * @returns The delete response.
+   */
   async delete(uuid: string): Promise<BaseResponse> {
     if (!isValidUuid(uuid)) {
       throw new AISecSDKException(
@@ -155,7 +173,11 @@ export class RedTeamTargetsClient {
     return res.data;
   }
 
-  /** Run profiling probes on a target. */
+  /**
+   * Run profiling probes on a target.
+   * @param request - The probe request body.
+   * @returns The target response after probing.
+   */
   async probe(request: TargetProbeRequest): Promise<TargetResponse> {
     const res = await managementHttpRequest<TargetResponse>({
       method: 'POST',
@@ -168,7 +190,11 @@ export class RedTeamTargetsClient {
     return res.data;
   }
 
-  /** Get profiling results for a target. */
+  /**
+   * Get profiling results for a target.
+   * @param uuid - The target UUID.
+   * @returns The target profile response.
+   */
   async getProfile(uuid: string): Promise<TargetProfileResponse> {
     if (!isValidUuid(uuid)) {
       throw new AISecSDKException(
@@ -187,7 +213,12 @@ export class RedTeamTargetsClient {
     return res.data;
   }
 
-  /** Update a target profile (background + additional context). */
+  /**
+   * Update a target profile (background + additional context).
+   * @param uuid - The target UUID.
+   * @param request - The context update request body.
+   * @returns The updated target response.
+   */
   async updateProfile(uuid: string, request: TargetContextUpdate): Promise<TargetResponse> {
     if (!isValidUuid(uuid)) {
       throw new AISecSDKException(

--- a/src/scan/content.ts
+++ b/src/scan/content.ts
@@ -137,7 +137,10 @@ export class Content {
     this._toolEvent = value;
   }
 
-  /** Total byte length of all text content fields. */
+  /**
+   * Total byte length of all text content fields.
+   * @returns Combined byte length of all text content fields.
+   */
   get length(): number {
     let total = 0;
     if (this._prompt) total += Buffer.byteLength(this._prompt);
@@ -148,7 +151,10 @@ export class Content {
     return total;
   }
 
-  /** Serialize to the API request format. */
+  /**
+   * Serialize to the API request format.
+   * @returns The content as a scan request contents inner object.
+   */
   toJSON(): ScanRequestContentsInner {
     const obj: ScanRequestContentsInner = {};
     if (this._prompt !== undefined) obj.prompt = this._prompt;


### PR DESCRIPTION
## Summary

- Added formal `@param` and `@returns` JSDoc tags to ~60 exported methods across 9 files
- Primary coverage: all red-team sub-clients, oauth-client, security-groups, content class
- No functional code changes

Closes #58

## Test plan

- [x] No functional changes — docs only
- [x] Full suite: 813 tests passing
- [x] Lint, typecheck, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)