### PR TITLE
docs: add @internal JSDoc tags to non-barrel exports

### DIFF
--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -12,7 +12,7 @@ import { AISecSDKException, ErrorType } from './errors.js';
 import { executeWithRetry } from './http-retry.js';
 import { generatePayloadHash } from './utils.js';
 
-/** Options for a scan API HTTP request. */
+/** @internal Options for a scan API HTTP request. */
 export interface HttpRequestOptions {
   /** HTTP method. */
   method: 'GET' | 'POST';
@@ -24,7 +24,7 @@ export interface HttpRequestOptions {
   params?: Record<string, string>;
 }
 
-/** Typed HTTP response wrapper. */
+/** @internal Typed HTTP response wrapper. */
 export interface HttpResponse<T = unknown> {
   /** HTTP status code. */
   status: number;
@@ -49,6 +49,10 @@ function buildHeaders(): Record<string, string> {
   return headers;
 }
 
+/**
+ * @internal
+ * Perform an HTTP request to the scan API with retry logic.
+ */
 export async function httpRequest<T>(opts: HttpRequestOptions): Promise<HttpResponse<T>> {
   if (!globalConfiguration.initialized) {
     throw new AISecSDKException(

--- a/src/http-retry.ts
+++ b/src/http-retry.ts
@@ -4,6 +4,7 @@ import { HTTP_FORCE_RETRY_STATUS_CODES } from './constants.js';
 import { AISecSDKException, ErrorType } from './errors.js';
 
 /**
+ * @internal
  * Sleep for the given number of milliseconds.
  * @param ms - Milliseconds to wait.
  */
@@ -12,6 +13,7 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * @internal
  * Calculate exponential backoff delay with full jitter for the given attempt.
  * Uses the "full jitter" strategy: uniform random in [0, 2^attempt * 1000].
  * @param attempt - Zero-based attempt number.
@@ -23,6 +25,7 @@ export function backoffDelay(attempt: number): number {
 }
 
 /**
+ * @internal
  * Check if an HTTP status code should trigger a retry.
  * @param status - HTTP status code.
  */
@@ -31,6 +34,7 @@ export function isRetryableStatus(status: number): boolean {
 }
 
 /**
+ * @internal
  * Classify an HTTP status code as server-side or client-side error.
  * @param status - HTTP status code.
  */
@@ -39,6 +43,7 @@ export function classifyErrorType(status: number): ErrorType {
 }
 
 /**
+ * @internal
  * Extract a human-readable error message from an API error response body.
  * Tries `error_message`, `message`, and `error.message` fields in order.
  * @param body - Raw response body string.
@@ -58,7 +63,7 @@ export function extractErrorMessage(body: string, status: number): string {
   }
 }
 
-/** Options for {@link executeWithRetry}. */
+/** @internal Options for {@link executeWithRetry}. */
 export interface RetryOptions {
   /** Maximum number of retry attempts. */
   maxRetries: number;
@@ -69,6 +74,7 @@ export interface RetryOptions {
 }
 
 /**
+ * @internal
  * Execute an HTTP request with exponential backoff retry.
  * @param opts - Retry configuration and request function.
  * @returns Successful HTTP Response.

--- a/src/models/oauth-token.ts
+++ b/src/models/oauth-token.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-/** Zod schema for an OAuth2 token response. */
+/** @internal Zod schema for an OAuth2 token response. */
 export const OAuthTokenResponseSchema = z
   .object({
     access_token: z.string(),
@@ -10,5 +10,5 @@ export const OAuthTokenResponseSchema = z
   })
   .passthrough();
 
-/** OAuth2 token response with access token and expiry. */
+/** @internal OAuth2 token response with access token and expiry. */
 export type OAuthTokenResponse = z.infer<typeof OAuthTokenResponseSchema>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { AISecSDKException, ErrorType } from './errors.js';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
+ * @internal
  * Test whether a string is a valid RFC 4122 UUID.
  * @param value - The string to validate.
  * @returns `true` if the string matches the UUID format.
@@ -15,6 +16,7 @@ export function isValidUuid(value: string): boolean {
 }
 
 /**
+ * @internal
  * Validate that a job ID is a valid UUID, throwing if not.
  * @param jobId - The job ID string to validate.
  * @throws {AISecSDKException} If the job ID is not a valid UUID.
@@ -26,6 +28,7 @@ export function validateJobId(jobId: string): void {
 }
 
 /**
+ * @internal
  * Generate an HMAC-SHA256 hex digest for API key authentication.
  * @param payload - The JSON payload string to sign.
  * @param secret - The API key secret.


### PR DESCRIPTION
## Summary
- Add `@internal` JSDoc tags to all exports in `src/utils.ts`, `src/http-retry.ts`, `src/http-client.ts`, and `src/models/oauth-token.ts`
- These modules are intentionally excluded from the public barrel (`src/index.ts`) — the tags make this explicit for consumers and tooling

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run typecheck` passes
- [x] All 829 tests pass
- [x] No new symbols added to `src/index.ts`

Closes #78