### PR TITLE
docs: fix sort_field value and backoff description

### DIFF
--- a/docs/reference/error-handling.md
+++ b/docs/reference/error-handling.md
@@ -48,6 +48,6 @@ try {
 The SDK automatically retries on transient errors:
 
 - **Status codes**: 500, 502, 503, 504
-- **Backoff**: Exponential (`2^attempt * 1000ms`)
+- **Backoff**: Exponential with full jitter (`uniform [0, 2^attempt × 1000ms]`)
 - **Max retries**: Configurable 0-5, default 5
 - **401/403 handling**: Management/Model Security/Red Team clients automatically refresh the OAuth token and retry once on 401 or 403 responses

--- a/docs/services/model-security-api.md
+++ b/docs/services/model-security-api.md
@@ -115,7 +115,7 @@ const evaluations = await client.scans.getEvaluations('scan-uuid', {
 
 // With sorting
 const sorted = await client.scans.getEvaluations('scan-uuid', {
-  sort_field: 'severity',
+  sort_field: 'created_at',
   sort_order: 'desc',
 });
 


### PR DESCRIPTION
## Summary
- **model-security-api.md**: `sort_field` example used `'severity'` which isn't a valid value — changed to `'created_at'` per source (`ModelSecurityEvaluationListOptions`)
- **error-handling.md**: backoff description said `2^attempt * 1000ms` but `http-retry.ts` uses full jitter — updated to match

## Test plan
- [x] All 829 tests pass
- [x] Verified against source: `src/model-security/scans-client.ts:57-58`, `src/http-retry.ts:20-22`

🤖 Generated with [Claude Code](https://claude.com/claude-code)