### PR TITLE
build: add format:check to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Format check
+        run: npm run format:check
+
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
## Summary
- Add `npm run format:check` step to the publish workflow before lint
- Ensures formatting is verified before any npm publish, completing the quality gate

## Test plan
- [x] Workflow YAML is valid
- [x] Existing CI workflows unaffected

Closes #80