### PR TITLE
docs: add sort param example + fix JSDoc inconsistencies

### DIFF
--- a/docs/services/model-security-api.md
+++ b/docs/services/model-security-api.md
@@ -113,6 +113,12 @@ const evaluations = await client.scans.getEvaluations('scan-uuid', {
   limit: 20,
 });
 
+// With sorting
+const sorted = await client.scans.getEvaluations('scan-uuid', {
+  sort_field: 'severity',
+  sort_order: 'desc',
+});
+
 // Get a single evaluation by UUID
 const evaluation = await client.scans.getEvaluation('evaluation-uuid');
 ```

--- a/src/management/topics.ts
+++ b/src/management/topics.ts
@@ -123,7 +123,7 @@ export class TopicsClient {
   /**
    * Force-delete a custom topic, removing it from any referencing profiles.
    * @param topicId - UUID of the topic to force-delete.
-   * @param updatedBy - Email of the user performing the deletion.
+   * @param updatedBy - Optional. Email of the user performing the deletion.
    * @returns Deletion confirmation message.
    */
   async forceDelete(topicId: string, updatedBy?: string): Promise<DeleteTopicResponse> {

--- a/src/scan/content.ts
+++ b/src/scan/content.ts
@@ -184,6 +184,7 @@ export class Content {
   /**
    * Load content from a JSON file.
    * @param filePath - Path to JSON file containing scan request contents.
+   * @returns A new Content instance populated from the JSON file.
    */
   static fromJSONFile(filePath: string): Content {
     const raw = readFileSync(filePath, 'utf-8');


### PR DESCRIPTION
## Summary
- Adds `sort_field`/`sort_order` example to Model Security API docs
- Adds missing `@returns` tag to `fromJSONFile()`
- Notes `updatedBy` optionality in `topics.forceDelete()` JSDoc

## Changes
- `docs/services/model-security-api.md`: sorting example for `getEvaluations()`
- `src/scan/content.ts`: `@returns` on `fromJSONFile()`
- `src/management/topics.ts`: optional note on `updatedBy` param

## Testing
- 813 tests passing, lint/format/typecheck clean

Closes #66