### PR TITLE
chore: release v0.7.0 — docs refresh + version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,14 @@ import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
 
 const client = new RedTeamClient(); // falls back to PANW_MGMT_* env vars
 
-// 5 sub-clients: scans, reports, customAttackReports, targets, customAttacks
+// 7 sub-clients: scans, reports, customAttackReports, targets, customAttacks, eula, instances
 const scans = await client.scans.list({ limit: 5 });
 const targets = await client.targets.list();
 const categories = await client.scans.getCategories();
+
+// EULA + instance management
+const eulaStatus = await client.eula.getStatus();
+const templates = await client.targets.getTargetTemplates();
 
 // 7 convenience methods on the top-level client
 const stats = await client.getScanStatistics();
@@ -148,7 +152,7 @@ Full documentation at **[cdot65.github.io/prisma-airs-sdk](https://cdot65.github
 ```bash
 npm install
 npm run build          # tsup (CJS + ESM + .d.ts)
-npm run test           # vitest (876 tests, 99%+ coverage)
+npm run test           # vitest (970 tests, 99%+ coverage)
 npm run lint           # eslint
 npm run typecheck      # tsc --noEmit
 ```

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,50 @@
 # Release Notes
 
+## v0.7.0
+
+### New Features — Red Team Management Plane Alignment
+
+Full alignment with the updated Red Team management-plane OpenAPI spec. Adds 2 new sub-clients, 3 new target methods, and 19 new Zod schemas.
+
+**New sub-clients:**
+
+- **`RedTeamEulaClient`** (`client.eula`) — EULA management with `getContent()`, `getStatus()`, `accept()` methods
+- **`RedTeamInstancesClient`** (`client.instances`) — Instance/device CRUD with `createInstance()`, `getInstance()`, `updateInstance()`, `deleteInstance()`, `createDevices()`, `updateDevices()` (PATCH), `deleteDevices()`, `getRegistryCredentials()`
+
+**New target methods:**
+
+- `targets.validateAuth()` — validate target authentication credentials
+- `targets.getTargetMetadata()` — get field definitions for target configuration
+- `targets.getTargetTemplates()` — get provider-specific target templates (OPENAI, HUGGING_FACE, DATABRICKS, BEDROCK, REST, STREAMING, WEBSOCKET)
+
+**Auth config schemas:**
+
+- `HeadersAuthConfigSchema`, `BasicAuthAuthConfigSchema`, `OAuth2AuthConfigSchema`, `AuthConfigSchema` (union)
+- `TargetAuthValidationRequestSchema`, `TargetAuthValidationResponseSchema`
+- `auth_type` field added to 6 target schemas; `auth_config` added to 3 request schemas
+
+**WebSocket support:**
+
+- `WebSocketConnectionParamsSchema` extends REST params with `ws_response_timeout` (default 110)
+- `ConnectionParamsSchema` union now includes WebSocket variant
+- `ResponseMode.WEBSOCKET` and `TargetConnectionType.WEBSOCKET` enum values
+
+**New enums:** `TargetAuthType` (HEADERS, BASIC_AUTH, OAUTH2), `BasicAuthLocation` (HEADER, PAYLOAD)
+
+**Instance/licensing schemas:** `DeviceInstanceSchema`, `DeviceLicenseSchema`, `DeviceSchema`, `DeviceStatusSchema`, `DeviceRequestSchema`, `DeviceResponseSchema`, `DeploymentProfileAttributeSchema`, `DeploymentProfileRequestSchema`, `InstanceExtraDetailsSchema`, `InstanceRequestSchema`, `InstanceResponseSchema`, `InstanceGetResponseSchema`, `RegistryCredentialsSchema`
+
+**Other schema fixes (#96):**
+
+- `PropertyNamesListResponseSchema.data`: `z.array(PropertyDefinitionSchema)` → `z.array(z.string())`
+- `CustomPromptSetListActiveSchema.data`: now uses `CustomPromptSetReferenceSchema`
+- `customAttacks.listPrompts()` gains `status` filter; `getPromptSetVersionInfo()` gains `version` query param
+
+**Infrastructure:** PATCH method support added to `managementHttpRequest`
+
+970 tests across 44 test files.
+
+---
+
 ## v0.6.11
 
 ### Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ Type-safe clients for all four AIRS service domains — real-time content scanni
 
   ***
 
-  53 typed enum const objects, 226 Zod schemas with `.passthrough()` for forward compatibility, and JSDoc on every exported symbol.
+  55 typed enum const objects, 245 Zod schemas with `.passthrough()` for forward compatibility, and JSDoc on every exported symbol.
 
 - :material-lightning-bolt:{ .lg .middle } **Zero Dependencies**
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -752,6 +752,8 @@ class RedTeamClient {
   readonly customAttackReports: RedTeamCustomAttackReportsClient;
   readonly targets: RedTeamTargetsClient;
   readonly customAttacks: RedTeamCustomAttacksClient;
+  readonly eula: RedTeamEulaClient;
+  readonly instances: RedTeamInstancesClient;
 
   // Data plane convenience methods
   getScanStatistics(params?: {
@@ -902,6 +904,9 @@ class RedTeamTargetsClient {
   probe(request: TargetProbeRequest): Promise<TargetResponse>;
   getProfile(uuid: string): Promise<TargetProfileResponse>;
   updateProfile(uuid: string, request: TargetContextUpdate): Promise<TargetResponse>;
+  validateAuth(request: TargetAuthValidationRequest): Promise<TargetAuthValidationResponse>;
+  getTargetMetadata(): Promise<Record<string, unknown>>;
+  getTargetTemplates(): Promise<TargetTemplateCollection>;
 }
 ```
 
@@ -918,6 +923,7 @@ interface PromptSetListOptions extends RedTeamListOptions {
 
 interface PromptListOptions extends RedTeamListOptions {
   active?: boolean;
+  status?: string;
 }
 
 class RedTeamCustomAttacksClient {
@@ -934,7 +940,10 @@ class RedTeamCustomAttacksClient {
     request: CustomPromptSetArchiveRequest,
   ): Promise<CustomPromptSetResponse>;
   getPromptSetReference(uuid: string): Promise<CustomPromptSetReference>;
-  getPromptSetVersionInfo(uuid: string): Promise<CustomPromptSetVersionInfo>;
+  getPromptSetVersionInfo(
+    uuid: string,
+    opts?: { version?: string },
+  ): Promise<CustomPromptSetVersionInfo>;
   listActivePromptSets(): Promise<CustomPromptSetListActive>;
   downloadTemplate(uuid: string): Promise<unknown>;
   uploadPromptsCsv(promptSetUuid: string, file: Blob): Promise<BaseResponse>;
@@ -956,6 +965,35 @@ class RedTeamCustomAttacksClient {
   getPropertyValues(propertyName: string): Promise<PropertyValuesResponse>;
   getPropertyValuesMultiple(propertyNames: string[]): Promise<PropertyValuesMultipleResponse>;
   createPropertyValue(request: PropertyValueCreateRequest): Promise<BaseResponse>;
+}
+```
+
+### `RedTeamEulaClient`
+
+Management plane EULA operations.
+
+```ts
+class RedTeamEulaClient {
+  getContent(): Promise<EulaContentResponse>;
+  getStatus(): Promise<EulaResponse>;
+  accept(request: EulaAcceptRequest): Promise<EulaResponse>;
+}
+```
+
+### `RedTeamInstancesClient`
+
+Management plane instance/licensing and registry credential operations.
+
+```ts
+class RedTeamInstancesClient {
+  createInstance(request: InstanceRequest): Promise<InstanceResponse>;
+  getInstance(tenantId: string): Promise<InstanceGetResponse>;
+  updateInstance(tenantId: string, request: InstanceRequest): Promise<InstanceResponse>;
+  deleteInstance(tenantId: string): Promise<InstanceResponse>;
+  createDevices(tenantId: string, request: DeviceRequest): Promise<DeviceResponse>;
+  updateDevices(tenantId: string, request: DeviceRequest): Promise<DeviceResponse>; // PATCH
+  deleteDevices(tenantId: string, serialNumbers: string): Promise<DeviceResponse>;
+  getRegistryCredentials(): Promise<RegistryCredentials>;
 }
 ```
 
@@ -1095,6 +1133,8 @@ import {
   SeverityFilter,
   StatusQueryParam,
   StreamType,
+  TargetAuthType,
+  BasicAuthLocation,
   TargetConnectionType,
   TargetStatus,
   TargetType,
@@ -1123,14 +1163,16 @@ import {
 | `PolicyType`            | `PROMPT_INJECTION`, `TOXIC_CONTENT`, `CUSTOM_TOPIC_GUARDRAILS`, `MALICIOUS_CODE_DETECTION`, `MALICIOUS_URL_DETECTION`, `SENSITIVE_DATA_PROTECTION`                                            |
 | `ProfilingStatus`       | `INIT`, `QUEUED`, `IN_PROGRESS`, `COMPLETED`, `FAILED`                                                                                                                                        |
 | `RedTeamCategory`       | `SECURITY`, `SAFETY`, `COMPLIANCE`, `BRAND`                                                                                                                                                   |
-| `ResponseMode`          | `REST`, `STREAMING`                                                                                                                                                                           |
+| `ResponseMode`          | `REST`, `STREAMING`, `WEBSOCKET`                                                                                                                                                              |
 | `RiskRating`            | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`                                                                                                                                                           |
 | `SafetySubCategory`     | `BIAS`, `CBRN`, `CYBERCRIME`, `DRUGS`, `HATE_TOXIC_ABUSE`, `NON_VIOLENT_CRIMES`, `POLITICAL`, `SELF_HARM`, `SEXUAL`, `VIOLENT_CRIMES_WEAPONS`                                                 |
 | `SecuritySubCategory`   | `ADVERSARIAL_SUFFIX`, `EVASION`, `INDIRECT_PROMPT_INJECTION`, `JAILBREAK`, `MULTI_TURN`, `PROMPT_INJECTION`, `REMOTE_CODE_EXECUTION`, `SYSTEM_PROMPT_LEAK`, `TOOL_LEAK`, `MALWARE_GENERATION` |
 | `SeverityFilter`        | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`                                                                                                                                                           |
 | `StatusQueryParam`      | `SUCCESSFUL`, `FAILED`                                                                                                                                                                        |
 | `StreamType`            | `NORMAL`, `ADVERSARIAL`                                                                                                                                                                       |
-| `TargetConnectionType`  | `DATABRICKS`, `BEDROCK`, `OPENAI`, `HUGGING_FACE`, `CUSTOM`, `REST`, `STREAMING`                                                                                                              |
+| `TargetAuthType`        | `HEADERS`, `BASIC_AUTH`, `OAUTH2`                                                                                                                                                             |
+| `BasicAuthLocation`     | `HEADER`, `PAYLOAD`                                                                                                                                                                           |
+| `TargetConnectionType`  | `DATABRICKS`, `BEDROCK`, `OPENAI`, `HUGGING_FACE`, `CUSTOM`, `REST`, `STREAMING`, `WEBSOCKET`                                                                                                 |
 | `TargetStatus`          | `DRAFT`, `VALIDATING`, `VALIDATED`, `ACTIVE`, `INACTIVE`, `FAILED`, `PENDING_AUTH`                                                                                                            |
 | `TargetType`            | `APPLICATION`, `AGENT`, `MODEL`                                                                                                                                                               |
 

--- a/docs/services/red-team-api.md
+++ b/docs/services/red-team-api.md
@@ -60,7 +60,7 @@ Token fetch, caching, and refresh are handled automatically. Retries (up to 5) u
 
 ## Sub-Clients
 
-The `RedTeamClient` exposes five sub-clients:
+The `RedTeamClient` exposes seven sub-clients:
 
 | Sub-Client            | Plane      | Access                       |
 | --------------------- | ---------- | ---------------------------- |
@@ -69,6 +69,8 @@ The `RedTeamClient` exposes five sub-clients:
 | `customAttackReports` | Data       | `client.customAttackReports` |
 | `targets`             | Management | `client.targets`             |
 | `customAttacks`       | Management | `client.customAttacks`       |
+| `eula`                | Management | `client.eula`                |
+| `instances`           | Management | `client.instances`           |
 
 Plus 7 convenience methods directly on `RedTeamClient` for dashboard, quota, error logs, and sentiment.
 
@@ -224,7 +226,7 @@ const stats = await client.customAttackReports.getPropertyStats('job-uuid');
 
 ## Targets
 
-CRUD for scan targets, plus profiling probes (9 methods, management plane).
+CRUD for scan targets, profiling probes, auth validation, and template retrieval (12 methods, management plane).
 
 ### Create
 
@@ -275,6 +277,102 @@ const updatedProfile = await client.targets.updateProfile('target-uuid', {
   background: 'Customer support chatbot for e-commerce',
   additional_context: 'Has access to order database',
 });
+```
+
+### Validate Auth, Metadata, and Templates
+
+```ts
+// Validate target authentication credentials
+const validation = await client.targets.validateAuth({
+  auth_type: 'HEADERS',
+  auth_config: { auth_header: { Authorization: 'Bearer token' } },
+});
+console.log(validation.validated); // true
+
+// Get target field metadata
+const metadata = await client.targets.getTargetMetadata();
+
+// Get target templates for all provider types (OPENAI, HUGGING_FACE, DATABRICKS, BEDROCK, REST, STREAMING, WEBSOCKET)
+const templates = await client.targets.getTargetTemplates();
+console.log(templates.OPENAI);
+```
+
+## EULA Management
+
+Manage EULA (End User License Agreement) acceptance for the Red Team service (3 methods, management plane).
+
+```ts
+// Get the current EULA content
+const content = await client.eula.getContent();
+console.log(content.content); // EULA text
+
+// Check acceptance status
+const status = await client.eula.getStatus();
+console.log(status.is_accepted); // true | false
+
+// Accept the EULA
+const result = await client.eula.accept({
+  eula_content: content.content,
+  accepted_at: new Date().toISOString(),
+});
+```
+
+## Instances and Licensing
+
+Manage tenant instances, device licensing, and registry credentials (8 methods, management plane).
+
+### Instance CRUD
+
+```ts
+// Create an instance
+const instance = await client.instances.createInstance({
+  tsg_id: 'tsg-1',
+  tenant_id: 'tenant-1',
+  app_id: 'app-1',
+  region: 'us-east-1',
+});
+
+// Get an instance
+const details = await client.instances.getInstance('tenant-1');
+
+// Update an instance
+const updated = await client.instances.updateInstance('tenant-1', {
+  tsg_id: 'tsg-1',
+  tenant_id: 'tenant-1',
+  app_id: 'app-1',
+  region: 'us-west-2',
+});
+
+// Delete an instance
+const result = await client.instances.deleteInstance('tenant-1');
+```
+
+### Device Management
+
+```ts
+// Create devices for an instance
+const devices = await client.instances.createDevices('tenant-1', {
+  instance: { app_id: 'app-1', region: 'us-east-1', tenant_id: 'tenant-1', tsg_id: 'tsg-1' },
+  devices: [{ serial_number: 'SN-001' }],
+});
+
+// Update devices (uses PATCH)
+const updated = await client.instances.updateDevices('tenant-1', {
+  instance: { app_id: 'app-1', region: 'us-east-1', tenant_id: 'tenant-1', tsg_id: 'tsg-1' },
+  devices: [{ serial_number: 'SN-001', device_name: 'updated-name' }],
+});
+
+// Delete devices by serial number
+const deleted = await client.instances.deleteDevices('tenant-1', 'SN-001,SN-002');
+```
+
+### Registry Credentials
+
+```ts
+// Get or create registry credentials
+const creds = await client.instances.getRegistryCredentials();
+console.log(creds.token); // JWT token
+console.log(creds.expiry); // expiration timestamp
 ```
 
 ## Custom Attacks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.6.11",
+  "version": "0.7.0",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.6.11';
+export const SDK_VERSION = '0.7.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
## Summary
- Update README test count (876 → 970), sub-client count (5 → 7)
- Update docs/index.md enum count (53 → 55), schema count (226 → 245)
- Update red-team-api.md: add EULA, Instances/Licensing, validate-auth/templates sections
- Update api-reference.md: add RedTeamEulaClient, RedTeamInstancesClient, new targets methods, new enums (TargetAuthType, BasicAuthLocation), fix ResponseMode/TargetConnectionType values
- Add v0.7.0 release notes
- Bump version to 0.7.0 (package.json + constants.ts)

Closes #110

## Test plan
- [x] 970 tests passing
- [x] All quality gates (lint, format, typecheck) green
- [x] mkdocs builds cleanly