### PR TITLE
chore: release v0.6.8

### DIFF
--- a/.changeset/0000-profiles-get-method.md
+++ b/.changeset/0000-profiles-get-method.md
@@ -1,5 +1,0 @@
----
-'@cdot65/prisma-airs-sdk': patch
----
-
-Add `profiles.get(profileId)` and `profiles.getByName(profileName)` convenience methods for retrieving a single security profile by UUID or name.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.6.8
+
+### New Features
+
+- **`profiles.get(profileId)`** — retrieve a security profile by UUID (filters from `list()` since no dedicated API endpoint exists)
+- **`profiles.getByName(profileName)`** — retrieve a security profile by name, returns highest revision when multiple matches exist
+- **E2E validation**: Added `npm run example:profiles-get` self-contained validation script with mock servers
+
+---
+
 ## v0.6.7
 
 ### Refactoring & Documentation

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -145,6 +145,8 @@ interface PaginationOptions {
 }
 
 class ProfilesClient {
+  get(profileId: string): Promise<SecurityProfile>;
+  getByName(profileName: string): Promise<SecurityProfile>;
   create(request: CreateSecurityProfileRequest): Promise<SecurityProfile>;
   list(opts?: PaginationOptions): Promise<SecurityProfileListResponse>;
   update(profileId: string, request: CreateSecurityProfileRequest): Promise<SecurityProfile>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.6.7';
+export const SDK_VERSION = '0.6.8';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
## Summary

- Bump version 0.6.7 → 0.6.8 (package.json + SDK_VERSION constant)
- Update API reference docs with `get()` and `getByName()` methods
- Add v0.6.8 release notes
- Consume changeset

### Included since v0.6.7

- `profiles.get(profileId)` — retrieve by UUID (#86)
- `profiles.getByName(profileName)` — retrieve by name, highest revision
- E2E validation script (`npm run example:profiles-get`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)