### PR TITLE
docs: clarify JSDoc for Promise<unknown> methods

### DIFF
--- a/src/management/oauth-client.ts
+++ b/src/management/oauth-client.ts
@@ -83,7 +83,6 @@ export class OAuthClient {
 
   /**
    * Clear the cached token, forcing a fresh fetch on next call.
-   * @returns Nothing.
    */
   clearToken(): void {
     this.accessToken = null;

--- a/src/red-team/custom-attacks-client.ts
+++ b/src/red-team/custom-attacks-client.ts
@@ -219,7 +219,7 @@ export class RedTeamCustomAttacksClient {
   /**
    * Download CSV template for a prompt set.
    * @param uuid - The prompt set UUID.
-   * @returns The CSV template data.
+   * @returns The CSV template content (untyped — raw response from the API).
    */
   async downloadTemplate(uuid: string): Promise<unknown> {
     validateUuid(uuid, 'prompt set uuid');

--- a/src/red-team/reports-client.ts
+++ b/src/red-team/reports-client.ts
@@ -340,7 +340,7 @@ export class RedTeamReportsClient {
    * Download a report in the specified format.
    * @param jobId - The job UUID.
    * @param format - The file format (e.g. "pdf", "csv").
-   * @returns The downloaded report data.
+   * @returns The report data in the requested format (untyped — shape depends on `format`).
    */
   async downloadReport(jobId: string, format: string): Promise<unknown> {
     validateJobId(jobId);
@@ -360,7 +360,7 @@ export class RedTeamReportsClient {
   /**
    * Generate a partial report for a running scan.
    * @param jobId - The job UUID.
-   * @returns The partial report data.
+   * @returns The partial report payload (untyped — schema not yet defined by the API).
    */
   async generatePartialReport(jobId: string): Promise<unknown> {
     validateJobId(jobId);


### PR DESCRIPTION
## Summary
- Clarify `@returns` for 3 `Promise<unknown>` methods to explain why the return type is untyped
- Remove redundant `@returns Nothing.` from `clearToken()` void method

## Changes
- `src/red-team/reports-client.ts`: `downloadReport`, `generatePartialReport`
- `src/red-team/custom-attacks-client.ts`: `downloadTemplate`
- `src/management/oauth-client.ts`: `clearToken`

## Testing
- No behavior changes — JSDoc only
- All 813 tests pass, lint/format/typecheck clean

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)