### PR TITLE
chore: release v0.6.9

### DIFF
--- a/.changeset/0000-policy-schema-remodel.md
+++ b/.changeset/0000-policy-schema-remodel.md
@@ -1,5 +1,0 @@
----
-'@cdot65/prisma-airs-sdk': patch
----
-
-Fix `PolicySchema` and all sub-schemas to match the actual AIRS Management API structure. The policy object is now properly typed with `ai-security-profiles[]` and `dlp-data-profiles[]` arrays and their full nested hierarchy (model-configuration, data-protection, app-protection, model-protection, agent-protection, latency).

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v0.6.9
+
+### Bug Fixes
+
+- **Fix `PolicySchema`**: Replaced 9 incorrect flat policy sub-schemas with 15 properly nested schemas matching the actual AIRS Management API OpenAPI spec
+- Policy now correctly typed with `ai-security-profiles[]` array containing `model-configuration` → `data-protection`, `app-protection` (URL categories), `model-protection[]` (topic guardrails), `agent-protection[]`, `latency`
+- Added `dlp-data-profiles[]` with rule definitions
+- 37 new schema tests with realistic API data (46 total, up from 9)
+
+---
+
 ## v0.6.8
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.6.8';
+export const SDK_VERSION = '0.6.9';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
## Summary

- Bump version 0.6.8 → 0.6.9 (package.json + SDK_VERSION constant)
- Add v0.6.9 release notes
- Consume changeset

### Included since v0.6.8

- Fix `PolicySchema` — 9 incorrect flat sub-schemas replaced with 15 properly nested schemas matching OpenAPI spec (#89)
- 37 new schema tests (870 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)