### PR TITLE
refactor: extract shared OAuth2 credential resolution

### DIFF
--- a/src/management/client.ts
+++ b/src/management/client.ts
@@ -1,14 +1,5 @@
-import {
-  DEFAULT_MGMT_ENDPOINT,
-  MGMT_CLIENT_ID,
-  MGMT_CLIENT_SECRET,
-  MGMT_TSG_ID,
-  MGMT_ENDPOINT,
-  MGMT_TOKEN_ENDPOINT,
-  MAX_NUMBER_OF_RETRIES,
-} from '../constants.js';
-import { AISecSDKException, ErrorType } from '../errors.js';
-import { OAuthClient } from './oauth-client.js';
+import { DEFAULT_MGMT_ENDPOINT, MGMT_ENDPOINT } from '../constants.js';
+import { resolveOAuthConfig } from '../oauth-config.js';
 import { ProfilesClient } from './profiles.js';
 import { TopicsClient } from './topics.js';
 import { ApiKeysClient } from './api-keys.js';
@@ -49,90 +40,66 @@ export class ManagementClient {
   public readonly oauth: OAuthManagementClient;
 
   constructor(opts: ManagementClientOptions = {}) {
-    const clientId = opts.clientId ?? process.env[MGMT_CLIENT_ID];
-    const clientSecret = opts.clientSecret ?? process.env[MGMT_CLIENT_SECRET];
-    const tsgId = opts.tsgId ?? process.env[MGMT_TSG_ID];
     const apiEndpoint = opts.apiEndpoint ?? process.env[MGMT_ENDPOINT] ?? DEFAULT_MGMT_ENDPOINT;
-    const tokenEndpoint = opts.tokenEndpoint ?? process.env[MGMT_TOKEN_ENDPOINT];
-    const numRetries = Math.min(
-      Math.max(opts.numRetries ?? MAX_NUMBER_OF_RETRIES, 0),
-      MAX_NUMBER_OF_RETRIES,
-    );
 
-    if (!clientId) {
-      throw new AISecSDKException(
-        'clientId is required (option or PANW_MGMT_CLIENT_ID env var)',
-        ErrorType.MISSING_VARIABLE,
-      );
-    }
-    if (!clientSecret) {
-      throw new AISecSDKException(
-        'clientSecret is required (option or PANW_MGMT_CLIENT_SECRET env var)',
-        ErrorType.MISSING_VARIABLE,
-      );
-    }
-    if (!tsgId) {
-      throw new AISecSDKException(
-        'tsgId is required (option or PANW_MGMT_TSG_ID env var)',
-        ErrorType.MISSING_VARIABLE,
-      );
-    }
-
-    const oauthClient = new OAuthClient({
-      clientId,
-      clientSecret,
-      tsgId,
-      tokenEndpoint,
+    const { baseUrl, oauthClient, numRetries, tsgId } = resolveOAuthConfig({
+      clientId: opts.clientId,
+      clientSecret: opts.clientSecret,
+      tsgId: opts.tsgId,
+      baseUrl: apiEndpoint,
+      numRetries: opts.numRetries,
+      tokenEndpoint: opts.tokenEndpoint,
+      primaryEnvPrefix: 'PANW_MGMT',
     });
 
     this.profiles = new ProfilesClient({
-      baseUrl: apiEndpoint,
+      baseUrl,
       oauthClient,
       tsgId,
       numRetries,
     });
 
     this.topics = new TopicsClient({
-      baseUrl: apiEndpoint,
+      baseUrl,
       oauthClient,
       tsgId,
       numRetries,
     });
 
     this.apiKeys = new ApiKeysClient({
-      baseUrl: apiEndpoint,
+      baseUrl,
       oauthClient,
       tsgId,
       numRetries,
     });
 
     this.customerApps = new CustomerAppsClient({
-      baseUrl: apiEndpoint,
+      baseUrl,
       oauthClient,
       tsgId,
       numRetries,
     });
 
     this.dlpProfiles = new DlpProfilesClient({
-      baseUrl: apiEndpoint,
+      baseUrl,
       oauthClient,
       numRetries,
     });
 
     this.deploymentProfiles = new DeploymentProfilesClient({
-      baseUrl: apiEndpoint,
+      baseUrl,
       oauthClient,
       numRetries,
     });
 
     this.scanLogs = new ScanLogsClient({
-      baseUrl: apiEndpoint,
+      baseUrl,
       oauthClient,
       numRetries,
     });
 
     this.oauth = new OAuthManagementClient({
-      baseUrl: apiEndpoint,
+      baseUrl,
       oauthClient,
       numRetries,
     });

--- a/src/model-security/client.ts
+++ b/src/model-security/client.ts
@@ -1,25 +1,16 @@
 import {
   DEFAULT_MODEL_SEC_DATA_ENDPOINT,
   DEFAULT_MODEL_SEC_MGMT_ENDPOINT,
-  MODEL_SEC_CLIENT_ID,
-  MODEL_SEC_CLIENT_SECRET,
-  MODEL_SEC_TSG_ID,
   MODEL_SEC_DATA_ENDPOINT,
   MODEL_SEC_MGMT_ENDPOINT,
-  MODEL_SEC_TOKEN_ENDPOINT,
-  MGMT_CLIENT_ID,
-  MGMT_CLIENT_SECRET,
-  MGMT_TSG_ID,
-  MGMT_TOKEN_ENDPOINT,
-  MAX_NUMBER_OF_RETRIES,
   MODEL_SEC_PYPI_AUTH_PATH,
 } from '../constants.js';
-import { AISecSDKException, ErrorType } from '../errors.js';
-import { OAuthClient } from '../management/oauth-client.js';
+import { resolveOAuthConfig } from '../oauth-config.js';
 import { managementHttpRequest } from '../management/management-http-client.js';
 import { ModelSecurityScansClient } from './scans-client.js';
 import { ModelSecurityGroupsClient } from './security-groups-client.js';
 import { ModelSecurityRulesClient } from './security-rules-client.js';
+import type { OAuthClient } from '../management/oauth-client.js';
 import type { PyPIAuthResponse } from '../models/model-security.js';
 
 /** Options for constructing a {@link ModelSecurityClient}. */
@@ -58,67 +49,41 @@ export class ModelSecurityClient {
   private readonly numRetries: number;
 
   constructor(opts: ModelSecurityClientOptions = {}) {
-    const clientId =
-      opts.clientId ?? process.env[MODEL_SEC_CLIENT_ID] ?? process.env[MGMT_CLIENT_ID];
-    const clientSecret =
-      opts.clientSecret ?? process.env[MODEL_SEC_CLIENT_SECRET] ?? process.env[MGMT_CLIENT_SECRET];
-    const tsgId = opts.tsgId ?? process.env[MODEL_SEC_TSG_ID] ?? process.env[MGMT_TSG_ID];
     const dataEndpoint =
       opts.dataEndpoint ?? process.env[MODEL_SEC_DATA_ENDPOINT] ?? DEFAULT_MODEL_SEC_DATA_ENDPOINT;
     const mgmtEndpoint =
       opts.mgmtEndpoint ?? process.env[MODEL_SEC_MGMT_ENDPOINT] ?? DEFAULT_MODEL_SEC_MGMT_ENDPOINT;
-    const tokenEndpoint =
-      opts.tokenEndpoint ??
-      process.env[MODEL_SEC_TOKEN_ENDPOINT] ??
-      process.env[MGMT_TOKEN_ENDPOINT];
-    const numRetries = Math.min(
-      Math.max(opts.numRetries ?? MAX_NUMBER_OF_RETRIES, 0),
-      MAX_NUMBER_OF_RETRIES,
-    );
 
-    if (!clientId) {
-      throw new AISecSDKException(
-        'clientId is required (option or PANW_MODEL_SEC_CLIENT_ID / PANW_MGMT_CLIENT_ID env var)',
-        ErrorType.MISSING_VARIABLE,
-      );
-    }
-    if (!clientSecret) {
-      throw new AISecSDKException(
-        'clientSecret is required (option or PANW_MODEL_SEC_CLIENT_SECRET / PANW_MGMT_CLIENT_SECRET env var)',
-        ErrorType.MISSING_VARIABLE,
-      );
-    }
-    if (!tsgId) {
-      throw new AISecSDKException(
-        'tsgId is required (option or PANW_MODEL_SEC_TSG_ID / PANW_MGMT_TSG_ID env var)',
-        ErrorType.MISSING_VARIABLE,
-      );
-    }
-
-    this.oauthClient = new OAuthClient({
-      clientId,
-      clientSecret,
-      tsgId,
-      tokenEndpoint,
+    const { oauthClient, numRetries } = resolveOAuthConfig({
+      clientId: opts.clientId,
+      clientSecret: opts.clientSecret,
+      tsgId: opts.tsgId,
+      baseUrl: mgmtEndpoint,
+      numRetries: opts.numRetries,
+      tokenEndpoint: opts.tokenEndpoint,
+      primaryEnvPrefix: 'PANW_MODEL_SEC',
+      fallbackEnvPrefix: 'PANW_MGMT',
     });
+
+    this.oauthClient = oauthClient;
     this.mgmtEndpoint = mgmtEndpoint;
     this.numRetries = numRetries;
 
     this.scans = new ModelSecurityScansClient({
       baseUrl: dataEndpoint,
-      oauthClient: this.oauthClient,
+      oauthClient,
       numRetries,
     });
 
     this.securityGroups = new ModelSecurityGroupsClient({
       baseUrl: mgmtEndpoint,
-      oauthClient: this.oauthClient,
+      oauthClient,
       numRetries,
     });
 
     this.securityRules = new ModelSecurityRulesClient({
       baseUrl: mgmtEndpoint,
-      oauthClient: this.oauthClient,
+      oauthClient,
       numRetries,
     });
   }

--- a/src/oauth-config.ts
+++ b/src/oauth-config.ts
@@ -11,6 +11,8 @@ export interface OAuthServiceConfig {
   oauthClient: OAuthClient;
   /** Clamped retry count. */
   numRetries: number;
+  /** Resolved Tenant Service Group ID. */
+  tsgId: string;
 }
 
 /** Options for {@link resolveOAuthConfig}. */
@@ -108,5 +110,5 @@ export function resolveOAuthConfig(opts: ResolveOAuthConfigOptions): OAuthServic
     onTokenRefresh: opts.onTokenRefresh,
   });
 
-  return { baseUrl: opts.baseUrl, oauthClient, numRetries };
+  return { baseUrl: opts.baseUrl, oauthClient, numRetries, tsgId };
 }

--- a/src/red-team/client.ts
+++ b/src/red-team/client.ts
@@ -1,17 +1,8 @@
 import {
   DEFAULT_RED_TEAM_DATA_ENDPOINT,
   DEFAULT_RED_TEAM_MGMT_ENDPOINT,
-  RED_TEAM_CLIENT_ID,
-  RED_TEAM_CLIENT_SECRET,
-  RED_TEAM_TSG_ID,
   RED_TEAM_DATA_ENDPOINT,
   RED_TEAM_MGMT_ENDPOINT,
-  RED_TEAM_TOKEN_ENDPOINT,
-  MGMT_CLIENT_ID,
-  MGMT_CLIENT_SECRET,
-  MGMT_TSG_ID,
-  MGMT_TOKEN_ENDPOINT,
-  MAX_NUMBER_OF_RETRIES,
   RED_TEAM_DASHBOARD_PATH,
   RED_TEAM_QUOTA_PATH,
   RED_TEAM_ERROR_LOG_PATH,
@@ -20,8 +11,9 @@ import {
 } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { isValidUuid } from '../utils.js';
-import { OAuthClient } from '../management/oauth-client.js';
+import { resolveOAuthConfig } from '../oauth-config.js';
 import { managementHttpRequest } from '../management/management-http-client.js';
+import type { OAuthClient } from '../management/oauth-client.js';
 import { RedTeamScansClient } from './scans-client.js';
 import { RedTeamReportsClient } from './reports-client.js';
 import { RedTeamCustomAttackReportsClient } from './custom-attack-reports-client.js';
@@ -79,75 +71,54 @@ export class RedTeamClient {
   private readonly numRetries: number;
 
   constructor(opts: RedTeamClientOptions = {}) {
-    const clientId =
-      opts.clientId ?? process.env[RED_TEAM_CLIENT_ID] ?? process.env[MGMT_CLIENT_ID];
-    const clientSecret =
-      opts.clientSecret ?? process.env[RED_TEAM_CLIENT_SECRET] ?? process.env[MGMT_CLIENT_SECRET];
-    const tsgId = opts.tsgId ?? process.env[RED_TEAM_TSG_ID] ?? process.env[MGMT_TSG_ID];
     const dataEndpoint =
       opts.dataEndpoint ?? process.env[RED_TEAM_DATA_ENDPOINT] ?? DEFAULT_RED_TEAM_DATA_ENDPOINT;
     const mgmtEndpoint =
       opts.mgmtEndpoint ?? process.env[RED_TEAM_MGMT_ENDPOINT] ?? DEFAULT_RED_TEAM_MGMT_ENDPOINT;
-    const tokenEndpoint =
-      opts.tokenEndpoint ??
-      process.env[RED_TEAM_TOKEN_ENDPOINT] ??
-      process.env[MGMT_TOKEN_ENDPOINT];
-    const numRetries = Math.min(
-      Math.max(opts.numRetries ?? MAX_NUMBER_OF_RETRIES, 0),
-      MAX_NUMBER_OF_RETRIES,
-    );
 
-    if (!clientId) {
-      throw new AISecSDKException(
-        'clientId is required (option or PANW_RED_TEAM_CLIENT_ID / PANW_MGMT_CLIENT_ID env var)',
-        ErrorType.MISSING_VARIABLE,
-      );
-    }
-    if (!clientSecret) {
-      throw new AISecSDKException(
-        'clientSecret is required (option or PANW_RED_TEAM_CLIENT_SECRET / PANW_MGMT_CLIENT_SECRET env var)',
-        ErrorType.MISSING_VARIABLE,
-      );
-    }
-    if (!tsgId) {
-      throw new AISecSDKException(
-        'tsgId is required (option or PANW_RED_TEAM_TSG_ID / PANW_MGMT_TSG_ID env var)',
-        ErrorType.MISSING_VARIABLE,
-      );
-    }
+    const { oauthClient, numRetries } = resolveOAuthConfig({
+      clientId: opts.clientId,
+      clientSecret: opts.clientSecret,
+      tsgId: opts.tsgId,
+      baseUrl: dataEndpoint,
+      numRetries: opts.numRetries,
+      tokenEndpoint: opts.tokenEndpoint,
+      primaryEnvPrefix: 'PANW_RED_TEAM',
+      fallbackEnvPrefix: 'PANW_MGMT',
+    });
 
-    this.oauthClient = new OAuthClient({ clientId, clientSecret, tsgId, tokenEndpoint });
+    this.oauthClient = oauthClient;
     this.dataEndpoint = dataEndpoint;
     this.mgmtEndpoint = mgmtEndpoint;
     this.numRetries = numRetries;
 
     this.scans = new RedTeamScansClient({
       baseUrl: dataEndpoint,
-      oauthClient: this.oauthClient,
+      oauthClient,
       numRetries,
     });
 
     this.reports = new RedTeamReportsClient({
       baseUrl: dataEndpoint,
-      oauthClient: this.oauthClient,
+      oauthClient,
       numRetries,
     });
 
     this.customAttackReports = new RedTeamCustomAttackReportsClient({
       baseUrl: dataEndpoint,
-      oauthClient: this.oauthClient,
+      oauthClient,
       numRetries,
     });
 
     this.targets = new RedTeamTargetsClient({
       baseUrl: mgmtEndpoint,
-      oauthClient: this.oauthClient,
+      oauthClient,
       numRetries,
     });
 
     this.customAttacks = new RedTeamCustomAttacksClient({
       baseUrl: mgmtEndpoint,
-      oauthClient: this.oauthClient,
+      oauthClient,
       numRetries,
     });
   }

--- a/test/oauth-config.spec.ts
+++ b/test/oauth-config.spec.ts
@@ -23,6 +23,7 @@ describe('resolveOAuthConfig', () => {
     expect(cfg.oauthClient).toBeInstanceOf(OAuthClient);
     expect(cfg.baseUrl).toBe('https://api.example.com');
     expect(cfg.numRetries).toBe(MAX_NUMBER_OF_RETRIES);
+    expect(cfg.tsgId).toBe('tsg1');
   });
 
   it('falls back to primary env prefix when opts missing', () => {


### PR DESCRIPTION
## Summary
- Extracts duplicated credential resolution from 3 parent clients into `resolveOAuthConfig()`
- Net -150 lines duplicated, +56 lines shared logic
- 14 new tests for the factory function

## Changes
- New: `src/oauth-config.ts`, `test/oauth-config.spec.ts`
- Modified: `src/management/client.ts`, `src/model-security/client.ts`, `src/red-team/client.ts`

## Testing
- 829 tests passing (815 existing + 14 new), lint/format/typecheck clean

Closes #71