### PR TITLE
refactor: unified request pipeline foundations

### DIFF
--- a/.changeset/0010-unified-request-foundations.md
+++ b/.changeset/0010-unified-request-foundations.md
@@ -1,0 +1,8 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Internal: foundations for unified request pipeline (no public API change).
+
+- Add `ErrorType.RESPONSE_VALIDATION` for backend response shape mismatches.
+- Add internal `request()` helper, `OAuthAuth` / `ApiKeyAuth` adapters, and shared `assertUuid` / `assertLength` validators. Sub-clients still use the legacy helpers; migrations land in subsequent releases.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,77 @@
+# CONTEXT.md
+
+Architecture vocabulary for the prisma-airs-sdk codebase. Use these terms exactly when discussing design — they have specific meanings here.
+
+## Domain concepts
+
+Reserved for AIRS domain terms (Scan, Profile, Topic, Job, Target, Custom Attack, EULA, Instance, …). Fill in as decisions crystallize.
+
+## Architecture concepts
+
+### Request spec
+
+A plain data object describing a single endpoint call: HTTP method, base URL, path, query params, request body, expected response schema, retry budget, and auth adapter. Sub-client methods construct a Request spec and hand it to `request()`.
+
+```ts
+interface RequestSpec<TResponse> {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  baseUrl: string;
+  path: string;
+  params?: Record<string, string | string[]>;
+  body?: unknown;
+  responseSchema?: z.ZodType<TResponse>;
+  numRetries: number;
+  auth: AuthAdapter;
+}
+```
+
+### Auth adapter
+
+The single seam where authentication strategy plugs into the request pipeline. Two implementations exist:
+
+- `OAuthAuth` — fetches OAuth2 bearer tokens, owns 401/403 refresh.
+- `ApiKeyAuth` — adds API-key headers and computes HMAC over the request body for the scan service.
+
+```ts
+interface AuthAdapter {
+  prepare(req: PreparedRequest): Promise<PreparedRequest>;
+  onUnauthorized?(res: Response): Promise<boolean>;
+}
+```
+
+`prepare()` returns the augmented request — typically with auth headers added. Body is read-only by convention; adapters mutate headers, not body. `onUnauthorized()` is called at most once per request after a retryable auth failure; returning `true` triggers a free retry that does not count against the retry budget.
+
+### PreparedRequest
+
+The in-flight request as the auth adapter sees it. The request helper has already serialized the body to JSON and assembled the URL.
+
+```ts
+interface PreparedRequest {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  url: URL;
+  headers: Record<string, string>;
+  bodyText?: string;
+}
+```
+
+### Pre-flight check
+
+A build-time script that diffs Zod schemas in `src/models/` against the authoritative OpenAPI specs in `specs/`. Catches schema drift before it reaches the production parsing path. Runs in CI; failures block merge.
+
+### Listing
+
+A paginated, filterable list request. Owns serialization of `skip` / `limit` / `search` / `sort` / typed filter args into URL search params, and exposes an `async *` iterator (`listAll`) that walks pages. Each list endpoint declares its filter shape; the module owns wire-format mechanics. Replaces ad-hoc per-client query-string building.
+
+```ts
+interface ListingOptions<TFilters = {}> {
+  skip?: number;
+  limit?: number;
+  search?: string;
+  sort?: { field: string; order: 'asc' | 'desc' };
+  filters?: TFilters;
+}
+```
+
+### RESPONSE_VALIDATION error
+
+`AISecSDKException` with `ErrorType.RESPONSE_VALIDATION` is thrown when the backend returns a 2xx with a body that does not match the declared response schema (or is not valid JSON). Distinct from `SERVER_SIDE_ERROR` (5xx) and `CLIENT_SIDE_ERROR` (4xx) so callers can route SDK-bug-vs-backend-bug-vs-client-bug differently.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,6 +14,8 @@ export enum ErrorType {
   AISEC_SDK_ERROR = 'AISEC_SDK_ERROR',
   /** OAuth2 token fetch failure. */
   OAUTH_ERROR = 'AISEC_OAUTH_ERROR',
+  /** Server returned a 2xx body that did not match the declared response schema, or invalid JSON. */
+  RESPONSE_VALIDATION = 'AISEC_RESPONSE_VALIDATION',
 }
 
 /**

--- a/src/http/auth/api-key.ts
+++ b/src/http/auth/api-key.ts
@@ -1,0 +1,46 @@
+import { BEARER, HEADER_API_KEY, HEADER_AUTH_TOKEN, PAYLOAD_HASH } from '../../constants.js';
+import { AISecSDKException, ErrorType } from '../../errors.js';
+import { generatePayloadHash } from '../../utils.js';
+import type { AuthAdapter, PreparedRequest } from '../types.js';
+
+/** Options for {@link ApiKeyAuth}. At least one of `apiKey` / `apiToken` is required. */
+export interface ApiKeyAuthOptions {
+  apiKey?: string;
+  apiToken?: string;
+}
+
+/**
+ * @internal
+ * Auth adapter for the AIRS scan service. Adds the API-key header, the bearer token header
+ * (if configured), and an HMAC-SHA256 payload hash over `bodyText` when both an apiKey and a
+ * body are present. Mirrors the behavior of the legacy `src/http-client.ts`.
+ */
+export class ApiKeyAuth implements AuthAdapter {
+  private readonly apiKey?: string;
+  private readonly apiToken?: string;
+
+  constructor(opts: ApiKeyAuthOptions) {
+    if (!opts.apiKey && !opts.apiToken) {
+      throw new AISecSDKException(
+        'ApiKeyAuth requires either apiKey or apiToken',
+        ErrorType.MISSING_VARIABLE,
+      );
+    }
+    this.apiKey = opts.apiKey;
+    this.apiToken = opts.apiToken;
+  }
+
+  async prepare(req: PreparedRequest): Promise<PreparedRequest> {
+    const headers = { ...req.headers };
+    if (this.apiToken) {
+      headers[HEADER_AUTH_TOKEN] = `${BEARER}${this.apiToken}`;
+    }
+    if (this.apiKey) {
+      headers[HEADER_API_KEY] = this.apiKey;
+      if (req.bodyText !== undefined) {
+        headers[PAYLOAD_HASH] = generatePayloadHash(req.bodyText, this.apiKey);
+      }
+    }
+    return { ...req, headers };
+  }
+}

--- a/src/http/auth/oauth.ts
+++ b/src/http/auth/oauth.ts
@@ -1,0 +1,27 @@
+import type { OAuthClient } from '../../management/oauth-client.js';
+import type { AuthAdapter, PreparedRequest } from '../types.js';
+
+/**
+ * @internal
+ * Auth adapter that attaches an OAuth2 bearer token via {@link OAuthClient} and clears the cached
+ * token on 401/403 to force a refresh on the free-retry attempt.
+ */
+export class OAuthAuth implements AuthAdapter {
+  constructor(private readonly oauthClient: OAuthClient) {}
+
+  async prepare(req: PreparedRequest): Promise<PreparedRequest> {
+    const token = await this.oauthClient.getToken();
+    return {
+      ...req,
+      headers: { ...req.headers, Authorization: `Bearer ${token}` },
+    };
+  }
+
+  async onUnauthorized(res: Response): Promise<boolean> {
+    if (res.status === 401 || res.status === 403) {
+      this.oauthClient.clearToken();
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -1,0 +1,85 @@
+import { USER_AGENT } from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
+import { executeWithRetry } from '../http-retry.js';
+import type { PreparedRequest, RequestSpec } from './types.js';
+
+/**
+ * @internal
+ * Execute a single AIRS API request: build URL + headers + body, run the auth adapter, retry per
+ * the spec's budget, and (if a response schema is declared) validate the response body.
+ *
+ * Returns the parsed response when `responseSchema` is provided, or `undefined` when omitted.
+ *
+ * Throws {@link AISecSDKException}:
+ * - `RESPONSE_VALIDATION` if a 2xx body is invalid JSON or fails the schema.
+ * - `CLIENT_SIDE_ERROR` for 4xx (or after `onUnauthorized` declines a 401/403).
+ * - `SERVER_SIDE_ERROR` for 5xx after exhausting retries.
+ */
+export async function request<TResponse = void>(spec: RequestSpec<TResponse>): Promise<TResponse> {
+  let hasRetriedAuth = false;
+
+  const response = await executeWithRetry({
+    maxRetries: spec.numRetries,
+    execute: async () => {
+      const baseUrl = spec.baseUrl.replace(/\/+$/, '');
+      const url = new URL(`${baseUrl}${spec.path}`);
+      if (spec.params) {
+        for (const [key, value] of Object.entries(spec.params)) {
+          if (Array.isArray(value)) {
+            for (const v of value) url.searchParams.append(key, v);
+          } else {
+            url.searchParams.set(key, value);
+          }
+        }
+      }
+
+      const headers: Record<string, string> = { 'User-Agent': USER_AGENT };
+      let bodyText: string | undefined;
+      if (spec.body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+        bodyText = JSON.stringify(spec.body);
+      }
+
+      const prepared: PreparedRequest = { method: spec.method, url, headers, bodyText };
+      const final = await spec.auth.prepare(prepared);
+
+      return fetch(final.url.toString(), {
+        method: final.method,
+        headers: final.headers,
+        body: final.bodyText,
+      });
+    },
+    onRetryableFailure: async (res) => {
+      if (hasRetriedAuth) return false;
+      if (!spec.auth.onUnauthorized) return false;
+      const should = await spec.auth.onUnauthorized(res);
+      if (should) {
+        hasRetriedAuth = true;
+        return true;
+      }
+      return false;
+    },
+  });
+
+  const text = await response.text();
+
+  if (!spec.responseSchema) {
+    return undefined as TResponse;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = text ? JSON.parse(text) : undefined;
+  } catch {
+    throw new AISecSDKException('Response body is not valid JSON', ErrorType.RESPONSE_VALIDATION);
+  }
+
+  const result = spec.responseSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new AISecSDKException(
+      `Response did not match schema: ${result.error.message}`,
+      ErrorType.RESPONSE_VALIDATION,
+    );
+  }
+  return result.data;
+}

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -1,0 +1,42 @@
+import type { z } from 'zod';
+
+/** @internal HTTP methods supported by the request pipeline. */
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/**
+ * @internal
+ * The in-flight request as an {@link AuthAdapter} sees it. Body is JSON-serialized to `bodyText`
+ * before the adapter runs; adapters mutate headers, not body, by convention.
+ */
+export interface PreparedRequest {
+  method: HttpMethod;
+  url: URL;
+  headers: Record<string, string>;
+  bodyText?: string;
+}
+
+/**
+ * @internal
+ * Plug-point for authentication strategy. `prepare()` augments outgoing requests (typically with
+ * auth headers). `onUnauthorized()` is called at most once per request after a retryable auth
+ * failure; returning `true` triggers a free retry that does not consume the retry budget.
+ */
+export interface AuthAdapter {
+  prepare(req: PreparedRequest): Promise<PreparedRequest>;
+  onUnauthorized?(res: Response): Promise<boolean>;
+}
+
+/**
+ * @internal
+ * Declarative description of one endpoint call.
+ */
+export interface RequestSpec<TResponse = void> {
+  method: HttpMethod;
+  baseUrl: string;
+  path: string;
+  params?: Record<string, string | string[]>;
+  body?: unknown;
+  responseSchema?: z.ZodType<TResponse>;
+  numRetries: number;
+  auth: AuthAdapter;
+}

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,0 +1,29 @@
+import { AISecSDKException, ErrorType } from './errors.js';
+import { isValidUuid } from './utils.js';
+
+/**
+ * @internal
+ * Throw `AISecSDKException(USER_REQUEST_PAYLOAD_ERROR)` if `value` is not a valid RFC 4122 UUID.
+ */
+export function assertUuid(value: string, fieldName: string): void {
+  if (!isValidUuid(value)) {
+    throw new AISecSDKException(
+      `Invalid ${fieldName}: ${value}`,
+      ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+    );
+  }
+}
+
+/**
+ * @internal
+ * Throw `AISecSDKException(USER_REQUEST_PAYLOAD_ERROR)` if `value.length` is outside `[min, max]`.
+ */
+export function assertLength(value: string, min: number, max: number, fieldName: string): void {
+  const len = value.length;
+  if (len < min || len > max) {
+    throw new AISecSDKException(
+      `Invalid ${fieldName}: length ${len} not in [${min}, ${max}]`,
+      ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+    );
+  }
+}

--- a/test/errors.spec.ts
+++ b/test/errors.spec.ts
@@ -33,5 +33,13 @@ describe('ErrorType', () => {
     expect(ErrorType.USER_REQUEST_PAYLOAD_ERROR).toBe('AISEC_USER_REQUEST_PAYLOAD_ERROR');
     expect(ErrorType.MISSING_VARIABLE).toBe('AISEC_MISSING_VARIABLE');
     expect(ErrorType.AISEC_SDK_ERROR).toBe('AISEC_SDK_ERROR');
+    expect(ErrorType.OAUTH_ERROR).toBe('AISEC_OAUTH_ERROR');
+    expect(ErrorType.RESPONSE_VALIDATION).toBe('AISEC_RESPONSE_VALIDATION');
+  });
+
+  it('RESPONSE_VALIDATION can be thrown and round-tripped', () => {
+    const err = new AISecSDKException('schema mismatch', ErrorType.RESPONSE_VALIDATION);
+    expect(err.errorType).toBe(ErrorType.RESPONSE_VALIDATION);
+    expect(err.message).toContain('schema mismatch');
   });
 });

--- a/test/http/auth/api-key.spec.ts
+++ b/test/http/auth/api-key.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { ApiKeyAuth } from '../../../src/http/auth/api-key.js';
+import type { PreparedRequest } from '../../../src/http/types.js';
+import { generatePayloadHash } from '../../../src/utils.js';
+import { HEADER_API_KEY, HEADER_AUTH_TOKEN, PAYLOAD_HASH } from '../../../src/constants.js';
+
+function baseRequest(): PreparedRequest {
+  return {
+    method: 'GET',
+    url: new URL('https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request'),
+    headers: { 'User-Agent': 'test' },
+  };
+}
+
+describe('ApiKeyAuth.prepare', () => {
+  it('adds x-pan-token header when configured with apiKey', async () => {
+    const auth = new ApiKeyAuth({ apiKey: 'sec-key' });
+    const out = await auth.prepare(baseRequest());
+    expect(out.headers[HEADER_API_KEY]).toBe('sec-key');
+  });
+
+  it('adds Authorization Bearer header when configured with apiToken', async () => {
+    const auth = new ApiKeyAuth({ apiToken: 'bearer-tok' });
+    const out = await auth.prepare(baseRequest());
+    expect(out.headers[HEADER_AUTH_TOKEN]).toBe('Bearer bearer-tok');
+  });
+
+  it('adds both auth headers when configured with apiKey and apiToken', async () => {
+    const auth = new ApiKeyAuth({ apiKey: 'sec-key', apiToken: 'bearer-tok' });
+    const out = await auth.prepare(baseRequest());
+    expect(out.headers[HEADER_API_KEY]).toBe('sec-key');
+    expect(out.headers[HEADER_AUTH_TOKEN]).toBe('Bearer bearer-tok');
+  });
+
+  it('adds payload hash header when bodyText present and apiKey configured', async () => {
+    const auth = new ApiKeyAuth({ apiKey: 'secret-123' });
+    const bodyText = '{"hello":"world"}';
+    const req: PreparedRequest = {
+      method: 'POST',
+      url: new URL('https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request'),
+      headers: {},
+      bodyText,
+    };
+    const out = await auth.prepare(req);
+    expect(out.headers[PAYLOAD_HASH]).toBe(generatePayloadHash(bodyText, 'secret-123'));
+  });
+
+  it('does not add payload hash when no bodyText', async () => {
+    const auth = new ApiKeyAuth({ apiKey: 'secret-123' });
+    const out = await auth.prepare(baseRequest());
+    expect(out.headers[PAYLOAD_HASH]).toBeUndefined();
+  });
+
+  it('does not add payload hash when only apiToken (no apiKey)', async () => {
+    const auth = new ApiKeyAuth({ apiToken: 'tok' });
+    const req: PreparedRequest = {
+      method: 'POST',
+      url: new URL('https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request'),
+      headers: {},
+      bodyText: '{"a":1}',
+    };
+    const out = await auth.prepare(req);
+    expect(out.headers[PAYLOAD_HASH]).toBeUndefined();
+  });
+
+  it('preserves existing headers', async () => {
+    const auth = new ApiKeyAuth({ apiKey: 'k' });
+    const req = baseRequest();
+    req.headers['X-Custom'] = 'keep';
+    const out = await auth.prepare(req);
+    expect(out.headers['X-Custom']).toBe('keep');
+    expect(out.headers['User-Agent']).toBe('test');
+  });
+
+  it('returns request with same url, method, bodyText', async () => {
+    const auth = new ApiKeyAuth({ apiKey: 'k' });
+    const req: PreparedRequest = {
+      method: 'POST',
+      url: new URL('https://api.example.com/v1/x'),
+      headers: {},
+      bodyText: '{"a":1}',
+    };
+    const out = await auth.prepare(req);
+    expect(out.method).toBe('POST');
+    expect(out.url.toString()).toBe('https://api.example.com/v1/x');
+    expect(out.bodyText).toBe('{"a":1}');
+  });
+
+  it('throws if neither apiKey nor apiToken configured', () => {
+    expect(() => new ApiKeyAuth({})).toThrow();
+  });
+
+  it('does not implement onUnauthorized (scan auth has no token refresh)', () => {
+    const auth = new ApiKeyAuth({ apiKey: 'k' });
+    expect(auth.onUnauthorized).toBeUndefined();
+  });
+});

--- a/test/http/auth/oauth.spec.ts
+++ b/test/http/auth/oauth.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { OAuthAuth } from '../../../src/http/auth/oauth.js';
+import type { OAuthClient } from '../../../src/management/oauth-client.js';
+import type { PreparedRequest } from '../../../src/http/types.js';
+
+function makeClient(token = 'tok-1'): OAuthClient {
+  return {
+    getToken: vi.fn().mockResolvedValue(token),
+    clearToken: vi.fn(),
+  } as unknown as OAuthClient;
+}
+
+function baseRequest(): PreparedRequest {
+  return {
+    method: 'GET',
+    url: new URL('https://api.example.com/v1/items'),
+    headers: { 'User-Agent': 'test' },
+  };
+}
+
+describe('OAuthAuth.prepare', () => {
+  it('adds Authorization Bearer header from getToken()', async () => {
+    const client = makeClient('my-token');
+    const auth = new OAuthAuth(client);
+    const out = await auth.prepare(baseRequest());
+    expect(out.headers['Authorization']).toBe('Bearer my-token');
+  });
+
+  it('preserves existing headers', async () => {
+    const auth = new OAuthAuth(makeClient());
+    const req = baseRequest();
+    req.headers['X-Custom'] = 'keep-me';
+    const out = await auth.prepare(req);
+    expect(out.headers['X-Custom']).toBe('keep-me');
+    expect(out.headers['User-Agent']).toBe('test');
+  });
+
+  it('returns a request with same url, method, and bodyText', async () => {
+    const auth = new OAuthAuth(makeClient());
+    const req: PreparedRequest = {
+      method: 'POST',
+      url: new URL('https://api.example.com/v1/things'),
+      headers: {},
+      bodyText: '{"a":1}',
+    };
+    const out = await auth.prepare(req);
+    expect(out.method).toBe('POST');
+    expect(out.url.toString()).toBe('https://api.example.com/v1/things');
+    expect(out.bodyText).toBe('{"a":1}');
+  });
+
+  it('propagates token fetch errors', async () => {
+    const client = {
+      getToken: vi.fn().mockRejectedValue(new Error('token fetch failed')),
+      clearToken: vi.fn(),
+    } as unknown as OAuthClient;
+    const auth = new OAuthAuth(client);
+    await expect(auth.prepare(baseRequest())).rejects.toThrow(/token fetch failed/);
+  });
+
+  it('calls getToken once per prepare', async () => {
+    const client = makeClient();
+    const auth = new OAuthAuth(client);
+    await auth.prepare(baseRequest());
+    expect(client.getToken).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('OAuthAuth.onUnauthorized', () => {
+  it('clears token and returns true on 401', async () => {
+    const client = makeClient();
+    const auth = new OAuthAuth(client);
+    const res = new Response(null, { status: 401 });
+    const should = await auth.onUnauthorized!(res);
+    expect(should).toBe(true);
+    expect(client.clearToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears token and returns true on 403', async () => {
+    const client = makeClient();
+    const auth = new OAuthAuth(client);
+    const res = new Response(null, { status: 403 });
+    const should = await auth.onUnauthorized!(res);
+    expect(should).toBe(true);
+    expect(client.clearToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false and does not clear token on 500', async () => {
+    const client = makeClient();
+    const auth = new OAuthAuth(client);
+    const res = new Response(null, { status: 500 });
+    const should = await auth.onUnauthorized!(res);
+    expect(should).toBe(false);
+    expect(client.clearToken).not.toHaveBeenCalled();
+  });
+
+  it('returns false on 400', async () => {
+    const client = makeClient();
+    const auth = new OAuthAuth(client);
+    const res = new Response(null, { status: 400 });
+    expect(await auth.onUnauthorized!(res)).toBe(false);
+    expect(client.clearToken).not.toHaveBeenCalled();
+  });
+});

--- a/test/http/request.spec.ts
+++ b/test/http/request.spec.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { z } from 'zod';
+import { request } from '../../src/http/request.js';
+import { AISecSDKException, ErrorType } from '../../src/errors.js';
+import type { AuthAdapter, PreparedRequest } from '../../src/http/types.js';
+
+const passthroughAuth: AuthAdapter = {
+  prepare: async (req) => req,
+};
+
+function refreshAuth(
+  opts: {
+    unauthorizedReturns?: boolean;
+  } = {},
+): AuthAdapter & { refreshCount: () => number } {
+  let count = 0;
+  return {
+    prepare: async (req) => req,
+    onUnauthorized: async () => {
+      count++;
+      return opts.unauthorizedReturns ?? true;
+    },
+    refreshCount: () => count,
+  } as AuthAdapter & { refreshCount: () => number };
+}
+
+function mockResponse(body: unknown, status = 200): Response {
+  const text = body === undefined ? '' : typeof body === 'string' ? body : JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(text),
+  } as unknown as Response;
+}
+
+const ItemSchema = z.object({ id: z.string(), name: z.string() });
+type Item = z.infer<typeof ItemSchema>;
+
+describe('request — URL building', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('builds URL from baseUrl + path', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://api.example.com/v1/items');
+  });
+
+  it('strips trailing slash from baseUrl', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com///',
+      path: '/v1/items',
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://api.example.com/v1/items');
+  });
+
+  it('appends scalar params', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      params: { skip: '10', limit: '20' },
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain('skip=10');
+    expect(url).toContain('limit=20');
+  });
+
+  it('appends array params with repeated keys', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      params: { tag: ['a', 'b', 'c'] },
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [url] = fetchSpy.mock.calls[0] as [string];
+    const parsed = new URL(url);
+    expect(parsed.searchParams.getAll('tag')).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('request — body handling', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('omits body and Content-Type when body undefined', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.body).toBeUndefined();
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+  });
+
+  it('JSON-stringifies body and sets Content-Type', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'POST',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      body: { name: 'foo' },
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.body).toBe(JSON.stringify({ name: 'foo' }));
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+  });
+
+  it('sets User-Agent on every request', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Record<string, string>)['User-Agent']).toMatch(/PAN-AIRS/);
+  });
+});
+
+describe('request — schema parsing', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns parsed body when schema matches', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ id: '1', name: 'foo' }));
+
+    const result = await request<Item>({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items/1',
+      responseSchema: ItemSchema,
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    expect(result).toEqual({ id: '1', name: 'foo' });
+  });
+
+  it('throws RESPONSE_VALIDATION when schema fails', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ id: 1, name: 'foo' }));
+
+    try {
+      await request<Item>({
+        method: 'GET',
+        baseUrl: 'https://api.example.com',
+        path: '/v1/items/1',
+        responseSchema: ItemSchema,
+        auth: passthroughAuth,
+        numRetries: 0,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AISecSDKException);
+      expect((err as AISecSDKException).errorType).toBe(ErrorType.RESPONSE_VALIDATION);
+    }
+  });
+
+  it('throws RESPONSE_VALIDATION when body is not valid JSON', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse('not-json{', 200));
+
+    try {
+      await request<Item>({
+        method: 'GET',
+        baseUrl: 'https://api.example.com',
+        path: '/v1/items/1',
+        responseSchema: ItemSchema,
+        auth: passthroughAuth,
+        numRetries: 0,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AISecSDKException);
+      expect((err as AISecSDKException).errorType).toBe(ErrorType.RESPONSE_VALIDATION);
+    }
+  });
+
+  it('returns undefined when no schema and empty body', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(undefined, 204));
+
+    const result = await request({
+      method: 'DELETE',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items/1',
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when no schema and any body (body is discarded)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ ignored: true }));
+
+    const result = await request({
+      method: 'POST',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('request — error handling', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('throws CLIENT_SIDE_ERROR on 4xx (non-401/403)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(JSON.stringify({ message: 'not found' })),
+    });
+
+    try {
+      await request({
+        method: 'GET',
+        baseUrl: 'https://api.example.com',
+        path: '/v1/missing',
+        auth: passthroughAuth,
+        numRetries: 0,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AISecSDKException);
+      expect((err as AISecSDKException).errorType).toBe(ErrorType.CLIENT_SIDE_ERROR);
+      expect((err as Error).message).toContain('not found');
+    }
+  });
+
+  it('retries on 5xx and eventually throws SERVER_SIDE_ERROR', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve(JSON.stringify({ message: 'unavailable' })),
+    });
+    globalThis.fetch = fetchSpy;
+
+    try {
+      await request({
+        method: 'GET',
+        baseUrl: 'https://api.example.com',
+        path: '/v1/x',
+        auth: passthroughAuth,
+        numRetries: 1,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as AISecSDKException).errorType).toBe(ErrorType.SERVER_SIDE_ERROR);
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('request — auth integration', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('calls auth.prepare for the request', async () => {
+    const adapter: AuthAdapter = {
+      prepare: vi.fn(async (req: PreparedRequest) => ({
+        ...req,
+        headers: { ...req.headers, 'X-Auth': 'yes' },
+      })),
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({}));
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      auth: adapter,
+      numRetries: 0,
+    });
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((init.headers as Record<string, string>)['X-Auth']).toBe('yes');
+    expect(adapter.prepare).toHaveBeenCalledTimes(1);
+  });
+
+  it('grants free retry when onUnauthorized returns true (401)', async () => {
+    const auth = refreshAuth();
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve(JSON.stringify({ message: 'unauthorized' })),
+      })
+      .mockResolvedValueOnce(mockResponse({ ok: true }, 200));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/x',
+      auth,
+      numRetries: 0,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(auth.refreshCount()).toBe(1);
+  });
+
+  it('only calls onUnauthorized once per request (401 twice → throws)', async () => {
+    const auth = refreshAuth();
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve(JSON.stringify({ message: 'unauthorized' })),
+    });
+    globalThis.fetch = fetchSpy;
+
+    await expect(
+      request({
+        method: 'GET',
+        baseUrl: 'https://api.example.com',
+        path: '/v1/x',
+        auth,
+        numRetries: 0,
+      }),
+    ).rejects.toThrow(/unauthorized/);
+
+    expect(auth.refreshCount()).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls through to CLIENT_SIDE_ERROR if onUnauthorized returns false', async () => {
+    const auth = refreshAuth({ unauthorizedReturns: false });
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve(JSON.stringify({ message: 'unauthorized' })),
+    });
+    globalThis.fetch = fetchSpy;
+
+    try {
+      await request({
+        method: 'GET',
+        baseUrl: 'https://api.example.com',
+        path: '/v1/x',
+        auth,
+        numRetries: 0,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as AISecSDKException).errorType).toBe(ErrorType.CLIENT_SIDE_ERROR);
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('adapter without onUnauthorized: 401 falls through immediately', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve(JSON.stringify({ message: 'unauthorized' })),
+    });
+    globalThis.fetch = fetchSpy;
+
+    await expect(
+      request({
+        method: 'GET',
+        baseUrl: 'https://api.example.com',
+        path: '/v1/x',
+        auth: passthroughAuth,
+        numRetries: 0,
+      }),
+    ).rejects.toThrow(/unauthorized/);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/validators.spec.ts
+++ b/test/validators.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { assertUuid, assertLength } from '../src/validators.js';
+import { AISecSDKException, ErrorType } from '../src/errors.js';
+
+describe('assertUuid', () => {
+  it('accepts canonical v4 UUID', () => {
+    expect(() => assertUuid('550e8400-e29b-41d4-a716-446655440000', 'scanId')).not.toThrow();
+  });
+
+  it('accepts mixed-case UUID', () => {
+    expect(() => assertUuid('550E8400-E29B-41D4-A716-446655440000', 'jobId')).not.toThrow();
+  });
+
+  it('throws USER_REQUEST_PAYLOAD_ERROR on malformed UUID', () => {
+    try {
+      assertUuid('not-a-uuid', 'scanId');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AISecSDKException);
+      expect((err as AISecSDKException).errorType).toBe(ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+      expect((err as Error).message).toContain('scanId');
+      expect((err as Error).message).toContain('not-a-uuid');
+    }
+  });
+
+  it('throws on empty string', () => {
+    expect(() => assertUuid('', 'reportId')).toThrow(AISecSDKException);
+  });
+
+  it('throws on UUID with extra characters', () => {
+    expect(() => assertUuid('550e8400-e29b-41d4-a716-446655440000-extra', 'scanId')).toThrow(
+      AISecSDKException,
+    );
+  });
+
+  it('embeds field name in error message', () => {
+    try {
+      assertUuid('bad', 'targetId');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as Error).message).toMatch(/targetId/);
+    }
+  });
+});
+
+describe('assertLength', () => {
+  it('accepts string at min boundary', () => {
+    expect(() => assertLength('abc', 3, 10, 'name')).not.toThrow();
+  });
+
+  it('accepts string at max boundary', () => {
+    expect(() => assertLength('abcdefghij', 3, 10, 'name')).not.toThrow();
+  });
+
+  it('accepts string in range', () => {
+    expect(() => assertLength('hello', 1, 100, 'description')).not.toThrow();
+  });
+
+  it('throws when shorter than min', () => {
+    try {
+      assertLength('ab', 3, 10, 'name');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AISecSDKException);
+      expect((err as AISecSDKException).errorType).toBe(ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+      expect((err as Error).message).toContain('name');
+    }
+  });
+
+  it('throws when longer than max', () => {
+    expect(() => assertLength('abcdefghijk', 3, 10, 'name')).toThrow(AISecSDKException);
+  });
+
+  it('embeds field name and bounds in error message', () => {
+    try {
+      assertLength('x', 5, 20, 'sessionId');
+      expect.fail('should have thrown');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/sessionId/);
+      expect(msg).toMatch(/5/);
+      expect(msg).toMatch(/20/);
+    }
+  });
+});


### PR DESCRIPTION
Closes #114. Part of #113.

## Summary

Add foundations for the unified request pipeline campaign — internal-only, zero behavior change. Sub-client migrations land in PRs 3-5.

- `src/http/request.ts` — single `request<T>()` helper with auth-adapter seam, retry, and Zod response validation.
- `src/http/auth/oauth.ts` — `OAuthAuth` adapter wrapping existing `OAuthClient`; owns 401/403 free-retry.
- `src/http/auth/api-key.ts` — `ApiKeyAuth` adapter with HMAC body signing for the AIRS scan service.
- `src/validators.ts` — shared `assertUuid`, `assertLength`.
- `src/errors.ts` — new `ErrorType.RESPONSE_VALIDATION` for backend response shape mismatches.
- `CONTEXT.md` — architecture vocabulary (Request spec, Auth adapter, PreparedRequest, Listing, Pre-flight, RESPONSE_VALIDATION).

## What changes

- **Public API**: nothing. `src/index.ts` is byte-identical.
- **Test count**: 983 → 1034 (+51).
- **Runtime deps**: none added.

## Test plan

- [x] `npm run test` — 1034/1034 green
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — builds CJS + ESM + types
- [x] No diff in `src/index.ts` (verified via `git diff origin/main -- src/index.ts`)

## Follow-ups (campaign sequence)

1. PR 2 — pre-flight check (`scripts/preflight-schemas.ts`, OpenAPI ↔ Zod diff in CI)
2. PR 3 — migrate `src/management/` to `request()`; delete `management-http-client.ts`
3. PR 4 — migrate `src/model-security/` and `src/red-team/`; add `src/listing.ts` for pagination dedup
4. PR 5 — migrate `src/scan/`; delete `src/http-client.ts`