### PR TITLE
feat: OpenAPI schema pre-flight check (warn-only CI gate)

### DIFF
--- a/.changeset/0011-preflight-schema-check.md
+++ b/.changeset/0011-preflight-schema-check.md
@@ -1,0 +1,8 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Internal: add OpenAPI schema pre-flight check (no public API change).
+
+- New `npm run preflight` / `preflight:warn` scripts diff every Zod schema in `src/models/` against the dereferenced OpenAPI components in `specs/`.
+- CI runs `preflight:warn` on every PR — drift is logged but does not block merge yet. Drift fixes land in follow-up PRs (#118), after which the gate flips to strict.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck
+
+      - name: OpenAPI schema pre-flight (warn-only)
+        run: npm run preflight:warn

--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,6 @@ coverage/
 .DS_Store
 Thumbs.db
 
-# OpenAPI specs (reference only, not published)
-specs/
-
 # MkDocs build output
 site/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@ coverage
 *.lock
 tsup.config.bundled_*
 review-*
+specs
+docs/diagrams

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.6.7",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.6.7",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"
       },
       "devDependencies": {
+        "@apidevtools/swagger-parser": "^12.1.0",
         "@types/node": "^25.3.3",
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
@@ -19,8 +20,10 @@
         "eslint": "^9.17.0",
         "prettier": "^3.8.1",
         "tsup": "^8.3.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.3.3",
-        "vitest": "^3.0.0"
+        "vitest": "^3.0.0",
+        "zod-to-json-schema": "^3.25.2"
       },
       "engines": {
         "node": ">=18"
@@ -39,6 +42,97 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -1810,6 +1904,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2322,6 +2423,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2433,6 +2551,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -2954,6 +3085,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3242,6 +3381,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3250,6 +3399,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -3745,6 +3904,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4125,6 +4304,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "preflight": "tsx scripts/preflight-schemas.ts",
+    "preflight:warn": "tsx scripts/preflight-schemas.ts --warn-only",
     "prepare": "git config core.hooksPath .githooks && npm run build",
     "prepublishOnly": "npm run lint && npm run test",
     "example:scan": "npx tsx --env-file=.env examples/basic-scan.ts",
@@ -67,6 +69,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@apidevtools/swagger-parser": "^12.1.0",
     "@types/node": "^25.3.3",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
@@ -74,7 +77,9 @@
     "eslint": "^9.17.0",
     "prettier": "^3.8.1",
     "tsup": "^8.3.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.3.3",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "zod-to-json-schema": "^3.25.2"
   }
 }

--- a/scripts/preflight-schemas.ts
+++ b/scripts/preflight-schemas.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env tsx
+/**
+ * @internal
+ * Pre-flight schema check.
+ *
+ * Loads every OpenAPI spec in `specs/`, every Zod `*Schema` export in `src/models/`, converts
+ * the Zod schemas to JSON Schema, and compares them against the matching OpenAPI components.
+ * Reports drift findings and exits non-zero unless `--warn-only` is passed.
+ *
+ * Usage:
+ *   tsx scripts/preflight-schemas.ts            # strict — exit 1 on drift
+ *   tsx scripts/preflight-schemas.ts --warn-only  # report drift, exit 0
+ */
+import { readdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+import { ZodType } from 'zod';
+import zodToJsonSchema from 'zod-to-json-schema';
+import type { OpenAPIV3 } from 'openapi-types';
+import { loadSpec } from './preflight/load-spec.js';
+import { diffSchemas, type DriftFinding, type JsonSchema } from './preflight/diff-schemas.js';
+import { resolveOpenApiName } from './preflight/resolve-name.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SPECS_DIR = join(ROOT, 'specs');
+const MODELS_DIR = join(ROOT, 'src', 'models');
+
+interface ModelSchema {
+  exportName: string;
+  shortName: string;
+  schema: ZodType;
+  sourceFile: string;
+}
+
+async function loadAllSpecs(): Promise<Map<string, OpenAPIV3.SchemaObject>> {
+  const entries = await readdir(SPECS_DIR);
+  const merged = new Map<string, OpenAPIV3.SchemaObject>();
+  const collisions: string[] = [];
+  for (const file of entries) {
+    if (!file.endsWith('.yaml') && !file.endsWith('.yml')) continue;
+    const path = join(SPECS_DIR, file);
+    const map = await loadSpec(path);
+    for (const [name, schema] of map) {
+      if (merged.has(name)) {
+        const existing = JSON.stringify(merged.get(name));
+        const incoming = JSON.stringify(schema);
+        if (existing !== incoming) {
+          collisions.push(`${name} (defined in multiple specs with different shapes)`);
+        }
+      }
+      merged.set(name, schema);
+    }
+  }
+  for (const c of collisions) {
+    console.warn(`[preflight] WARN: ${c}`);
+  }
+  return merged;
+}
+
+async function loadAllModels(): Promise<ModelSchema[]> {
+  const entries = await readdir(MODELS_DIR);
+  const out: ModelSchema[] = [];
+  for (const file of entries) {
+    if (!file.endsWith('.ts') || file === 'index.ts') continue;
+    const sourceFile = join(MODELS_DIR, file);
+    const mod = (await import(sourceFile)) as Record<string, unknown>;
+    for (const [exportName, value] of Object.entries(mod)) {
+      if (!exportName.endsWith('Schema')) continue;
+      if (!(value instanceof ZodType)) continue;
+      out.push({
+        exportName,
+        shortName: exportName.replace(/Schema$/, ''),
+        schema: value,
+        sourceFile,
+      });
+    }
+  }
+  return out;
+}
+
+interface PreflightReport {
+  findings: DriftFinding[];
+  unmatchedZodSchemas: { exportName: string; sourceFile: string }[];
+  totalZod: number;
+  totalSpec: number;
+  matched: number;
+}
+
+async function runPreflight(): Promise<PreflightReport> {
+  const [specMap, models] = await Promise.all([loadAllSpecs(), loadAllModels()]);
+  const findings: DriftFinding[] = [];
+  const unmatched: { exportName: string; sourceFile: string }[] = [];
+  let matched = 0;
+
+  for (const m of models) {
+    const resolved = resolveOpenApiName(m.shortName, specMap);
+    if (!resolved) {
+      unmatched.push({ exportName: m.exportName, sourceFile: m.sourceFile });
+      continue;
+    }
+    matched++;
+    const zodJson = zodToJsonSchema(m.schema, { target: 'openApi3' }) as JsonSchema;
+    findings.push(...diffSchemas(zodJson, resolved.schema as JsonSchema, resolved.matchedName));
+  }
+
+  return {
+    findings,
+    unmatchedZodSchemas: unmatched,
+    totalZod: models.length,
+    totalSpec: specMap.size,
+    matched,
+  };
+}
+
+function printReport(report: PreflightReport): void {
+  console.log(
+    `[preflight] Zod schemas: ${report.totalZod} | OpenAPI components: ${report.totalSpec} | matched: ${report.matched}`,
+  );
+
+  if (report.unmatchedZodSchemas.length > 0) {
+    console.log(
+      `[preflight] Unmatched Zod schemas (no OpenAPI counterpart, likely local helpers): ${report.unmatchedZodSchemas.length}`,
+    );
+    for (const u of report.unmatchedZodSchemas) {
+      console.log(`  - ${u.exportName}  (${relative(ROOT, u.sourceFile)})`);
+    }
+  }
+
+  if (report.findings.length === 0) {
+    console.log('[preflight] No drift detected.');
+    return;
+  }
+
+  console.log(`[preflight] Drift findings: ${report.findings.length}`);
+  const bySchema = new Map<string, DriftFinding[]>();
+  for (const f of report.findings) {
+    const arr = bySchema.get(f.schemaName) ?? [];
+    arr.push(f);
+    bySchema.set(f.schemaName, arr);
+  }
+  for (const [schemaName, fs] of bySchema) {
+    console.log(`\n  ${schemaName} (${fs.length}):`);
+    for (const f of fs) {
+      console.log(`    [${f.kind}] ${f.message}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const warnOnly = process.argv.includes('--warn-only');
+  const report = await runPreflight();
+  printReport(report);
+  if (report.findings.length > 0 && !warnOnly) {
+    process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('[preflight] Fatal error:', err);
+  process.exit(2);
+});

--- a/scripts/preflight/diff-schemas.ts
+++ b/scripts/preflight/diff-schemas.ts
@@ -1,0 +1,120 @@
+/**
+ * @internal
+ * JSON-Schema-shaped object subset used by the pre-flight differ. Both `zod-to-json-schema`
+ * output and dereferenced OpenAPI components fit this shape after light normalization.
+ */
+export interface JsonSchema {
+  type?: string | string[];
+  required?: string[];
+  properties?: Record<string, JsonSchema>;
+  items?: JsonSchema;
+  enum?: unknown[];
+  nullable?: boolean;
+  [k: string]: unknown;
+}
+
+/** Kinds of drift the pre-flight detects. */
+export type DriftKind =
+  | 'missing-required-field'
+  | 'extra-required-field'
+  | 'type-mismatch'
+  | 'extra-field';
+
+/** A single drift finding, suitable for printing or aggregating into a report. */
+export interface DriftFinding {
+  schemaName: string;
+  path: string;
+  kind: DriftKind;
+  expected?: string;
+  actual?: string;
+  message: string;
+}
+
+function effectiveType(s: JsonSchema): string | undefined {
+  if (Array.isArray(s.type)) {
+    const nonNull = s.type.filter((t) => t !== 'null');
+    return nonNull[0];
+  }
+  return s.type;
+}
+
+function typesCompatible(a: string | undefined, b: string | undefined): boolean {
+  if (a === undefined || b === undefined) return true;
+  if (a === b) return true;
+  // OpenAPI uses integer; Zod tends to use number — treat as compatible
+  if ((a === 'integer' || a === 'number') && (b === 'integer' || b === 'number')) return true;
+  return false;
+}
+
+/**
+ * @internal
+ * Compare a Zod-derived JSON Schema (`zod`) against an OpenAPI-derived JSON Schema (`openapi`)
+ * and return drift findings. Recurses into shared object properties.
+ *
+ * Asymmetry: Zod is allowed to omit *optional* OpenAPI fields (passthrough handles them at
+ * runtime). Required fields and shared field types are checked strictly.
+ */
+export function diffSchemas(
+  zod: JsonSchema,
+  openapi: JsonSchema,
+  name: string,
+  basePath = '$',
+): DriftFinding[] {
+  const findings: DriftFinding[] = [];
+  const zType = effectiveType(zod);
+  const oType = effectiveType(openapi);
+
+  if (!typesCompatible(zType, oType)) {
+    findings.push({
+      schemaName: name,
+      path: basePath,
+      kind: 'type-mismatch',
+      expected: oType,
+      actual: zType,
+      message: `${name} ${basePath}: type mismatch (expected ${oType}, got ${zType})`,
+    });
+    return findings;
+  }
+
+  if (zType === 'object' && oType === 'object') {
+    const zReq = new Set(zod.required ?? []);
+    const oReq = new Set(openapi.required ?? []);
+    for (const r of oReq) {
+      if (!zReq.has(r)) {
+        findings.push({
+          schemaName: name,
+          path: `${basePath}.${r}`,
+          kind: 'missing-required-field',
+          message: `${name} ${basePath}: missing required field ${r}`,
+        });
+      }
+    }
+    for (const r of zReq) {
+      if (!oReq.has(r)) {
+        findings.push({
+          schemaName: name,
+          path: `${basePath}.${r}`,
+          kind: 'extra-required-field',
+          message: `${name} ${basePath}: ${r} required in Zod but optional in OpenAPI`,
+        });
+      }
+    }
+
+    const zProps = zod.properties ?? {};
+    const oProps = openapi.properties ?? {};
+    for (const [pName, pSchema] of Object.entries(zProps)) {
+      if (!(pName in oProps)) {
+        findings.push({
+          schemaName: name,
+          path: `${basePath}.${pName}`,
+          kind: 'extra-field',
+          message: `${name} ${basePath}: property ${pName} not in OpenAPI`,
+        });
+      } else {
+        findings.push(...diffSchemas(pSchema, oProps[pName], name, `${basePath}.${pName}`));
+      }
+    }
+  }
+
+  return findings;
+}

--- a/scripts/preflight/load-spec.ts
+++ b/scripts/preflight/load-spec.ts
@@ -1,0 +1,17 @@
+import SwaggerParser from '@apidevtools/swagger-parser';
+import type { OpenAPIV3 } from 'openapi-types';
+
+/**
+ * @internal
+ * Load + dereference an OpenAPI 3.x YAML/JSON spec and return a map from component schema name
+ * to the inlined JSON Schema. All `$ref`s are resolved so callers can compare flat shapes.
+ */
+export async function loadSpec(path: string): Promise<Map<string, OpenAPIV3.SchemaObject>> {
+  const api = (await SwaggerParser.dereference(path)) as OpenAPIV3.Document;
+  const schemas = api.components?.schemas ?? {};
+  const map = new Map<string, OpenAPIV3.SchemaObject>();
+  for (const [name, schema] of Object.entries(schemas)) {
+    map.set(name, schema as OpenAPIV3.SchemaObject);
+  }
+  return map;
+}

--- a/scripts/preflight/resolve-name.ts
+++ b/scripts/preflight/resolve-name.ts
@@ -1,0 +1,34 @@
+import type { OpenAPIV3 } from 'openapi-types';
+
+/**
+ * @internal
+ * Suffixes tried in order when mapping a Zod `<Name>Schema` to an OpenAPI component name.
+ * Empty string first so a direct match wins over any suffixed alternate.
+ */
+export const NAME_SUFFIXES = [
+  '',
+  'Object',
+  'Response',
+  'Request',
+  'Result',
+  'Detail',
+  'List',
+  'Item',
+];
+
+/**
+ * @internal
+ * Try each `NAME_SUFFIXES` entry against `specMap` and return the first match. Returns
+ * `undefined` if no suffix matches — caller treats those as local helpers.
+ */
+export function resolveOpenApiName(
+  shortName: string,
+  specMap: Map<string, OpenAPIV3.SchemaObject>,
+): { matchedName: string; schema: OpenAPIV3.SchemaObject } | undefined {
+  for (const suffix of NAME_SUFFIXES) {
+    const candidate = `${shortName}${suffix}`;
+    const hit = specMap.get(candidate);
+    if (hit) return { matchedName: candidate, schema: hit };
+  }
+  return undefined;
+}

--- a/specs/AIRS-Model-Security-DataPlane.yaml
+++ b/specs/AIRS-Model-Security-DataPlane.yaml
@@ -1,0 +1,1492 @@
+openapi: 3.1.0
+info:
+  title: Prisma AIRS AI Model Security API
+  version: 0.1.0
+  description: "Use the Model Security Data Plane API to execute scans and manage\
+    \ your model data securely. This Open API spec file was created on February 24,\
+    \ 2026. \xA9 2026 Palo Alto Networks, Inc. Palo Alto Networks is a registered\
+    \ trademark of Palo Alto Networks. A list of our trademarks can be found at [https://www.paloaltonetworks.com/company/trademarks.html](https://www.paloaltonetworks.com/company/trademarks.html).\
+    \ All other marks mentioned herein may be trademarks of their respective companies."
+components:
+  schemas:
+    ErrorCodes:
+      enum:
+      - UNKNOWN_ERROR
+      - SCAN_ERROR
+      - INVALID_RESPONSE
+      - ACCESS_DENIED
+      - MISSING_CREDENTIALS
+      - NO_SUCH_KEY
+      - NO_SUCH_BUCKET
+      - INVALID_BUCKET_NAME
+      - INTERNAL_ERROR
+      - SERVICE_UNAVAILABLE
+      - INVALID_OBJECT_STATE
+      - UNKNOWN_REMOTE_SERVICE_ERROR
+      - UNSUPPORTED_REMOTE_STORAGE
+      - MISSING_ARTIFACTS
+      - WORKER_ERROR
+      - POLICY_EVAL_ERROR
+      title: ErrorCodes
+      type: string
+    EvalOutcome:
+      enum:
+      - PENDING
+      - ALLOWED
+      - BLOCKED
+      - ERROR
+      title: EvalOutcome
+      type: string
+    EvalSummarySchema:
+      properties:
+        rules_failed:
+          default: 0
+          title: Rules Failed
+          type: integer
+        rules_passed:
+          default: 0
+          title: Rules Passed
+          type: integer
+        total_rules:
+          default: 0
+          title: Total Rules
+          type: integer
+      title: EvalSummarySchema
+      type: object
+    FileListSchema:
+      description: Schema for file list responses.
+      properties:
+        files:
+          items:
+            $ref: '#/components/schemas/FileResponseSchema'
+          title: Files
+          type: array
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+      required:
+      - pagination
+      - files
+      title: FileListSchema
+      type: object
+    FileResponseSchema:
+      description: Schema for file response details.
+      properties:
+        blob_id:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Blob Id
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        formats:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Formats
+        model_version_uuid:
+          format: uuid
+          title: Model Version Uuid
+          type: string
+        parent_path:
+          maxLength: 1024
+          title: Parent Path
+          type: string
+        path:
+          maxLength: 1024
+          title: Path
+          type: string
+        result:
+          $ref: '#/components/schemas/FileScanResult'
+        scan_uuid:
+          anyOf:
+          - format: uuid
+            type: string
+          - type: 'null'
+          title: Scan Uuid
+        tsg_id:
+          maxLength: 64
+          title: Tsg Id
+          type: string
+        type:
+          $ref: '#/components/schemas/FileType'
+        updated_at:
+          format: date-time
+          title: Updated At
+          type: string
+        uuid:
+          format: uuid
+          title: Uuid
+          type: string
+      required:
+      - uuid
+      - tsg_id
+      - created_at
+      - updated_at
+      - path
+      - parent_path
+      - type
+      - result
+      - model_version_uuid
+      title: FileResponseSchema
+      type: object
+    FileScanDataSchema:
+      properties:
+        blob_id:
+          maxLength: 256
+          title: Blob Id
+          type: string
+        error_message:
+          anyOf:
+          - maxLength: 1024
+            type: string
+          - type: 'null'
+          title: Error Message
+        file_path:
+          maxLength: 1024
+          title: File Path
+          type: string
+        formats:
+          anyOf:
+          - items:
+              maxLength: 256
+              type: string
+            maxItems: 20
+            type: array
+          - type: 'null'
+          title: Formats
+        issues_detected:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/ModelScanIssue'
+            type: array
+          - type: 'null'
+          title: Issues Detected
+        modelscan_status:
+          $ref: '#/components/schemas/ModelScanStatus'
+      required:
+      - file_path
+      - modelscan_status
+      - blob_id
+      title: FileScanDataSchema
+      type: object
+    FileScanResult:
+      description: Results of individual file scanning.
+      enum:
+      - SKIPPED
+      - SUCCESS
+      - ERROR
+      - FAILED
+      title: FileScanResult
+      type: string
+    FileType:
+      enum:
+      - DIRECTORY
+      - FILE
+      title: FileType
+      type: string
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          title: Detail
+          type: array
+      title: HTTPValidationError
+      type: object
+    LabelKeyListSchema:
+      properties:
+        keys:
+          items:
+            maxLength: 128
+            minLength: 1
+            pattern: ^[a-zA-Z0-9_-]+$
+            type: string
+          title: Keys
+          type: array
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+      required:
+      - pagination
+      - keys
+      title: LabelKeyListSchema
+      type: object
+    LabelSchema:
+      properties:
+        key:
+          maxLength: 128
+          minLength: 1
+          pattern: ^[a-zA-Z0-9_-]+$
+          title: Key
+          type: string
+        value:
+          maxLength: 256
+          minLength: 1
+          pattern: ^[a-zA-Z0-9_-]+$
+          title: Value
+          type: string
+      required:
+      - key
+      - value
+      title: LabelSchema
+      type: object
+    LabelValueListSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        values:
+          items:
+            maxLength: 256
+            minLength: 1
+            pattern: ^[a-zA-Z0-9_-]+$
+            type: string
+          title: Values
+          type: array
+      required:
+      - pagination
+      - values
+      title: LabelValueListSchema
+      type: object
+    LabelsCreateRequestSchema:
+      additionalProperties: false
+      properties:
+        labels:
+          items:
+            $ref: '#/components/schemas/LabelSchema'
+          maxItems: 50
+          minItems: 1
+          title: Labels
+          type: array
+      required:
+      - labels
+      title: LabelsCreateRequestSchema
+      type: object
+    LabelsResponseSchema:
+      properties: {}
+      title: LabelsResponseSchema
+      type: object
+    ModelScanIssue:
+      properties:
+        description:
+          maxLength: 4096
+          title: Description
+          type: string
+        module:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Module
+        operator:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Operator
+        source:
+          maxLength: 1024
+          title: Source
+          type: string
+        threat:
+          anyOf:
+          - $ref: '#/components/schemas/ThreatCategory'
+          - type: 'null'
+      required:
+      - description
+      - source
+      title: ModelScanIssue
+      type: object
+    ModelScanStatus:
+      enum:
+      - SCANNED
+      - SKIPPED
+      - ERROR
+      title: ModelScanStatus
+      type: string
+    PaginationSchema:
+      properties:
+        total_items:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Total Items
+      title: PaginationSchema
+      type: object
+    RuleEvaluationListSchema:
+      properties:
+        evaluations:
+          items:
+            $ref: '#/components/schemas/RuleEvaluationResponseSchema'
+          title: Evaluations
+          type: array
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+      required:
+      - pagination
+      - evaluations
+      title: RuleEvaluationListSchema
+      type: object
+    RuleEvaluationResponseSchema:
+      properties:
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        result:
+          $ref: '#/components/schemas/RuleEvaluationResult'
+        rule_description:
+          title: Rule Description
+          type: string
+        rule_instance_state:
+          $ref: '#/components/schemas/RuleState'
+        rule_instance_uuid:
+          format: uuid
+          title: Rule Instance Uuid
+          type: string
+        rule_name:
+          title: Rule Name
+          type: string
+        scan_uuid:
+          format: uuid
+          title: Scan Uuid
+          type: string
+        tsg_id:
+          maxLength: 64
+          title: Tsg Id
+          type: string
+        updated_at:
+          format: date-time
+          title: Updated At
+          type: string
+        uuid:
+          format: uuid
+          title: Uuid
+          type: string
+        violation_count:
+          title: Violation Count
+          type: integer
+      required:
+      - uuid
+      - tsg_id
+      - created_at
+      - updated_at
+      - result
+      - violation_count
+      - rule_instance_uuid
+      - scan_uuid
+      - rule_name
+      - rule_description
+      - rule_instance_state
+      title: RuleEvaluationResponseSchema
+      type: object
+    RuleEvaluationResult:
+      description: Results of rule evaluation.
+      enum:
+      - PASSED
+      - FAILED
+      - ERROR
+      title: RuleEvaluationResult
+      type: string
+    RuleState:
+      description: Rule evaluation states.
+      enum:
+      - DISABLED
+      - ALLOWING
+      - BLOCKING
+      title: RuleState
+      type: string
+    ScanBaseResponseSchema:
+      properties:
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        created_by:
+          anyOf:
+          - format: uuid
+            type: string
+          - type: 'null'
+          title: Created By
+        enabled_rule_count_snapshot:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Enabled Rule Count Snapshot
+        error_code:
+          anyOf:
+          - $ref: '#/components/schemas/ErrorCodes'
+          - type: 'null'
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+        eval_outcome:
+          $ref: '#/components/schemas/EvalOutcome'
+        eval_summary:
+          anyOf:
+          - $ref: '#/components/schemas/EvalSummarySchema'
+          - type: 'null'
+        labels:
+          items:
+            $ref: '#/components/schemas/LabelSchema'
+          title: Labels
+          type: array
+        model_formats:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Model Formats
+        model_uri:
+          title: Model Uri
+          type: string
+        model_version_uuid:
+          format: uuid
+          title: Model Version Uuid
+          type: string
+        owner:
+          maxLength: 256
+          title: Owner
+          type: string
+        scan_origin:
+          $ref: '#/components/schemas/ScanOrigin'
+        scanner_version:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Scanner Version
+        security_group_name:
+          maxLength: 256
+          title: Security Group Name
+          type: string
+        security_group_uuid:
+          format: uuid
+          title: Security Group Uuid
+          type: string
+        source_type:
+          $ref: '#/components/schemas/SourceType'
+          readOnly: true
+        time_started:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Time Started
+        total_files_scanned:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Total Files Scanned
+        total_files_skipped:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Total Files Skipped
+        tsg_id:
+          maxLength: 64
+          title: Tsg Id
+          type: string
+        updated_at:
+          format: date-time
+          title: Updated At
+          type: string
+        uuid:
+          format: uuid
+          title: Uuid
+          type: string
+      required:
+      - uuid
+      - tsg_id
+      - created_at
+      - updated_at
+      - model_uri
+      - owner
+      - scan_origin
+      - security_group_uuid
+      - security_group_name
+      - model_version_uuid
+      - eval_outcome
+      - source_type
+      title: ScanBaseResponseSchema
+      type: object
+    ScanCreateRequestSchema:
+      additionalProperties: false
+      properties:
+        allow_patterns:
+          anyOf:
+          - items:
+              maxLength: 256
+              type: string
+            type: array
+          - type: 'null'
+          title: Allow Patterns
+        ignore_patterns:
+          anyOf:
+          - items:
+              maxLength: 256
+              type: string
+            type: array
+          - type: 'null'
+          title: Ignore Patterns
+        labels:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/LabelSchema'
+            maxItems: 50
+            type: array
+          - type: 'null'
+          title: Labels
+        model_author:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Model Author
+        model_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Model Name
+        model_uri:
+          title: Model Uri
+          type: string
+        model_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Model Version
+        scan_details:
+          anyOf:
+          - $ref: '#/components/schemas/ScanDetails'
+          - type: 'null'
+        scan_origin:
+          $ref: '#/components/schemas/ScanOrigin'
+        security_group_uuid:
+          format: uuid
+          title: Security Group Uuid
+          type: string
+      required:
+      - model_uri
+      - security_group_uuid
+      - scan_origin
+      title: ScanCreateRequestSchema
+      type: object
+    ScanDetails:
+      additionalProperties: false
+      properties:
+        error_code:
+          anyOf:
+          - $ref: '#/components/schemas/ErrorCodes'
+          - type: 'null'
+        error_message:
+          anyOf:
+          - maxLength: 1024
+            type: string
+          - type: 'null'
+          title: Error Message
+        files:
+          items:
+            $ref: '#/components/schemas/FileScanDataSchema'
+          maxItems: 1000
+          title: Files
+          type: array
+        model_formats:
+          items:
+            maxLength: 64
+            type: string
+          maxItems: 100
+          title: Model Formats
+          type: array
+        model_size_bytes:
+          title: Model Size Bytes
+          type: integer
+        scan_duration_ms:
+          title: Scan Duration Ms
+          type: integer
+        scanner_version:
+          maxLength: 64
+          title: Scanner Version
+          type: string
+        time_started:
+          format: date-time
+          title: Time Started
+          type: string
+        total_files_scanned:
+          title: Total Files Scanned
+          type: integer
+        total_files_skipped:
+          title: Total Files Skipped
+          type: integer
+      required:
+      - scanner_version
+      - time_started
+      - files
+      - total_files_scanned
+      - total_files_skipped
+      - model_formats
+      - model_size_bytes
+      - scan_duration_ms
+      title: ScanDetails
+      type: object
+    ScanListSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        scans:
+          items:
+            $ref: '#/components/schemas/ScanBaseResponseSchema'
+          title: Scans
+          type: array
+      required:
+      - pagination
+      - scans
+      title: ScanListSchema
+      type: object
+    ScanOrigin:
+      enum:
+      - MODEL_SECURITY_SDK
+      - HUGGING_FACE
+      title: ScanOrigin
+      type: string
+    SortByDateField:
+      enum:
+      - created_at
+      - updated_at
+      title: SortByDateField
+      type: string
+    SortByFileField:
+      enum:
+      - path
+      - type
+      title: SortByFileField
+      type: string
+    SortDirection:
+      enum:
+      - asc
+      - desc
+      title: SortDirection
+      type: string
+    SourceType:
+      enum:
+      - LOCAL
+      - HUGGING_FACE
+      - S3
+      - GCS
+      - AZURE
+      - ARTIFACTORY
+      - GITLAB
+      - ALL
+      title: SourceType
+      type: string
+    ThreatCategory:
+      description: 'Enum for threat categories with their descriptions.
+
+        Should be in sync with modelscan-pai issue codes
+
+        https://code.pan.run/airs/model-security/modelscan-pai/-/blob/1df3e4ca9f175398155ab1f249ed10211d222751/modelscan_pai/issues.py#L7'
+      enum:
+      - PAIT-ARV-100
+      - PAIT-GGUF-100
+      - PAIT-GGUF-101
+      - PAIT-KERAS-100
+      - PAIT-KERAS-101
+      - PAIT-KERAS-102
+      - PAIT-JOBLIB-100
+      - PAIT-JOBLIB-101
+      - PAIT-PKL-100
+      - PAIT-PKL-101
+      - PAIT-PYTCH-100
+      - PAIT-PYTCH-101
+      - PAIT-EXDIR-100
+      - PAIT-EXDIR-101
+      - PAIT-ONNX-200
+      - PAIT-TF-200
+      - PAIT-LMAFL-300
+      - PAIT-LITERT-300
+      - PAIT-LITERT-301
+      - PAIT-LITERT-302
+      - PAIT-KERAS-300
+      - PAIT-KERAS-301
+      - PAIT-TCHST-300
+      - PAIT-TCHST-301
+      - PAIT-TF-300
+      - PAIT-TF-301
+      - PAIT-TF-302
+      - PAIT-TMT-300
+      - PAIT-TMT-301
+      - UNAPPROVED_FORMATS
+      title: ThreatCategory
+      type: string
+    ValidationError:
+      properties:
+        ctx:
+          title: Context
+          type: object
+        input:
+          title: Input
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          title: Location
+          type: array
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+      type: object
+    ViolationListSchema:
+      description: Schema for violation list responses.
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        violations:
+          items:
+            $ref: '#/components/schemas/ViolationResponseSchema'
+          title: Violations
+          type: array
+      required:
+      - pagination
+      - violations
+      title: ViolationListSchema
+      type: object
+    ViolationResponseSchema:
+      description: Schema for violation responses with enhanced rule details.
+      properties:
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        description:
+          title: Description
+          type: string
+        file:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: File
+        hash:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Hash
+        module:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Module
+        operator:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Operator
+        rule_description:
+          title: Rule Description
+          type: string
+        rule_instance_state:
+          $ref: '#/components/schemas/RuleState'
+        rule_instance_uuid:
+          format: uuid
+          title: Rule Instance Uuid
+          type: string
+        rule_name:
+          title: Rule Name
+          type: string
+        threat:
+          anyOf:
+          - $ref: '#/components/schemas/ThreatCategory'
+          - type: 'null'
+        threat_description:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Threat Description
+        tsg_id:
+          maxLength: 64
+          title: Tsg Id
+          type: string
+        updated_at:
+          format: date-time
+          title: Updated At
+          type: string
+        uuid:
+          format: uuid
+          title: Uuid
+          type: string
+      required:
+      - uuid
+      - tsg_id
+      - created_at
+      - updated_at
+      - description
+      - rule_instance_uuid
+      - rule_name
+      - rule_description
+      - rule_instance_state
+      title: ViolationResponseSchema
+      type: object
+servers:
+- description: Prisma AIRS Model Security data endpoint
+  url: https://api.sase.paloaltonetworks.com/aims/data
+ExternalTags: {}
+paths:
+  /v1/evaluations/{uuid}:
+    get:
+      summary: Retrieve Rule Evaluation
+      description: Retrieve a specific evaluation to view detailed rule information.
+      operationId: get_evaluation_v1_evaluations__uuid__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuleEvaluationResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      tags:
+      - Evaluations
+  /v1/scans:
+    get:
+      summary: List All Scans
+      description: Retrieve a paginated list of model security scans.
+      operationId: list_scans_v1_scans_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanListSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          maximum: 100
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          title: Skip
+          type: integer
+      - in: query
+        name: sort_order
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortDirection'
+          default: desc
+      - description: Search query for model_uri or uuid
+        in: query
+        name: search_query
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          description: Search query for model_uri or uuid
+          title: Search Query
+      - description: Filter by security group UUID
+        in: query
+        name: security_group_uuid
+        required: false
+        schema:
+          anyOf:
+          - format: uuid
+            type: string
+          - type: 'null'
+          description: Filter by security group UUID
+          title: Security Group Uuid
+      - description: A list of source types to filter by
+        in: query
+        name: source_types
+        required: false
+        schema:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/SourceType'
+            type: array
+          - type: 'null'
+          description: A list of source types to filter by
+          title: Source Types
+      - description: A list of evaluation outcomes to filter by
+        in: query
+        name: eval_outcomes
+        required: false
+        schema:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/EvalOutcome'
+            type: array
+          - type: 'null'
+          description: A list of evaluation outcomes to filter by
+          title: Eval Outcomes
+      - in: query
+        name: start_time
+        required: false
+        schema:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Start Time
+      - in: query
+        name: end_time
+        required: false
+        schema:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: End Time
+      - description: Query for labels
+        in: query
+        name: labels_query
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 4096
+            type: string
+          - type: 'null'
+          description: Query for labels
+          title: Labels Query
+      tags:
+      - Scans
+    post:
+      summary: Create New Scan
+      description: Initiate a new model security scan.
+      operationId: create_scan_v1_scans_post
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanBaseResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters: []
+      tags:
+      - Scans
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanCreateRequestSchema'
+        required: true
+  /v1/scans/label-keys:
+    get:
+      summary: Retrieve Label Keys
+      description: Retrieve a list of distinct label keys across all scans. Filter
+        the results by prefix using the search parameter.
+      operationId: list_scan_label_keys_v1_scans_label_keys_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelKeyListSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          maximum: 100
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          title: Skip
+          type: integer
+      - in: query
+        name: search
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 128
+            minLength: 1
+            pattern: ^[a-zA-Z0-9_-]+$
+            type: string
+          - type: 'null'
+          title: Search
+      tags:
+      - Scan Labels
+  /v1/scans/label-keys/{key}/values:
+    get:
+      summary: Retrieve Key Values
+      description: Retrieve a list of distinct values for a specific label key across
+        all scans. Filter the results by prefix using the search parameter.
+      operationId: list_scan_label_key_values_v1_scans_label_keys__key__values_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelValueListSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          maxLength: 128
+          minLength: 1
+          pattern: ^[a-zA-Z0-9_-]+$
+          title: Key
+          type: string
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          maximum: 100
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          title: Skip
+          type: integer
+      - in: query
+        name: search
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 256
+            minLength: 1
+            pattern: ^[a-zA-Z0-9_-]+$
+            type: string
+          - type: 'null'
+          title: Search
+      tags:
+      - Scan Labels
+  /v1/scans/{scan_uuid}/evaluations:
+    get:
+      summary: Get Scan Evaluations
+      description: Retrieve rule evaluations and detailed rule information for a specific
+        scan.
+      operationId: get_scan_evaluations_v1_scans__scan_uuid__evaluations_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuleEvaluationListSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: scan_uuid
+        required: true
+        schema:
+          format: uuid
+          title: Scan Uuid
+          type: string
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          maximum: 100
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          title: Skip
+          type: integer
+      - in: query
+        name: sort_field
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortByDateField'
+          default: created_at
+      - in: query
+        name: sort_order
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortDirection'
+          default: desc
+      - description: Filter by evaluation results
+        in: query
+        name: result
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/RuleEvaluationResult'
+          - type: 'null'
+          description: Filter by evaluation results
+          title: Result
+      - description: Filter by rule instance UUID
+        in: query
+        name: rule_instance_uuid
+        required: false
+        schema:
+          anyOf:
+          - format: uuid
+            type: string
+          - type: 'null'
+          description: Filter by rule instance UUID
+          title: Rule Instance Uuid
+      tags:
+      - Scans
+  /v1/scans/{scan_uuid}/files:
+    get:
+      summary: Retrieve Scan Files
+      description: Retrieve files for a specific scan organized in a tree structure.
+      operationId: get_files_v1_scans__scan_uuid__files_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileListSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - description: UUID of the scan to get files for
+        in: path
+        name: scan_uuid
+        required: true
+        schema:
+          description: UUID of the scan to get files for
+          format: uuid
+          title: Scan Uuid
+          type: string
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          maximum: 100
+          minimum: 1
+          title: Limit
+          type: integer
+      - description: Number of items to skip
+        in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          description: Number of items to skip
+          minimum: 0
+          title: Skip
+          type: integer
+      - description: Field to sort by
+        in: query
+        name: sort_field
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortByFileField'
+          default: path
+          description: Field to sort by
+      - description: Sort direction
+        in: query
+        name: sort_dir
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortDirection'
+          default: asc
+          description: Sort direction
+      - description: Optional path to filter files within the scan. Use this to navigate
+          into specific directories.
+        in: query
+        name: query_path
+        required: false
+        schema:
+          default: /
+          description: Optional path to filter files within the scan. Use this to
+            navigate into specific directories.
+          title: Query Path
+          type: string
+      tags:
+      - Scans
+  /v1/scans/{scan_uuid}/labels:
+    delete:
+      summary: Delete Scan Labels
+      description: Delete labels matching the specified keys from the scan.
+      operationId: delete_scan_labels_v1_scans__scan_uuid__labels_delete
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: scan_uuid
+        required: true
+        schema:
+          format: uuid
+          title: Scan Uuid
+          type: string
+      - in: query
+        name: keys
+        required: true
+        schema:
+          items:
+            maxLength: 128
+            minLength: 1
+            pattern: ^[a-zA-Z0-9_-]+$
+            type: string
+          maxItems: 50
+          minItems: 1
+          title: Keys
+          type: array
+      tags:
+      - Scan Labels
+    post:
+      summary: Add Scan Labels
+      description: Add labels to the specified scan. The Application Programming Interface
+        overwrites the existing label value if you provide a label key that already
+        exists on the scan.
+      operationId: add_scan_labels_v1_scans__scan_uuid__labels_post
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelsResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: scan_uuid
+        required: true
+        schema:
+          format: uuid
+          title: Scan Uuid
+          type: string
+      tags:
+      - Scan Labels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LabelsCreateRequestSchema'
+        required: true
+    put:
+      summary: Set Scan Labels
+      description: Set the labels for a scan to match the provided input. This operation
+        completely removes and replaces any existing labels.
+      operationId: set_scan_labels_v1_scans__scan_uuid__labels_put
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelsResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: scan_uuid
+        required: true
+        schema:
+          format: uuid
+          title: Scan Uuid
+          type: string
+      tags:
+      - Scan Labels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LabelsCreateRequestSchema'
+        required: true
+  /v1/scans/{scan_uuid}/rule-violations:
+    get:
+      summary: Get Scan Violations
+      description: Retrieve rule violations and view detailed rule information for
+        a specific scan.
+      operationId: get_scan_violations_v1_scans__scan_uuid__rule_violations_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ViolationListSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: scan_uuid
+        required: true
+        schema:
+          format: uuid
+          title: Scan Uuid
+          type: string
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          maximum: 100
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          title: Skip
+          type: integer
+      tags:
+      - Scans
+  /v1/scans/{uuid}:
+    get:
+      summary: Retrieve Specific Scan
+      description: Retrieve a specific scan by its UUID. You can optionally paginate
+        the associated violations.
+      operationId: get_scan_v1_scans__uuid__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanBaseResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      tags:
+      - Scans
+  /v1/violations/{uuid}:
+    get:
+      summary: Retrieve Specific Violation
+      description: Retrieve a specific violation to view its detailed rule information.
+      operationId: get_violation_v1_violations__uuid__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ViolationResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      tags:
+      - Violations

--- a/specs/AIRS-Model-Security-Management.yaml
+++ b/specs/AIRS-Model-Security-Management.yaml
@@ -1,0 +1,956 @@
+openapi: 3.1.0
+info:
+  title: Prisma AIRS AI Security Model API
+  version: 0.1.0
+  description: "Configure and manage security groups and rules for AI/ML model scanning\
+    \ using the Model Security Management API. This Open API spec file was created\
+    \ on February 24, 2026. \xA9 2026 Palo Alto Networks, Inc. Palo Alto Networks\
+    \ is a registered trademark of Palo Alto Networks. A list of our trademarks can\
+    \ be found at [https://www.paloaltonetworks.com/company/trademarks.html](https://www.paloaltonetworks.com/company/trademarks.html).\
+    \ All other marks mentioned herein may be trademarks of their respective companies."
+components:
+  schemas:
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          title: Detail
+          type: array
+      title: HTTPValidationError
+      type: object
+    ListModelSecurityGroupsResponseSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        security_groups:
+          items:
+            $ref: '#/components/schemas/ModelSecurityGroupResponseSchema'
+          title: Security Groups
+          type: array
+      required:
+      - pagination
+      - security_groups
+      title: ListModelSecurityGroupsResponseSchema
+      type: object
+    ListModelSecurityRuleInstancesResponseSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        rule_instances:
+          items:
+            $ref: '#/components/schemas/ModelSecurityRuleInstanceResponseSchema'
+          title: Rule Instances
+          type: array
+      required:
+      - pagination
+      - rule_instances
+      title: ListModelSecurityRuleInstancesResponseSchema
+      type: object
+    ListModelSecurityRulesResponseSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        rules:
+          items:
+            $ref: '#/components/schemas/ModelSecurityRuleResponseSchema'
+          title: Rules
+          type: array
+      required:
+      - pagination
+      - rules
+      title: ListModelSecurityRulesResponseSchema
+      type: object
+    ModelSecurityGroupCreateRequestSchema:
+      additionalProperties: false
+      properties:
+        description:
+          default: ''
+          maxLength: 1000
+          title: Description
+          type: string
+        name:
+          maxLength: 255
+          minLength: 1
+          title: Name
+          type: string
+        rule_configurations:
+          additionalProperties:
+            $ref: '#/components/schemas/RuleConfigurationSchema'
+          description: Keys in this dictionary should be rule UUIDs to customize upon
+            creation of the model security group.
+          propertyNames:
+            maxLength: 64
+          title: Rule Configurations
+          type: object
+        source_type:
+          $ref: '#/components/schemas/SourceType'
+      required:
+      - name
+      - source_type
+      title: ModelSecurityGroupCreateRequestSchema
+      type: object
+    ModelSecurityGroupResponseSchema:
+      properties:
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        description:
+          title: Description
+          type: string
+        is_tombstone:
+          description: Indicates whether this security group is deleted
+          title: Is Tombstone
+          type: boolean
+        name:
+          title: Name
+          type: string
+        source_type:
+          $ref: '#/components/schemas/SourceType'
+        state:
+          $ref: '#/components/schemas/ModelSecurityGroupState'
+        tsg_id:
+          maxLength: 64
+          title: Tsg Id
+          type: string
+        updated_at:
+          format: date-time
+          title: Updated At
+          type: string
+        uuid:
+          format: uuid
+          title: Uuid
+          type: string
+      required:
+      - uuid
+      - tsg_id
+      - created_at
+      - updated_at
+      - name
+      - description
+      - source_type
+      - state
+      - is_tombstone
+      title: ModelSecurityGroupResponseSchema
+      type: object
+    ModelSecurityGroupState:
+      description: Security group states.
+      enum:
+      - PENDING
+      - ACTIVE
+      title: ModelSecurityGroupState
+      type: string
+    ModelSecurityGroupUpdateRequestSchema:
+      additionalProperties: false
+      properties:
+        description:
+          anyOf:
+          - maxLength: 1000
+            type: string
+          - type: 'null'
+          title: Description
+        name:
+          anyOf:
+          - maxLength: 255
+            minLength: 1
+            type: string
+          - type: 'null'
+          title: Name
+      title: ModelSecurityGroupUpdateRequestSchema
+      type: object
+    ModelSecurityRuleInstanceResponseSchema:
+      description: Instantiated rule schema - actual rules that get evaluated
+      properties:
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        field_values:
+          additionalProperties: true
+          description: Dictionary for configuring policies custom settings to applicable
+            policies. Allowed keys are approved_formats, approved_locations, approved_licenses,
+            deny_orgs, and denied_org_models. Values should be a list of strings.
+          propertyNames:
+            $ref: '#/components/schemas/RuleFieldValueKey'
+          title: Field Values
+          type: object
+        rule:
+          $ref: '#/components/schemas/ModelSecurityRuleResponseSchema'
+        security_group_uuid:
+          format: uuid
+          title: Security Group Uuid
+          type: string
+        security_rule_uuid:
+          format: uuid
+          title: Security Rule Uuid
+          type: string
+        state:
+          $ref: '#/components/schemas/RuleState'
+        tsg_id:
+          maxLength: 64
+          title: Tsg Id
+          type: string
+        updated_at:
+          format: date-time
+          title: Updated At
+          type: string
+        uuid:
+          format: uuid
+          title: Uuid
+          type: string
+      required:
+      - uuid
+      - tsg_id
+      - created_at
+      - updated_at
+      - security_group_uuid
+      - security_rule_uuid
+      - state
+      - rule
+      title: ModelSecurityRuleInstanceResponseSchema
+      type: object
+    ModelSecurityRuleInstanceUpdateRequestSchema:
+      additionalProperties: false
+      description: Update rule instance
+      properties:
+        field_values:
+          anyOf:
+          - additionalProperties: true
+            description: Dictionary for configuring policies custom settings to applicable
+              policies. Allowed keys are approved_formats, approved_locations, approved_licenses,
+              deny_orgs, and denied_org_models. Values should be a list of strings.
+            propertyNames:
+              $ref: '#/components/schemas/RuleFieldValueKey'
+            type: object
+          - type: 'null'
+          title: Field Values
+        security_group_uuid:
+          format: uuid
+          title: Security Group Uuid
+          type: string
+        state:
+          anyOf:
+          - $ref: '#/components/schemas/RuleState'
+          - type: 'null'
+      required:
+      - security_group_uuid
+      title: ModelSecurityRuleInstanceUpdateRequestSchema
+      type: object
+    ModelSecurityRuleResponseSchema:
+      description: Response schema for model security rules - excludes internal fields
+        like opa_path
+      properties:
+        compatible_sources:
+          items:
+            $ref: '#/components/schemas/SourceType'
+          title: Compatible Sources
+          type: array
+        constant_values:
+          additionalProperties: true
+          propertyNames:
+            maxLength: 256
+          title: Constant Values
+          type: object
+        default_state:
+          $ref: '#/components/schemas/RuleState'
+        default_values:
+          additionalProperties: true
+          propertyNames:
+            $ref: '#/components/schemas/RuleFieldValueKey'
+          title: Default Values
+          type: object
+        description:
+          title: Description
+          type: string
+        editable_fields:
+          items:
+            $ref: '#/components/schemas/RuleEditableFieldSchema'
+          title: Editable Fields
+          type: array
+        name:
+          title: Name
+          type: string
+        remediation:
+          $ref: '#/components/schemas/RuleRemediationSchema'
+        rule_type:
+          $ref: '#/components/schemas/RuleType'
+        uuid:
+          format: uuid
+          title: Uuid
+          type: string
+      required:
+      - uuid
+      - name
+      - description
+      - rule_type
+      - compatible_sources
+      - default_state
+      - remediation
+      - editable_fields
+      - constant_values
+      - default_values
+      title: ModelSecurityRuleResponseSchema
+      type: object
+    PaginationSchema:
+      properties:
+        total_items:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Total Items
+      title: PaginationSchema
+      type: object
+    PyPIAuthResponseSchema:
+      description: Schema for PyPI authentication response.
+      properties:
+        expires_at:
+          description: Token expiration timestamp in UTC
+          format: date-time
+          title: Expires At
+          type: string
+        url:
+          description: Authenticated Google Artifact Registry URL with embedded token
+          title: Url
+          type: string
+      required:
+      - url
+      - expires_at
+      title: PyPIAuthResponseSchema
+      type: object
+    RuleConfigurationSchema:
+      description: Configuration for customizing a rule during security group creation.
+      properties:
+        field_values:
+          additionalProperties: true
+          description: Dictionary for configuring policies custom settings to applicable
+            policies. Allowed keys are approved_formats, approved_locations, approved_licenses,
+            deny_orgs, and denied_org_models. Values should be a list of strings.
+          propertyNames:
+            $ref: '#/components/schemas/RuleFieldValueKey'
+          title: Field Values
+          type: object
+        state:
+          anyOf:
+          - $ref: '#/components/schemas/RuleState'
+          - type: 'null'
+      title: RuleConfigurationSchema
+      type: object
+    RuleEditableFieldDropdownSchema:
+      properties:
+        label:
+          maxLength: 256
+          title: Label
+          type: string
+        value:
+          maxLength: 256
+          title: Value
+          type: string
+      required:
+      - value
+      - label
+      title: RuleEditableFieldDropdownSchema
+      type: object
+    RuleEditableFieldSchema:
+      properties:
+        attribute_name:
+          maxLength: 256
+          title: Attribute Name
+          type: string
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        display_name:
+          maxLength: 256
+          title: Display Name
+          type: string
+        display_type:
+          $ref: '#/components/schemas/RuleEditableFieldType'
+        dropdown_values:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/RuleEditableFieldDropdownSchema'
+            type: array
+          - type: 'null'
+          title: Dropdown Values
+        type:
+          maxLength: 256
+          title: Type
+          type: string
+      required:
+      - attribute_name
+      - type
+      - display_name
+      - display_type
+      title: RuleEditableFieldSchema
+      type: object
+    RuleEditableFieldType:
+      description: Editable field types are used by rule structure for UI rendering
+      enum:
+      - SELECT
+      - LIST
+      title: RuleEditableFieldType
+      type: string
+    RuleFieldValueKey:
+      enum:
+      - approved_formats
+      - approved_locations
+      - approved_licenses
+      - deny_orgs
+      - denied_org_models
+      - approved_org_models
+      title: RuleFieldValueKey
+      type: string
+    RuleRemediationSchema:
+      description: Remediation steps for each rule
+      properties:
+        description:
+          maxLength: 256
+          title: Description
+          type: string
+        steps:
+          items:
+            maxLength: 256
+            type: string
+          title: Steps
+          type: array
+        url:
+          maxLength: 256
+          title: Url
+          type: string
+      required:
+      - description
+      - steps
+      - url
+      title: RuleRemediationSchema
+      type: object
+    RuleState:
+      description: Rule evaluation states.
+      enum:
+      - DISABLED
+      - ALLOWING
+      - BLOCKING
+      title: RuleState
+      type: string
+    RuleType:
+      description: Rule types for different scanning approaches.
+      enum:
+      - METADATA
+      - ARTIFACT
+      title: RuleType
+      type: string
+    SortByDateField:
+      enum:
+      - created_at
+      - updated_at
+      title: SortByDateField
+      type: string
+    SortDirection:
+      enum:
+      - asc
+      - desc
+      title: SortDirection
+      type: string
+    SourceType:
+      enum:
+      - LOCAL
+      - HUGGING_FACE
+      - S3
+      - GCS
+      - AZURE
+      - ARTIFACTORY
+      - GITLAB
+      - ALL
+      title: SourceType
+      type: string
+    ValidationError:
+      properties:
+        ctx:
+          title: Context
+          type: object
+        input:
+          title: Input
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          title: Location
+          type: array
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+      type: object
+servers:
+- description: Prisma AIRS Model Security management endpoint
+  url: https://api.sase.paloaltonetworks.com/aims/mgmt
+ExternalTags: {}
+paths:
+  /v1/pypi/authenticate:
+    get:
+      summary: Retrieve PyPI Uniform Resource Locator
+      description: Retrieve the Google Artifact Registry Uniform Resource Locator
+        to access PyPI.
+      operationId: get_pypi_url_v1_pypi_authenticate_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PyPIAuthResponseSchema'
+          description: Successful Response
+      parameters: []
+      tags:
+      - PyPI Authentication
+  /v1/security-groups:
+    get:
+      summary: List Security Groups
+      description: Retrieve a paginated list of model security groups.
+      operationId: list_security_groups_v1_security_groups_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListModelSecurityGroupsResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - description: Number of items to skip
+        in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          description: Number of items to skip
+          minimum: 0
+          title: Skip
+          type: integer
+      - description: Number of items to return
+        in: query
+        name: limit
+        required: false
+        schema:
+          anyOf:
+          - maximum: 100
+            minimum: 1
+            type: integer
+          - type: 'null'
+          default: 50
+          description: Number of items to return
+          title: Limit
+      - description: Field to sort by
+        in: query
+        name: sort_field
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortByDateField'
+          default: created_at
+          description: Field to sort by
+      - description: Sort direction
+        in: query
+        name: sort_dir
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortDirection'
+          default: desc
+          description: Sort direction
+      - description: Filter by source types
+        in: query
+        name: source_types
+        required: false
+        schema:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/SourceType'
+            type: array
+          - type: 'null'
+          description: Filter by source types
+          title: Source Types
+      - description: Search term (matches UUID or Name)
+        in: query
+        name: search_query
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 1000
+            minLength: 3
+            type: string
+          - type: 'null'
+          description: Search term (matches UUID or Name)
+          title: Search Query
+      - description: A list of rule UUIDs to filter by. Only security groups with
+          one of these rules set to ALLOWING or BLOCKING will be returned.
+        in: query
+        name: enabled_rules
+        required: false
+        schema:
+          anyOf:
+          - items:
+              format: uuid
+              type: string
+            type: array
+          - type: 'null'
+          description: A list of rule UUIDs to filter by. Only security groups with
+            one of these rules set to ALLOWING or BLOCKING will be returned.
+          title: Enabled Rules
+      tags:
+      - Model Security Groups
+    post:
+      summary: Create Security Group
+      description: Create a new model security group with the specified parameters.
+      operationId: create_security_group_v1_security_groups_post
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelSecurityGroupResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters: []
+      tags:
+      - Model Security Groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelSecurityGroupCreateRequestSchema'
+        required: true
+  /v1/security-groups/{security_group_uuid}/rule-instances:
+    get:
+      summary: List Rule Instances
+      description: Retrieve a paginated list of rule instances for a specific security
+        group.
+      operationId: list_rule_instances_v1_security_groups__security_group_uuid__rule_instances_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListModelSecurityRuleInstancesResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - description: Security group UUID
+        in: path
+        name: security_group_uuid
+        required: true
+        schema:
+          description: Security group UUID
+          format: uuid
+          title: Security Group Uuid
+          type: string
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          title: Limit
+          type: integer
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          title: Skip
+          type: integer
+      - in: query
+        name: security_rule_uuid
+        required: false
+        schema:
+          anyOf:
+          - format: uuid
+            type: string
+          - type: 'null'
+          title: Security Rule Uuid
+      - in: query
+        name: state
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/RuleState'
+          - type: 'null'
+          title: State
+      tags:
+      - Model Security Groups
+      - Model Security Rule Instances
+  /v1/security-groups/{security_group_uuid}/rule-instances/{rule_instance_uuid}:
+    get:
+      summary: Retrieve Rule Instance
+      description: Retrieve a specific rule instance by its UUID.
+      operationId: get_rule_instance_v1_security_groups__security_group_uuid__rule_instances__rule_instance_uuid__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelSecurityRuleInstanceResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - description: Security group UUID
+        in: path
+        name: security_group_uuid
+        required: true
+        schema:
+          description: Security group UUID
+          format: uuid
+          title: Security Group Uuid
+          type: string
+      - description: Rule instance UUID
+        in: path
+        name: rule_instance_uuid
+        required: true
+        schema:
+          description: Rule instance UUID
+          format: uuid
+          title: Rule Instance Uuid
+          type: string
+      tags:
+      - Model Security Groups
+      - Model Security Rule Instances
+    put:
+      summary: Update Rule Instance
+      description: Update the details of a specific rule instance.
+      operationId: update_rule_instance_v1_security_groups__security_group_uuid__rule_instances__rule_instance_uuid__put
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelSecurityRuleInstanceResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - description: Security group UUID
+        in: path
+        name: security_group_uuid
+        required: true
+        schema:
+          description: Security group UUID
+          format: uuid
+          title: Security Group Uuid
+          type: string
+      - description: Rule instance UUID
+        in: path
+        name: rule_instance_uuid
+        required: true
+        schema:
+          description: Rule instance UUID
+          format: uuid
+          title: Rule Instance Uuid
+          type: string
+      tags:
+      - Model Security Groups
+      - Model Security Rule Instances
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelSecurityRuleInstanceUpdateRequestSchema'
+        required: true
+  /v1/security-groups/{uuid}:
+    delete:
+      summary: Delete Security Group
+      description: Soft-delete a security group by its UUID to hide it and its rule
+        instances from list operations while retaining retrieval access.
+      operationId: delete_security_group_v1_security_groups__uuid__delete
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      tags:
+      - Model Security Groups
+    get:
+      summary: Retrieve Security Group
+      description: Retrieve the details of a specific security group by its UUID.
+      operationId: get_security_group_v1_security_groups__uuid__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelSecurityGroupResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      tags:
+      - Model Security Groups
+    put:
+      summary: Update Security Group
+      description: Update the configuration of an existing security group.
+      operationId: update_security_group_v1_security_groups__uuid__put
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelSecurityGroupResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      tags:
+      - Model Security Groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelSecurityGroupUpdateRequestSchema'
+        required: true
+  /v1/security-rules:
+    get:
+      summary: List Security Rules
+      description: Retrieve a paginated list of security rules, optionally filtering
+        the results by source type.
+      operationId: list_security_rules_v1_security_rules_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListModelSecurityRulesResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          title: Limit
+          type: integer
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          title: Skip
+          type: integer
+      - in: query
+        name: source_type
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/SourceType'
+          - type: 'null'
+          title: Source Type
+      - description: Search term (matches UUID or Name)
+        in: query
+        name: search_query
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 1000
+            minLength: 3
+            type: string
+          - type: 'null'
+          description: Search term (matches UUID or Name)
+          title: Search Query
+      tags:
+      - Model Security Rules
+  /v1/security-rules/{uuid}:
+    get:
+      summary: Retrieve Security Rule
+      description: Retrieve a specific security rule by its UUID.
+      operationId: get_security_rule_v1_security_rules__uuid__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelSecurityRuleResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      tags:
+      - Model Security Rules

--- a/specs/PaloAltoNetworks-AIRS-RedTeam-DataPlane.yaml
+++ b/specs/PaloAltoNetworks-AIRS-RedTeam-DataPlane.yaml
@@ -1,0 +1,5051 @@
+openapi: 3.1.0
+info:
+  title: Prisma AIRS Red Teaming Dataplane API
+  version: 0.5.20
+  description: "Red Teaming Data Plane API - Data processing and scanning services\
+    \ for AI/ML model security. \xA9 2025 Palo Alto Networks, Inc This Open API spec\
+    \ file was created on February 25, 2026. \xA9 2026 Palo Alto Networks, Inc. Palo\
+    \ Alto Networks is a registered trademark of Palo Alto Networks. A list of our\
+    \ trademarks can be found at [https://www.paloaltonetworks.com/company/trademarks.html](https://www.paloaltonetworks.com/company/trademarks.html).\
+    \ All other marks mentioned herein may be trademarks of their respective companies."
+servers:
+- url: https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane
+security:
+- bearerAuth: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    ApiEndpointType:
+      type: string
+      enum:
+      - PUBLIC
+      - PRIVATE
+      - NETWORK_BROKER
+      title: ApiEndpointType
+      description: API endpoint accessibility type.
+    AttackDetailResponseSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Associated job UUID
+        target_id:
+          type: string
+          format: uuid
+          title: Target Id
+          description: Target UUID
+        prompt:
+          type: string
+          title: Prompt
+          description: The actual prompt text used
+        status:
+          $ref: '#/components/schemas/AttackStatus'
+          description: Attack status
+          default: INIT
+        marked_safe:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Marked Safe
+          description: Manual safety marking
+        extra_info:
+          additionalProperties: true
+          type: object
+          title: Extra Info
+          description: Additional metadata
+        threat:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Threat
+          description: Threat detection result
+        attack_type:
+          $ref: '#/components/schemas/AttackType'
+          description: Type of attack
+          default: NORMAL
+        multi_turn:
+          type: boolean
+          title: Multi Turn
+          description: Multi-turn conversation flag
+          default: false
+        asr:
+          anyOf:
+          - type: number
+            maximum: 100
+            minimum: 0
+          - type: 'null'
+          title: Asr
+          description: Attack Success Rate (0-100)
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Attack version
+        prompt_mapping_id:
+          type: string
+          format: uuid
+          title: Prompt Mapping Id
+          description: Prompt mapping UUID
+        prompt_id:
+          type: string
+          format: uuid
+          title: Prompt Id
+          description: Prompt UUID
+        category:
+          $ref: '#/components/schemas/Category'
+          description: Attack category
+        sub_category:
+          anyOf:
+          - $ref: '#/components/schemas/SecuritySubCategory'
+          - $ref: '#/components/schemas/SafetySubCategory'
+          - $ref: '#/components/schemas/BrandSubCategory'
+          - $ref: '#/components/schemas/ComplianceSubCategory'
+          title: Sub Category
+          description: Attack subcategory
+        severity:
+          type: string
+          description: Attack severity level
+        category_display_name:
+          type: string
+          title: Category Display Name
+        sub_category_display_name:
+          type: string
+          title: Sub Category Display Name
+        compliance_frameworks:
+          items:
+            $ref: '#/components/schemas/ComplianceWithTechniqueModel'
+          type: array
+          title: Compliance Frameworks
+        outputs:
+          items:
+            $ref: '#/components/schemas/AttackOutputSchema'
+          type: array
+          title: Outputs
+          description: Outputs for attacks
+        goal:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - job_id
+      - target_id
+      - prompt
+      - prompt_mapping_id
+      - prompt_id
+      - category
+      - sub_category
+      - category_display_name
+      - sub_category_display_name
+      - compliance_frameworks
+      - goal
+      title: AttackDetailResponseSchema
+    AttackListResponseSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        data:
+          items:
+            $ref: '#/components/schemas/AttackListSchema'
+          type: array
+          title: Data
+          description: List of Attacks
+      type: object
+      required:
+      - pagination
+      - data
+      title: AttackListResponseSchema
+      description: Response schema for listing attacks following common pagination
+        pattern.
+    AttackListSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Associated job UUID
+        target_id:
+          type: string
+          format: uuid
+          title: Target Id
+          description: Target UUID
+        prompt:
+          type: string
+          title: Prompt
+          description: The actual prompt text used
+        status:
+          $ref: '#/components/schemas/AttackStatus'
+          description: Attack status
+          default: INIT
+        marked_safe:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Marked Safe
+          description: Manual safety marking
+        extra_info:
+          additionalProperties: true
+          type: object
+          title: Extra Info
+          description: Additional metadata
+        threat:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Threat
+          description: Threat detection result
+        attack_type:
+          $ref: '#/components/schemas/AttackType'
+          description: Type of attack
+          default: NORMAL
+        multi_turn:
+          type: boolean
+          title: Multi Turn
+          description: Multi-turn conversation flag
+          default: false
+        asr:
+          anyOf:
+          - type: number
+            maximum: 100
+            minimum: 0
+          - type: 'null'
+          title: Asr
+          description: Attack Success Rate (0-100)
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Attack version
+        prompt_mapping_id:
+          type: string
+          format: uuid
+          title: Prompt Mapping Id
+          description: Prompt mapping UUID
+        prompt_id:
+          type: string
+          format: uuid
+          title: Prompt Id
+          description: Prompt UUID
+        category:
+          $ref: '#/components/schemas/Category'
+          description: Attack category
+        sub_category:
+          anyOf:
+          - $ref: '#/components/schemas/SecuritySubCategory'
+          - $ref: '#/components/schemas/SafetySubCategory'
+          - $ref: '#/components/schemas/BrandSubCategory'
+          - $ref: '#/components/schemas/ComplianceSubCategory'
+          title: Sub Category
+          description: Attack subcategory
+        severity:
+          type: string
+          description: Attack severity level
+        category_display_name:
+          type: string
+          title: Category Display Name
+        sub_category_display_name:
+          type: string
+          title: Sub Category Display Name
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - job_id
+      - target_id
+      - prompt
+      - prompt_mapping_id
+      - prompt_id
+      - category
+      - sub_category
+      - category_display_name
+      - sub_category_display_name
+      title: AttackListSchema
+    AttackMultiTurnDetailResponseSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Associated job UUID
+        target_id:
+          type: string
+          format: uuid
+          title: Target Id
+          description: Target UUID
+        prompt:
+          type: string
+          title: Prompt
+          description: The actual prompt text used
+        status:
+          $ref: '#/components/schemas/AttackStatus'
+          description: Attack status
+          default: INIT
+        marked_safe:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Marked Safe
+          description: Manual safety marking
+        extra_info:
+          additionalProperties: true
+          type: object
+          title: Extra Info
+          description: Additional metadata
+        threat:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Threat
+          description: Threat detection result
+        attack_type:
+          $ref: '#/components/schemas/AttackType'
+          description: Type of attack
+          default: NORMAL
+        multi_turn:
+          type: boolean
+          title: Multi Turn
+          description: Multi-turn conversation flag
+          default: false
+        asr:
+          anyOf:
+          - type: number
+            maximum: 100
+            minimum: 0
+          - type: 'null'
+          title: Asr
+          description: Attack Success Rate (0-100)
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Attack version
+        prompt_mapping_id:
+          type: string
+          format: uuid
+          title: Prompt Mapping Id
+          description: Prompt mapping UUID
+        prompt_id:
+          type: string
+          format: uuid
+          title: Prompt Id
+          description: Prompt UUID
+        category:
+          $ref: '#/components/schemas/Category'
+          description: Attack category
+        sub_category:
+          anyOf:
+          - $ref: '#/components/schemas/SecuritySubCategory'
+          - $ref: '#/components/schemas/SafetySubCategory'
+          - $ref: '#/components/schemas/BrandSubCategory'
+          - $ref: '#/components/schemas/ComplianceSubCategory'
+          title: Sub Category
+          description: Attack subcategory
+        severity:
+          type: string
+          description: Attack severity level
+        category_display_name:
+          type: string
+          title: Category Display Name
+        sub_category_display_name:
+          type: string
+          title: Sub Category Display Name
+        compliance_frameworks:
+          items:
+            $ref: '#/components/schemas/ComplianceWithTechniqueModel'
+          type: array
+          title: Compliance Frameworks
+        outputs:
+          items:
+            items:
+              $ref: '#/components/schemas/AttackMultiTurnOutputSchema'
+            type: array
+          type: array
+          title: Outputs
+          description: List of conversations, where each conversation is a list of
+            turns ordered by turn number. Each inner list represents one generation
+            of the multi-turn attack.
+        goal:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - job_id
+      - target_id
+      - prompt
+      - prompt_mapping_id
+      - prompt_id
+      - category
+      - sub_category
+      - category_display_name
+      - sub_category_display_name
+      - compliance_frameworks
+      - goal
+      title: AttackMultiTurnDetailResponseSchema
+    AttackMultiTurnOutputSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        attack_id:
+          type: string
+          format: uuid
+          title: Attack Id
+          description: Associated attack UUID
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Associated job UUID
+        target_id:
+          type: string
+          format: uuid
+          title: Target Id
+          description: Target UUID
+        output:
+          type: string
+          title: Output
+          description: Attack output. String for single-turn, dict for multi-turn.
+        threat:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Threat
+          description: Threat detection result
+        marked_safe:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Marked Safe
+          description: Manual safety marking
+        prompt:
+          type: string
+          title: Prompt
+          description: User prompt for this turn
+        turn:
+          type: integer
+          title: Turn
+          description: Current turn number in multi-turn conversation
+        generation:
+          type: integer
+          title: Generation
+          description: Generation/conversation number (1-based) for grouping multi-turn
+            outputs
+          default: 1
+        multi_turn:
+          type: boolean
+          title: Multi Turn
+          description: Multi-turn conversation flag
+          default: true
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - attack_id
+      - job_id
+      - target_id
+      - output
+      - prompt
+      - turn
+      title: AttackMultiTurnOutputSchema
+      description: Schema for multi-turn attack outputs.
+    AttackOutputSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        attack_id:
+          type: string
+          format: uuid
+          title: Attack Id
+          description: Associated attack UUID
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Associated job UUID
+        target_id:
+          type: string
+          format: uuid
+          title: Target Id
+          description: Target UUID
+        output:
+          type: string
+          title: Output
+          description: Attack output. String for single-turn, dict for multi-turn.
+        threat:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Threat
+          description: Threat detection result
+        marked_safe:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Marked Safe
+          description: Manual safety marking
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - attack_id
+      - job_id
+      - target_id
+      - output
+      title: AttackOutputSchema
+      description: Schema for attack output responses.
+    AttackStatus:
+      type: string
+      enum:
+      - INIT
+      - ATTACK
+      - DETECTION
+      - REPORT
+      - COMPLETED
+      - FAILED
+      title: AttackStatus
+    AttackType:
+      type: string
+      enum:
+      - NORMAL
+      - CUSTOM
+      title: AttackType
+    BrandSubCategory:
+      type: string
+      enum:
+      - COMPETITOR_ENDORSEMENTS
+      - BRAND_TARNISHING_SELF_CRITICISM
+      - DISCRIMINATING_CLAIMS
+      - POLITICAL_ENDORSEMENTS
+      title: BrandSubCategory
+    Category:
+      type: string
+      enum:
+      - SECURITY
+      - SAFETY
+      - COMPLIANCE
+      - BRAND
+      title: Category
+    CategoryModel:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Unique identifier
+        display_name:
+          type: string
+          title: Display Name
+          description: Frontend display name
+        description:
+          type: string
+          title: Description
+          description: Description
+        preselect:
+          type: boolean
+          title: Preselect
+          description: Whether this category should be preselected in UI
+          default: true
+        sub_categories:
+          items:
+            $ref: '#/components/schemas/SubCategoryModel'
+          type: array
+          title: Sub Categories
+          description: List of subcategories
+      type: object
+      required:
+      - id
+      - display_name
+      - description
+      - sub_categories
+      title: CategoryModel
+      description: Pydantic model for category data
+    CategoryReportSchema:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Unique identifier
+        display_name:
+          type: string
+          title: Display Name
+          description: Frontend display name
+        description:
+          type: string
+          title: Description
+          description: Description
+        preselect:
+          type: boolean
+          title: Preselect
+          description: Whether this category should be preselected in UI
+          default: true
+        sub_categories:
+          items:
+            $ref: '#/components/schemas/SubCategoryStatsSchema'
+          type: array
+          title: Sub Categories
+          description: Statistics per subcategory (e.g., ADVERSARIAL_SUFFIX, BIAS)
+        asr:
+          type: number
+          maximum: 100
+          minimum: 0
+          title: Asr
+          description: Attack success rate percentage
+        total_prompts:
+          type: integer
+          title: Total Prompts
+          description: Total unique prompts used
+        total_attacks:
+          type: integer
+          title: Total Attacks
+          description: Total attacks executed
+        successful:
+          type: integer
+          title: Successful
+          description: Total successful attacks
+        failed:
+          type: integer
+          title: Failed
+          description: Total failed attacks
+      type: object
+      required:
+      - id
+      - display_name
+      - description
+      - sub_categories
+      - asr
+      - total_prompts
+      - total_attacks
+      - successful
+      - failed
+      title: CategoryReportSchema
+      description: Security or Safety risk overview widget data.
+    ComplianceReportSchema:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Compliance framework unique identifier
+        display_name:
+          type: string
+          title: Display Name
+          description: Compliance framework display name for frontend
+        description:
+          type: string
+          title: Description
+          description: Compliance framework description
+        active:
+          type: boolean
+          title: Active
+          description: Whether compliance framework is active
+        version:
+          type: string
+          title: Version
+          description: Compliance framework version
+        link:
+          type: string
+          title: Link
+          description: Compliance framework documentation link
+        techniques:
+          items:
+            $ref: '#/components/schemas/ComplianceTechniqueSchema'
+          type: array
+          title: Techniques
+        score:
+          type: integer
+          title: Score
+          description: 'Compliance score: (1 - ASR%) % 5'
+          default: 0
+      type: object
+      required:
+      - id
+      - display_name
+      - description
+      - active
+      - version
+      - link
+      - techniques
+      title: ComplianceReportSchema
+    ComplianceSubCategory:
+      type: string
+      enum:
+      - OWASP
+      - MITRE_ATLAS
+      - NIST
+      - DASF_V2
+      title: ComplianceSubCategory
+    ComplianceTechniqueSchema:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Technique unique identifier
+        display_name:
+          type: string
+          title: Display Name
+          description: Technique display name for frontend
+        compliance_id:
+          type: string
+          title: Compliance Id
+          description: Associated compliance framework ID
+        description:
+          type: string
+          title: Description
+          description: Technique description
+        link:
+          type: string
+          title: Link
+          description: Technique documentation link
+        version:
+          type: string
+          title: Version
+          description: Technique version
+        active:
+          type: boolean
+          title: Active
+          description: Whether technique is active
+        successful:
+          type: integer
+          title: Successful
+          description: Number of successful attacks
+          default: 0
+        failed:
+          type: integer
+          title: Failed
+          description: Number of failed attacks
+          default: 0
+        total:
+          type: integer
+          title: Total
+          description: Total attacks for this technique
+          default: 0
+      type: object
+      required:
+      - id
+      - display_name
+      - compliance_id
+      - description
+      - link
+      - version
+      - active
+      title: ComplianceTechniqueSchema
+      description: Compliance Technique Model
+    ComplianceWithTechniqueModel:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Compliance framework unique identifier
+        display_name:
+          type: string
+          title: Display Name
+          description: Compliance framework display name for frontend
+        description:
+          type: string
+          title: Description
+          description: Compliance framework description
+        active:
+          type: boolean
+          title: Active
+          description: Whether compliance framework is active
+        version:
+          type: string
+          title: Version
+          description: Compliance framework version
+        link:
+          type: string
+          title: Link
+          description: Compliance framework documentation link
+        techniques:
+          items:
+            $ref: '#/components/schemas/TechniqueModel'
+          type: array
+          title: Techniques
+          description: List of Techniques
+      type: object
+      required:
+      - id
+      - display_name
+      - description
+      - active
+      - version
+      - link
+      - techniques
+      title: ComplianceWithTechniqueModel
+    CountByNameSchema:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Name of the item (e.g., target type, status)
+        count:
+          type: integer
+          minimum: 0
+          title: Count
+          description: Count of items
+      type: object
+      required:
+      - name
+      - count
+      title: CountByNameSchema
+      description: 'Generic count schema with name field for extensible list structures.
+
+
+        Used in dashboard and other endpoints to provide counts grouped by a name
+        field.
+
+        Frontend-friendly list format for easy iteration.
+
+        '
+    CountedQuotaEnum:
+      type: string
+      enum:
+      - HELD
+      - COUNTED
+      - NOT_COUNTED
+      title: CountedQuotaEnum
+      description: Enum for counting Quota.
+    CustomAttackOutputSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        custom_attack_id:
+          type: string
+          format: uuid
+          title: Custom Attack Id
+          description: Associated custom attack UUID
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Associated job UUID
+        target_id:
+          type: string
+          format: uuid
+          title: Target Id
+          description: Target UUID
+        output:
+          type: string
+          title: Output
+          description: Attack output content
+        threat:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Threat
+          description: Threat detection result
+        marked_safe:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Marked Safe
+          description: Manual safety marking
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - custom_attack_id
+      - job_id
+      - target_id
+      - output
+      title: CustomAttackOutputSchema
+      description: Schema for custom attack output response.
+    CustomAttackReportResponse:
+      properties:
+        total_prompts:
+          type: integer
+          title: Total Prompts
+          description: Total number of unique prompts
+        total_attacks:
+          type: integer
+          title: Total Attacks
+          description: Total number of attacks executed
+        total_threats:
+          type: integer
+          title: Total Threats
+          description: Number of threats detected
+        failed_attacks:
+          type: integer
+          title: Failed Attacks
+          description: Number of failed attacks (no threats detected)
+        score:
+          type: number
+          title: Score
+          description: Overall threat score (0-100)
+        asr:
+          type: number
+          title: Asr
+          description: Attack Success Rate (0-100)
+        custom_attack_reports:
+          items:
+            $ref: '#/components/schemas/PromptSetSummary'
+          type: array
+          title: Custom Attack Reports
+          description: Reports for each prompt set
+        property_statistics:
+          items:
+            $ref: '#/components/schemas/PropertyStatistic'
+          type: array
+          title: Property Statistics
+          description: Aggregated property statistics
+      type: object
+      required:
+      - total_prompts
+      - total_attacks
+      - total_threats
+      - failed_attacks
+      - score
+      - asr
+      title: CustomAttackReportResponse
+      description: Main custom attack report response.
+    CustomAttacksListResponse:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        data:
+          items:
+            $ref: '#/components/schemas/PromptDetailResponse'
+          type: array
+          title: Data
+          description: List of attack details
+        total_attacks:
+          type: integer
+          title: Total Attacks
+          description: Total number of attacks
+        total_threats:
+          type: integer
+          title: Total Threats
+          description: Number of threats detected
+      type: object
+      required:
+      - pagination
+      - data
+      - total_attacks
+      - total_threats
+      title: CustomAttacksListResponse
+      description: Enhanced list response for custom attacks.
+    CustomJobMetadata:
+      properties:
+        rate_limit_enabled:
+          type: boolean
+          title: Rate Limit Enabled
+          default: false
+        rate_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rate Limit
+        rate_limit_error_code:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rate Limit Error Code
+        rate_limit_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Rate Limit Error Message
+        rate_limit_error_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rate Limit Error Json
+        content_filter_enabled:
+          type: boolean
+          title: Content Filter Enabled
+          description: Enable content filtering
+          default: false
+        content_filter_error_code:
+          anyOf:
+          - type: integer
+            maximum: 599
+            minimum: 400
+          - type: 'null'
+          title: Content Filter Error Code
+          description: HTTP error code for content filter (400-599)
+        content_filter_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Content Filter Error Message
+          description: Content filter error message
+        content_filter_error_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Content Filter Error Json
+        custom_prompt_sets:
+          items:
+            type: string
+            format: uuid
+          type: array
+          minItems: 1
+          title: Custom Prompt Sets
+          description: List of custom prompt set UUIDs
+      type: object
+      required:
+      - custom_prompt_sets
+      title: CustomJobMetadata
+      description: Enhanced metadata for custom attack jobs.
+    CustomTopicGuardrailsSchema:
+      properties:
+        action:
+          $ref: '#/components/schemas/GuardrailAction'
+          description: 'Action to take: ''allow'', ''block'''
+          default: BLOCK
+        blocked_topics:
+          items:
+            type: string
+          type: array
+          title: Blocked Topics
+          description: List of blocked topics
+      type: object
+      title: CustomTopicGuardrailsSchema
+      description: Custom topic guardrails with blocked topics.
+    DateRangeFilter:
+      type: string
+      enum:
+      - LAST_7_DAYS
+      - LAST_15_DAYS
+      - LAST_30_DAYS
+      - ALL
+      title: DateRangeFilter
+      description: Predefined date range filters for chart APIs.
+    DynamicJobMetadata:
+      properties:
+        rate_limit_enabled:
+          type: boolean
+          title: Rate Limit Enabled
+          default: false
+        rate_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rate Limit
+        rate_limit_error_code:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rate Limit Error Code
+        rate_limit_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Rate Limit Error Message
+        rate_limit_error_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rate Limit Error Json
+        content_filter_enabled:
+          type: boolean
+          title: Content Filter Enabled
+          description: Enable content filtering
+          default: false
+        content_filter_error_code:
+          anyOf:
+          - type: integer
+            maximum: 599
+            minimum: 400
+          - type: 'null'
+          title: Content Filter Error Code
+          description: HTTP error code for content filter (400-599)
+        content_filter_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Content Filter Error Message
+          description: Content filter error message
+        content_filter_error_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Content Filter Error Json
+        stream_breadth:
+          type: integer
+          maximum: 20
+          minimum: 1
+          title: Stream Breadth
+          description: Number of parallel attack streams (1-20)
+          default: 6
+        stream_depth:
+          type: integer
+          maximum: 20
+          minimum: 1
+          title: Stream Depth
+          description: Depth of each attack stream (1-20)
+          default: 10
+        max_tokens:
+          type: integer
+          maximum: 4096
+          minimum: 128
+          title: Max Tokens
+          description: Maximum tokens per response (128-4096)
+          default: 256
+        context_size:
+          type: integer
+          maximum: 20
+          minimum: 1
+          title: Context Size
+          description: Context window size (1-20)
+          default: 10
+        attack_goals:
+          items:
+            type: string
+          type: array
+          title: Attack Goals
+          description: List of attack objectives
+        base_model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Base Model
+          description: Base model identifier
+        use_case:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Use Case
+          description: Attack use case description
+        system_prompt:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: System Prompt
+          description: Custom system prompt
+      type: object
+      title: DynamicJobMetadata
+      description: Enhanced metadata for dynamic attack jobs with proper constraints.
+    DynamicJobReportSchema:
+      properties:
+        total_goals:
+          type: integer
+          minimum: 0
+          title: Total Goals
+          description: Total number of goals tested
+          default: 0
+        total_streams:
+          type: integer
+          minimum: 0
+          title: Total Streams
+          description: Total number of attack streams
+          default: 0
+        total_threats:
+          type: integer
+          minimum: 0
+          title: Total Threats
+          description: Total number of threats detected
+          default: 0
+        goals_achieved:
+          type: integer
+          minimum: 0
+          title: Goals Achieved
+          description: Number of goals with at least one threat
+          default: 0
+        report_summary:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Report Summary
+          description: LLM-generated executive summary for the dynamic job
+        score:
+          type: number
+          maximum: 100
+          minimum: 0
+          title: Score
+          description: Overall security score (0-100)
+          default: 0
+        asr:
+          type: number
+          maximum: 100
+          minimum: 0
+          title: Asr
+          description: Attack Success Rate (0-100)
+          default: 0
+      type: object
+      title: DynamicJobReportSchema
+      description: Core metrics for report generation.
+    DynamicJobReportStats:
+      properties:
+        total_goals:
+          type: integer
+          minimum: 0
+          title: Total Goals
+          description: Total number of goals tested
+          default: 0
+        total_streams:
+          type: integer
+          minimum: 0
+          title: Total Streams
+          description: Total number of attack streams
+          default: 0
+        total_threats:
+          type: integer
+          minimum: 0
+          title: Total Threats
+          description: Total number of threats detected
+          default: 0
+        goals_achieved:
+          type: integer
+          minimum: 0
+          title: Goals Achieved
+          description: Number of goals with at least one threat
+          default: 0
+        report_summary:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Report Summary
+          description: LLM-generated executive summary for the dynamic job
+      type: object
+      title: DynamicJobReportStats
+    ErrorLogListResponseSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        data:
+          items:
+            $ref: '#/components/schemas/ErrorLogListSchema'
+          type: array
+          title: Data
+          description: List of error logs
+      type: object
+      required:
+      - pagination
+      - data
+      title: ErrorLogListResponseSchema
+      description: Schema for error log list response.
+    ErrorLogListSchema:
+      properties:
+        job_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Job Id
+          description: UUID of the job associated with this error
+        target_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Target Id
+          description: UUID of the target associated with this error
+        target_version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Target Version
+          description: Version of the target configuration when error occurred
+        attack_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Attack Id
+          description: UUID of the attack attempt that caused the error
+        error_type:
+          anyOf:
+          - $ref: '#/components/schemas/ErrorType'
+          - type: 'null'
+          description: Type/category of the error
+        error_source:
+          anyOf:
+          - $ref: '#/components/schemas/ErrorSource'
+          - type: 'null'
+          description: Source/origin of the error
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+          description: Human-readable error message
+        target_object:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Target Object
+          description: Snapshot of target configuration at error time
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Any additional context or metadata
+        version:
+          type: integer
+          title: Version
+          description: Schema version for future evolution
+          default: 1
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: When the error log was created
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: When the error log was last updated
+      type: object
+      required:
+      - created_at
+      - updated_at
+      title: ErrorLogListSchema
+    ErrorSource:
+      type: string
+      enum:
+      - TARGET
+      - JOB
+      - SYSTEM
+      - VALIDATION
+      - TARGET_PROFILING
+      title: ErrorSource
+      description: Source/origin of the error.
+    ErrorType:
+      type: string
+      enum:
+      - CONTENT_FILTER
+      - RATE_LIMIT
+      - AUTHENTICATION
+      - NETWORK
+      - VALIDATION
+      - NETWORK_CHANNEL
+      - UNKNOWN
+      title: ErrorType
+      description: Classification of error types.
+    FileFormat:
+      type: string
+      enum:
+      - CSV
+      - JSON
+      - ALL
+      title: FileFormat
+      description: File format options for report downloads.
+    GoalListResponseSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        data:
+          items:
+            $ref: '#/components/schemas/GoalSchema'
+          type: array
+          title: Data
+          description: List of Goals
+      type: object
+      required:
+      - pagination
+      - data
+      title: GoalListResponseSchema
+      description: Response schema for listing attacks following common pagination
+        pattern.
+    GoalSchema:
+      properties:
+        goal:
+          type: string
+          title: Goal
+          description: The test goal/prompt
+        safe_response:
+          type: string
+          title: Safe Response
+          description: The complete safe response with proper refusal
+        jailbroken_response:
+          type: string
+          minLength: 1
+          title: Jailbroken Response
+          description: The complete jailbroken response without disclaimers
+        goal_metadata:
+          additionalProperties: true
+          type: object
+          title: Goal Metadata
+          description: Additional metadata
+        custom_goal:
+          type: boolean
+          title: Custom Goal
+          description: Indicates if it is a custom goal
+          default: false
+        goal_type:
+          $ref: '#/components/schemas/GoalType'
+          description: 'Goal type: BASE, TOOL_MISUSE, GOAL_MANIPULATION'
+          default: BASE
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Job identifier
+        goal_to_show:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal To Show
+          description: Goal to use in the backend
+        threat:
+          type: boolean
+          title: Threat
+          description: Indicates if it is a threat
+          default: false
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Goal schema version
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Extra info
+      type: object
+      required:
+      - goal
+      - safe_response
+      - jailbroken_response
+      - uuid
+      - tsg_id
+      - job_id
+      title: GoalSchema
+    GoalType:
+      type: string
+      enum:
+      - BASE
+      - TOOL_MISUSE
+      - GOAL_MANIPULATION
+      title: GoalType
+    GoalTypeQueryParam:
+      type: string
+      enum:
+      - AGENT
+      - HUMAN_AUGMENTED
+      title: GoalTypeQueryParam
+    GuardrailAction:
+      type: string
+      enum:
+      - ALLOW
+      - BLOCK
+      title: GuardrailAction
+      description: Actions that can be taken by guardrails.
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    JobAbortResponseSchema:
+      properties:
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: UUID of the aborted job
+        message:
+          type: string
+          title: Message
+          description: Status message
+      type: object
+      required:
+      - job_id
+      - message
+      title: JobAbortResponseSchema
+      description: Response schema for job abort operation.
+    JobCreateRequestSchema:
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          minLength: 3
+          title: Name
+          description: Job name (3-255 characters)
+        target:
+          $ref: '#/components/schemas/TargetJobRequest'
+          description: Target reference for job creation
+        job_type:
+          $ref: '#/components/schemas/JobType'
+          description: Type of job to execute
+        job_metadata:
+          anyOf:
+          - $ref: '#/components/schemas/StaticJobMetadata'
+          - $ref: '#/components/schemas/DynamicJobMetadata'
+          - $ref: '#/components/schemas/CustomJobMetadata'
+          title: Job Metadata
+          description: Job-specific metadata
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Job version
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      - target
+      - job_type
+      - job_metadata
+      title: JobCreateRequestSchema
+      description: Request schema for creating jobs.
+    JobListResponseSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        data:
+          items:
+            $ref: '#/components/schemas/JobResponseSchema'
+          type: array
+          title: Data
+          description: List of jobs
+      type: object
+      required:
+      - pagination
+      - data
+      title: JobListResponseSchema
+      description: Response schema for listing jobs following common pagination pattern.
+    JobResponseSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        name:
+          type: string
+          maxLength: 255
+          minLength: 3
+          title: Name
+          description: Job name (3-255 characters)
+        target:
+          $ref: '#/components/schemas/TargetReferenceSchema'
+          description: Full target configuration
+        job_type:
+          $ref: '#/components/schemas/JobType'
+          description: Type of job to execute
+        job_metadata:
+          anyOf:
+          - $ref: '#/components/schemas/StaticJobMetadata'
+          - $ref: '#/components/schemas/DynamicJobMetadata'
+          - $ref: '#/components/schemas/CustomJobMetadata'
+          title: Job Metadata
+          description: Job-specific metadata
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Job version
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+        target_id:
+          type: string
+          format: uuid
+          title: Target Id
+          description: Target UUID (denormalized)
+        target_type:
+          type: string
+          title: Target Type
+          description: Target type (APPLICATION, AGENT, MODEL)
+        total:
+          anyOf:
+          - type: integer
+            minimum: 0
+          - type: 'null'
+          title: Total
+          description: Total tasks in job
+        completed:
+          anyOf:
+          - type: integer
+            minimum: 0
+          - type: 'null'
+          title: Completed
+          description: Completed tasks
+        status:
+          $ref: '#/components/schemas/JobStatus'
+          description: Current job status
+          default: INIT
+        score:
+          anyOf:
+          - type: number
+            maximum: 100
+            minimum: 0
+          - type: 'null'
+          title: Score
+          description: Overall job performance score (0-100)
+        asr:
+          anyOf:
+          - type: number
+            maximum: 100
+            minimum: 0
+          - type: 'null'
+          title: Asr
+          description: Updated Attack Success Rate (0-100)
+        time_record:
+          anyOf:
+          - $ref: '#/components/schemas/JobTimeRecord'
+          - type: 'null'
+          description: Job timing information
+        created_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Updated At
+          description: Last update timestamp
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+          description: UUID of the user creating this job
+        report_stats:
+          anyOf:
+          - $ref: '#/components/schemas/StaticJobReportStats'
+          - $ref: '#/components/schemas/DynamicJobReportStats'
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Report Stats
+          description: Report statistics (StaticJobReportStats for STATIC/CUSTOM jobs,
+            DynamicJobReportStats for DYNAMIC jobs)
+        metering_quota_uuid:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Metering Quota Uuid
+          description: UUID of the metering quota used for this job
+        counted_towards_quota:
+          $ref: '#/components/schemas/CountedQuotaEnum'
+          description: Whether this job is counted towards quota consumption
+          default: HELD
+        invocation_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Invocation Id
+          description: Restate invocationId of this job
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - name
+      - target
+      - job_type
+      - job_metadata
+      - target_id
+      - target_type
+      title: JobResponseSchema
+      description: Job response schema. ONLY to be used in API response.
+    JobStatus:
+      type: string
+      enum:
+      - INIT
+      - QUEUED
+      - RUNNING
+      - COMPLETED
+      - PARTIALLY_COMPLETE
+      - FAILED
+      - ABORTED
+      title: JobStatus
+      description: Complete job status enum including internal INIT status.
+    JobStatusFilter:
+      type: string
+      enum:
+      - QUEUED
+      - RUNNING
+      - COMPLETED
+      - PARTIALLY_COMPLETE
+      - FAILED
+      - ABORTED
+      title: JobStatusFilter
+      description: Job status enum for API filtering - excludes INIT from public API.
+    JobTimeRecord:
+      properties:
+        queued_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Queued At
+          description: Job queue timestamp
+        started_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Started At
+          description: Job start timestamp
+        completed_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Completed At
+          description: Job completion timestamp
+        time_taken:
+          anyOf:
+          - type: string
+            format: duration
+          - type: 'null'
+          title: Time Taken
+          description: Total execution time
+      type: object
+      title: JobTimeRecord
+      description: Enhanced time tracking with validation.
+    JobType:
+      type: string
+      enum:
+      - STATIC
+      - DYNAMIC
+      - CUSTOM
+      title: JobType
+      description: Type of job execution.
+    MaliciousCodeDetectionSchema:
+      properties:
+        action:
+          $ref: '#/components/schemas/GuardrailAction'
+          description: 'Action to take: ''allow'', ''block'''
+          default: BLOCK
+      type: object
+      title: MaliciousCodeDetectionSchema
+      description: Guardrail configuration for malicious code detection.
+    MaliciousURLDetectionSchema:
+      properties:
+        action:
+          $ref: '#/components/schemas/GuardrailAction'
+          description: 'Action to take: ''allow'', ''block'''
+          default: BLOCK
+      type: object
+      title: MaliciousURLDetectionSchema
+      description: Guardrail configuration for malicious URL detection.
+    PaginationSchema:
+      properties:
+        total_items:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Total Items
+      type: object
+      title: PaginationSchema
+    PolicyType:
+      type: string
+      enum:
+      - PROMPT_INJECTION
+      - TOXIC_CONTENT
+      - CUSTOM_TOPIC_GUARDRAILS
+      - MALICIOUS_CODE_DETECTION
+      - MALICIOUS_URL_DETECTION
+      - SENSITIVE_DATA_PROTECTION
+      title: PolicyType
+      description: Policy types with metadata.
+    PrerequisiteModel:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Prerequisite unique identifier
+        display_name:
+          type: string
+          title: Display Name
+          description: Prerequisite display name for frontend
+        description:
+          type: string
+          title: Description
+          description: Prerequisite description
+      type: object
+      required:
+      - id
+      - display_name
+      - description
+      title: PrerequisiteModel
+      description: Pydantic model for prerequisite data
+    ProfilingStatus:
+      type: string
+      enum:
+      - INIT
+      - QUEUED
+      - IN_PROGRESS
+      - COMPLETED
+      - FAILED
+      title: ProfilingStatus
+      description: Status of target profiling workflow.
+    PromptDetailResponse:
+      properties:
+        prompt_id:
+          type: string
+          format: uuid
+          title: Prompt Id
+          description: Prompt UUID
+        prompt_text:
+          type: string
+          title: Prompt Text
+          description: The prompt text
+        goal:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal
+          description: Goal of the prompt
+        user_defined_goal:
+          type: boolean
+          title: User Defined Goal
+          description: Whether goal is user-defined
+          default: false
+        properties:
+          items:
+            $ref: '#/components/schemas/PropertyAssignment'
+          type: array
+          title: Properties
+          description: Property assignments
+        attack_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Attack Id
+          description: Associated attack UUID
+        threat:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Threat
+          description: Whether threat was detected
+        attack_outputs:
+          items:
+            type: string
+          type: array
+          title: Attack Outputs
+          description: Attack output strings
+        asr:
+          anyOf:
+          - type: number
+            maximum: 100
+            minimum: 0
+          - type: 'null'
+          title: Asr
+          description: Attack Success Rate for this prompt (0-100)
+        prompt_set_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Prompt Set Id
+          description: Prompt set UUID
+        prompt_set_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Prompt Set Name
+          description: Prompt set name
+      type: object
+      required:
+      - prompt_id
+      - prompt_text
+      title: PromptDetailResponse
+      description: Detailed prompt response.
+    PromptInjectionGuardrailSchema:
+      properties:
+        action:
+          $ref: '#/components/schemas/GuardrailAction'
+          description: 'Action to take: ''allow'', ''block'''
+          default: BLOCK
+      type: object
+      title: PromptInjectionGuardrailSchema
+      description: Guardrail configuration for prompt injection.
+    PromptSetSummary:
+      properties:
+        prompt_set_id:
+          type: string
+          format: uuid
+          title: Prompt Set Id
+          description: Custom prompt set UUID
+        prompt_set_name:
+          type: string
+          title: Prompt Set Name
+          description: Name of the prompt set
+        total_prompts:
+          type: integer
+          title: Total Prompts
+          description: Total number of unique prompts
+        total_attacks:
+          type: integer
+          title: Total Attacks
+          description: Total number of attacks executed
+        total_threats:
+          type: integer
+          title: Total Threats
+          description: Number of threats detected
+        failed_attacks:
+          type: integer
+          title: Failed Attacks
+          description: Number of failed attacks (no threats detected)
+        threat_rate:
+          type: number
+          title: Threat Rate
+          description: Threat detection rate (0-100)
+        property_names:
+          items:
+            type: string
+          type: array
+          title: Property Names
+          description: List of unique property names in this prompt set
+        property_statistics:
+          items:
+            $ref: '#/components/schemas/PropertyStatistic'
+          type: array
+          title: Property Statistics
+          description: Property-based statistics
+      type: object
+      required:
+      - prompt_set_id
+      - prompt_set_name
+      - total_prompts
+      - total_attacks
+      - total_threats
+      - failed_attacks
+      - threat_rate
+      title: PromptSetSummary
+      description: Prompt set summary with statistics.
+    PromptSetsReportResponse:
+      properties:
+        prompt_sets:
+          items:
+            $ref: '#/components/schemas/PromptSetSummary'
+          type: array
+          title: Prompt Sets
+          description: List of prompt set summaries
+        total_prompt_sets:
+          type: integer
+          title: Total Prompt Sets
+          description: Total number of prompt sets
+        applied_filters:
+          additionalProperties: true
+          type: object
+          title: Applied Filters
+          description: Filters applied to the results
+      type: object
+      required:
+      - prompt_sets
+      - total_prompt_sets
+      title: PromptSetsReportResponse
+      description: Response for prompt sets with filtering.
+    PropertyAssignment:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Property name
+        value:
+          type: string
+          title: Value
+          description: Property value
+      type: object
+      required:
+      - name
+      - value
+      title: PropertyAssignment
+      description: Property assignment for custom attacks.
+    PropertyStatistic:
+      properties:
+        property_name:
+          type: string
+          title: Property Name
+          description: Name of the property
+        values:
+          items:
+            $ref: '#/components/schemas/PropertyValueStatistic'
+          type: array
+          title: Values
+          description: Statistics for each property value
+      type: object
+      required:
+      - property_name
+      - values
+      title: PropertyStatistic
+      description: Property statistics for prompt sets and job-level aggregation.
+    PropertyValueStatistic:
+      properties:
+        value:
+          type: string
+          title: Value
+          description: Property value
+        successful_attack_count:
+          type: integer
+          title: Successful Attack Count
+          description: Number of successful attacks
+        total_attack_count:
+          type: integer
+          title: Total Attack Count
+          description: Total number of attacks
+        success_rate:
+          type: number
+          title: Success Rate
+          description: Auto-calculated success rate percentage
+      type: object
+      required:
+      - value
+      - successful_attack_count
+      - total_attack_count
+      - success_rate
+      title: PropertyValueStatistic
+      description: Statistics for a specific property value.
+    QuotaDetails:
+      properties:
+        allocated:
+          type: integer
+          title: Allocated
+          description: Total allocated scans for this type
+        unlimited:
+          type: boolean
+          title: Unlimited
+          description: Whether this scan type has unlimited quota
+        consumed:
+          type: integer
+          title: Consumed
+          description: Total consumed scans for this type
+      type: object
+      required:
+      - allocated
+      - unlimited
+      - consumed
+      title: QuotaDetails
+      description: Details for a specific scan type quota.
+    QuotaSummarySchema:
+      properties:
+        static:
+          $ref: '#/components/schemas/QuotaDetails'
+          description: Static scan quota details
+        dynamic:
+          $ref: '#/components/schemas/QuotaDetails'
+          description: Dynamic scan quota details
+        custom:
+          $ref: '#/components/schemas/QuotaDetails'
+          description: Custom scan quota details
+      type: object
+      required:
+      - static
+      - dynamic
+      - custom
+      title: QuotaSummarySchema
+      description: Schema for quota summary response organized by scan type.
+    RemediationDetailSchema:
+      properties:
+        remediation:
+          type: string
+          title: Remediation
+          description: Remediation recommendation title
+        description:
+          type: string
+          title: Description
+          description: Detailed description of the remediation
+        resource_links:
+          items:
+            type: string
+          type: array
+          title: Resource Links
+          description: URLs for additional resources and documentation
+        priority_level:
+          type: string
+          description: Priority level for this remediation
+        ease_of_implementation_level:
+          type: string
+          description: Ease of implementation level for this remediation
+        effectiveness_level:
+          type: string
+          description: Effectiveness rating for this remediation
+      type: object
+      required:
+      - remediation
+      - description
+      title: RemediationDetailSchema
+    RemediationResponseSchema:
+      properties:
+        remediations:
+          items:
+            $ref: '#/components/schemas/RemediationDetailSchema'
+          type: array
+          title: Remediations
+          description: List of applicable remediation recommendations for static and
+            dynamic jobs
+      type: object
+      title: RemediationResponseSchema
+    ResponseMode:
+      type: string
+      enum:
+      - REST
+      - STREAMING
+      title: ResponseMode
+      description: Response mode for target interactions.
+    RiskLevelSchema:
+      properties:
+        risk_rating:
+          $ref: '#/components/schemas/RiskRating'
+          description: Risk rating level based on job score
+        total:
+          type: integer
+          minimum: 0
+          title: Total
+          description: Total count for this risk rating level
+        targets_by_type:
+          items:
+            $ref: '#/components/schemas/CountByNameSchema'
+          type: array
+          title: Targets By Type
+          description: Breakdown by target type (APPLICATION, AGENT, MODEL)
+      type: object
+      required:
+      - risk_rating
+      - total
+      title: RiskLevelSchema
+      description: Risk level breakdown with risk rating and target type counts.
+    RiskRating:
+      type: string
+      enum:
+      - LOW
+      - MEDIUM
+      - HIGH
+      - CRITICAL
+      title: RiskRating
+      description: Risk rating levels with score ranges.
+    RuntimeSecurityPolicySchema:
+      properties:
+        policy_id:
+          $ref: '#/components/schemas/PolicyType'
+          description: Runtime Security Policy type
+        display_name:
+          type: string
+          title: Display Name
+          description: Runtime Security Policy display name
+        config:
+          anyOf:
+          - $ref: '#/components/schemas/PromptInjectionGuardrailSchema'
+          - $ref: '#/components/schemas/ToxicContentGuardrailSchema'
+          - $ref: '#/components/schemas/CustomTopicGuardrailsSchema'
+          - $ref: '#/components/schemas/MaliciousCodeDetectionSchema'
+          - $ref: '#/components/schemas/MaliciousURLDetectionSchema'
+          - $ref: '#/components/schemas/SensitiveDataProtectionSchema'
+          title: Config
+          description: Runtime Security Policy configuration
+      type: object
+      required:
+      - policy_id
+      - display_name
+      - config
+      title: RuntimeSecurityPolicySchema
+      description: Runtime security policy configuration.
+    RuntimeSecurityProfileResponseSchema:
+      properties:
+        runtime_security_profile:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/RuntimeSecurityPolicySchema'
+            type: array
+          - type: 'null'
+          title: Runtime Security Profile
+          description: Recommended runtime security profile configuration
+      type: object
+      title: RuntimeSecurityProfileResponseSchema
+    SafetySubCategory:
+      type: string
+      enum:
+      - BIAS
+      - CBRN
+      - CYBERCRIME
+      - DRUGS
+      - HATE_TOXIC_ABUSE
+      - NON_VIOLENT_CRIMES
+      - POLITICAL
+      - SELF_HARM
+      - SEXUAL
+      - VIOLENT_CRIMES_WEAPONS
+      title: SafetySubCategory
+    SensitiveDataProtectionSchema:
+      properties:
+        action:
+          $ref: '#/components/schemas/GuardrailAction'
+          description: 'Action to take: ''allow'', ''block'''
+          default: BLOCK
+        masking_sensitive_data:
+          type: boolean
+          title: Masking Sensitive Data
+          description: Whether to mask sensitive data in responses
+          default: true
+      type: object
+      title: SensitiveDataProtectionSchema
+      description: Guardrail configuration for sensitive data protection.
+    ScanStatisticsResponseSchema:
+      properties:
+        total_scans:
+          type: integer
+          minimum: 0
+          title: Total Scans
+          description: Total number of scans
+        targets_scanned:
+          type: integer
+          minimum: 0
+          title: Targets Scanned
+          description: Number of unique targets scanned
+        targets_scanned_by_type:
+          items:
+            $ref: '#/components/schemas/CountByNameSchema'
+          type: array
+          title: Targets Scanned By Type
+          description: Targets scanned grouped by type (APPLICATION, AGENT, MODEL)
+        scan_status:
+          items:
+            $ref: '#/components/schemas/CountByNameSchema'
+          type: array
+          title: Scan Status
+          description: Scan counts by status (COMPLETED, IN_PROGRESS, QUEUED, FAILED)
+        risk_profile:
+          items:
+            $ref: '#/components/schemas/RiskLevelSchema'
+          type: array
+          title: Risk Profile
+          description: Risk breakdown by severity level with target type details
+      type: object
+      required:
+      - total_scans
+      - targets_scanned
+      title: ScanStatisticsResponseSchema
+      description: 'Dashboard scan statistics response.
+
+
+        Endpoint: GET /api/v1/dashboard/scan-statistics
+
+        Returns scan counts, target stats, and risk profile in list format.
+
+        '
+    ScoreTrendResponseSchema:
+      properties:
+        labels:
+          items:
+            type: string
+          type: array
+          title: Labels
+          description: Date labels (e.g., 'Jan 1', 'Jan 2')
+        series:
+          items:
+            $ref: '#/components/schemas/ScoreTrendSeriesSchema'
+          type: array
+          title: Series
+          description: Score series per job type
+      type: object
+      required:
+      - labels
+      - series
+      title: ScoreTrendResponseSchema
+      description: 'Response for score trend chart API.
+
+
+        Endpoint: GET /api/v1/dashboard/score-trend
+
+        Returns time-series risk scores grouped by job type for chart display.
+
+        '
+    ScoreTrendSeriesSchema:
+      properties:
+        label:
+          $ref: '#/components/schemas/JobType'
+          description: Job type for this series
+        data:
+          items:
+            anyOf:
+            - type: number
+            - type: 'null'
+          type: array
+          title: Data
+          description: Score per date label, null if no completed scan on that date
+      type: object
+      required:
+      - label
+      - data
+      title: ScoreTrendSeriesSchema
+      description: A single series in the score trend chart.
+    SecuritySubCategory:
+      type: string
+      enum:
+      - ADVERSARIAL_SUFFIX
+      - EVASION
+      - INDIRECT_PROMPT_INJECTION
+      - JAILBREAK
+      - MULTI_TURN
+      - PROMPT_INJECTION
+      - REMOTE_CODE_EXECUTION
+      - SYSTEM_PROMPT_LEAK
+      - TOOL_LEAK
+      - MALWARE_GENERATION
+      title: SecuritySubCategory
+    SentimentRequestSchema:
+      properties:
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Id of the job scan
+        up_vote:
+          type: boolean
+          title: Up Vote
+          description: Up vote for the job scan report summary
+          default: false
+          examples:
+          - false
+        down_vote:
+          type: boolean
+          title: Down Vote
+          description: Down vote for the job scan report summary
+          default: false
+          examples:
+          - false
+      additionalProperties: false
+      type: object
+      required:
+      - job_id
+      title: SentimentRequestSchema
+      description: Sentiment Request for report summary.
+    SentimentResponseSchema:
+      properties:
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Id of the job scan
+        up_vote:
+          type: boolean
+          title: Up Vote
+          description: Up vote for the job scan report summary
+          default: false
+          examples:
+          - false
+        down_vote:
+          type: boolean
+          title: Down Vote
+          description: Down vote for the job scan report summary
+          default: false
+          examples:
+          - false
+      additionalProperties: false
+      type: object
+      required:
+      - job_id
+      title: SentimentResponseSchema
+      description: Sentiment Response for report summary.
+    SeverityFilter:
+      type: string
+      enum:
+      - LOW
+      - MEDIUM
+      - HIGH
+      - CRITICAL
+      title: SeverityFilter
+      description: Severity filter enum for API filtering - uses string values.
+    SeverityReportSchema:
+      properties:
+        stats:
+          items:
+            $ref: '#/components/schemas/SeverityStatsSchema'
+          type: array
+          title: Stats
+          description: List of severity statistics
+        successful:
+          type: integer
+          title: Successful
+          description: Total successful attacks across all severities
+          default: 0
+        failed:
+          type: integer
+          title: Failed
+          description: Total failed attacks across all severities
+          default: 0
+        total_attacks:
+          type: integer
+          title: Total Attacks
+          description: Total number of attacks across all severities
+          default: 0
+      type: object
+      required:
+      - stats
+      title: SeverityReportSchema
+      description: Attack Severity statistics with breakdown by severity level.
+    SeverityStatsSchema:
+      properties:
+        severity:
+          type: string
+          description: Severity level (LOW, MEDIUM, HIGH, CRITICAL)
+        successful:
+          type: integer
+          title: Successful
+          description: Number of successful attacks at this severity
+          default: 0
+        failed:
+          type: integer
+          title: Failed
+          description: Number of failed attacks at this severity
+          default: 0
+      type: object
+      required:
+      - severity
+      title: SeverityStatsSchema
+      description: Breakdown for a single severity level.
+    StaticJobMetadata:
+      properties:
+        rate_limit_enabled:
+          type: boolean
+          title: Rate Limit Enabled
+          default: false
+        rate_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rate Limit
+        rate_limit_error_code:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rate Limit Error Code
+        rate_limit_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Rate Limit Error Message
+        rate_limit_error_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rate Limit Error Json
+        content_filter_enabled:
+          type: boolean
+          title: Content Filter Enabled
+          description: Enable content filtering
+          default: false
+        content_filter_error_code:
+          anyOf:
+          - type: integer
+            maximum: 599
+            minimum: 400
+          - type: 'null'
+          title: Content Filter Error Code
+          description: HTTP error code for content filter (400-599)
+        content_filter_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Content Filter Error Message
+          description: Content filter error message
+        content_filter_error_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Content Filter Error Json
+        categories:
+          additionalProperties:
+            items:
+              anyOf:
+              - $ref: '#/components/schemas/SecuritySubCategory'
+              - $ref: '#/components/schemas/SafetySubCategory'
+              - $ref: '#/components/schemas/BrandSubCategory'
+              - $ref: '#/components/schemas/ComplianceSubCategory'
+            type: array
+          propertyNames:
+            $ref: '#/components/schemas/Category'
+          type: object
+          title: Categories
+          description: Attack categories and their subcategories
+          example:
+            COMPLIANCE:
+            - OWASP
+            - NIST
+            SAFETY:
+            - BIAS
+            SECURITY:
+            - ADVERSARIAL_SUFFIX
+            - JAILBREAK
+      type: object
+      required:
+      - categories
+      title: StaticJobMetadata
+      description: Enhanced metadata for static attack jobs with validation.
+    StaticJobRemediationRecommendationSchema:
+      properties:
+        runtime_security_policy_configuration:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/RuntimeSecurityPolicySchema'
+            type: array
+          - type: 'null'
+          title: Runtime Security Policy Configuration
+          description: Recommended runtime security policy configuration
+        other_measures:
+          items:
+            $ref: '#/components/schemas/StaticJobRemediationSchema'
+          type: array
+          title: Other Measures
+          description: List of applicable remediations for static job
+      type: object
+      title: StaticJobRemediationRecommendationSchema
+      description: Remediation recommendations with security profile and other remediations.
+        To build and store in db
+    StaticJobRemediationSchema:
+      properties:
+        mapping_remediation_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Mapping Remediation Id
+          description: UUID from remediations.csv identifying this remediation
+        subcategories:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Subcategories
+          description: Subcategories this remediation applies to
+        effectiveness:
+          type: integer
+          title: Effectiveness
+          description: Effectiveness rating of this remediation (higher is more effective)
+          default: 0
+        ease_of_implementation:
+          type: integer
+          title: Ease Of Implementation
+          description: Ease of implementation rating (higher is easier to implement)
+          default: 0
+        priority:
+          type: integer
+          title: Priority
+          description: Priority level for implementing this remediation (LOW, MEDIUM,
+            HIGH)
+          default: 0
+        remediation:
+          type: string
+          title: Remediation
+          description: Remediation recommendation title
+        description:
+          type: string
+          title: Description
+          description: Detailed description of the remediation
+        resource_links:
+          items:
+            type: string
+          type: array
+          title: Resource Links
+          description: URLs for additional resources and documentation
+        categories:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Categories
+          description: Categories this remediation applies to (e.g., Security, Safety)
+      type: object
+      required:
+      - remediation
+      - description
+      title: StaticJobRemediationSchema
+      description: Static Job Individual remediation.
+    StaticJobReportSchema:
+      properties:
+        asr:
+          anyOf:
+          - type: number
+            maximum: 100
+            minimum: 0
+          - type: 'null'
+          title: Asr
+          description: Attack Success Rate percentage (0-100)
+        score:
+          anyOf:
+          - type: number
+            maximum: 100
+            minimum: 0
+          - type: 'null'
+          title: Score
+          description: Overall job performance score (0-100)
+        security_report:
+          anyOf:
+          - $ref: '#/components/schemas/CategoryReportSchema'
+          - type: 'null'
+          description: Security risk overview widget
+        safety_report:
+          anyOf:
+          - $ref: '#/components/schemas/CategoryReportSchema'
+          - type: 'null'
+          description: Safety risk overview widget
+        brand_report:
+          anyOf:
+          - $ref: '#/components/schemas/CategoryReportSchema'
+          - type: 'null'
+          description: Brand reputation risk overview widget
+        compliance_report:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/ComplianceReportSchema'
+            type: array
+          - type: 'null'
+          title: Compliance Report
+          description: Compliance widget with all frameworks
+        severity_report:
+          $ref: '#/components/schemas/SeverityReportSchema'
+          description: Breakdown of all successful attacks by severity level for the
+            entire job
+        report_summary:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Report Summary
+          description: Report summary from the LLM for the statics job run
+        recommendations:
+          anyOf:
+          - $ref: '#/components/schemas/StaticJobRemediationRecommendationSchema'
+          - type: 'null'
+          description: Remediation recommendations with security profile and actionable
+            fixes
+      type: object
+      required:
+      - severity_report
+      title: StaticJobReportSchema
+      description: Complete static job report data structure.
+    StaticJobReportStats:
+      properties:
+        output_completion_percentage:
+          type: number
+          minimum: 0
+          title: Output Completion Percentage
+          description: Percentage of attack outputs that completed successfully (0-100)
+        partial_report_unlocked:
+          type: boolean
+          title: Partial Report Unlocked
+          description: Whether user has unlocked this partial report with a credit
+          default: false
+        partial_report_unlocked_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Partial Report Unlocked At
+          description: Timestamp when the partial report was unlocked
+        report_summary:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Report Summary
+          description: Report summary from the LLM for the statics job run
+      type: object
+      required:
+      - output_completion_percentage
+      title: StaticJobReportStats
+      description: 'Report statistics for static jobs stored in job.report_stats JSONB
+        field.
+
+        Tracks output completion and partial report unlock status.
+
+        '
+    StatusQueryParam:
+      type: string
+      enum:
+      - SUCCESSFUL
+      - FAILED
+      title: StatusQueryParam
+    StreamDetailResponseSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Job identifier
+        target_id:
+          type: string
+          format: uuid
+          title: Target Id
+          description: Target identifier
+        stream_idx:
+          type: integer
+          title: Stream Idx
+          description: Stream index
+          default: 0
+        iteration:
+          type: integer
+          title: Iteration
+          description: Iteration
+          default: 0
+        goal_id:
+          type: string
+          format: uuid
+          title: Goal Id
+          description: Goal identifier
+        goal:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal
+          description: Goal to use in the backend
+        marked_safe:
+          type: boolean
+          title: Marked Safe
+          description: Marked safe
+          default: false
+        stream_type:
+          anyOf:
+          - $ref: '#/components/schemas/StreamType'
+          - type: 'null'
+          default: NORMAL
+        threat:
+          type: boolean
+          title: Threat
+          description: Indicates if it is a threat
+          default: false
+        first_threat_iteration:
+          anyOf:
+          - $ref: '#/components/schemas/StreamIterationDataSchema'
+          - type: 'null'
+          description: First threat iteration data (denormalized JSONB for performance)
+        created_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Created At
+        updated_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Updated At
+        extra_info:
+          additionalProperties: true
+          type: object
+          title: Extra Info
+          description: Extra information
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Stream schema version
+        iterations:
+          items:
+            $ref: '#/components/schemas/StreamIterationDataSchema'
+          type: array
+          title: Iterations
+          description: List of iterations
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - job_id
+      - target_id
+      - goal_id
+      title: StreamDetailResponseSchema
+    StreamIterationDataSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Job identifier
+        stream_id:
+          type: string
+          format: uuid
+          title: Stream Id
+          description: Stream identifier
+        goal_id:
+          type: string
+          format: uuid
+          title: Goal Id
+          description: Goal identifier
+        iteration:
+          type: integer
+          minimum: 0
+          title: Iteration
+          description: Iteration number
+        prompt:
+          type: string
+          minLength: 1
+          title: Prompt
+          description: The attack prompt
+        techniques:
+          type: string
+          title: Techniques
+          description: Techniques used in the attack
+        improvement:
+          type: string
+          title: Improvement
+          description: Improvement strategy for next iteration
+        prompts_objective:
+          type: string
+          title: Prompts Objective
+          description: Objective of the prompt
+        summary:
+          type: string
+          title: Summary
+          description: Summary of the attack
+        output:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Output
+          description: Best target output (highest score)
+        score:
+          anyOf:
+          - type: integer
+            maximum: 10
+            minimum: 0
+          - type: 'null'
+          title: Score
+          description: Best judge score
+          default: 0
+        judge_reasoning:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Judge Reasoning
+          description: Judge reasoning for best output
+        threat:
+          type: boolean
+          title: Threat
+          description: Whether this is a threat (score == 3)
+          default: false
+        created_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Created At
+        updated_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Updated At
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Extra information
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Stream Iter data schema version
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - job_id
+      - stream_id
+      - goal_id
+      - iteration
+      - prompt
+      - techniques
+      - improvement
+      - prompts_objective
+      - summary
+      title: StreamIterationDataSchema
+      description: Main stream iteration data - one row per iteration.
+    StreamListResponseSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        data:
+          items:
+            $ref: '#/components/schemas/StreamSchema'
+          type: array
+          title: Data
+          description: List of streams
+      type: object
+      required:
+      - pagination
+      - data
+      title: StreamListResponseSchema
+      description: Response schema for listing attacks following common pagination
+        pattern.
+    StreamSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Job identifier
+        target_id:
+          type: string
+          format: uuid
+          title: Target Id
+          description: Target identifier
+        stream_idx:
+          type: integer
+          title: Stream Idx
+          description: Stream index
+          default: 0
+        iteration:
+          type: integer
+          title: Iteration
+          description: Iteration
+          default: 0
+        goal_id:
+          type: string
+          format: uuid
+          title: Goal Id
+          description: Goal identifier
+        goal:
+          anyOf:
+          - $ref: '#/components/schemas/GoalSchema'
+          - type: string
+          - type: 'null'
+          title: Goal
+          description: Goal to use in the backend
+        marked_safe:
+          type: boolean
+          title: Marked Safe
+          description: Marked safe
+          default: false
+        stream_type:
+          anyOf:
+          - $ref: '#/components/schemas/StreamType'
+          - type: 'null'
+          default: NORMAL
+        threat:
+          type: boolean
+          title: Threat
+          description: Indicates if it is a threat
+          default: false
+        first_threat_iteration:
+          anyOf:
+          - $ref: '#/components/schemas/StreamIterationDataSchema'
+          - type: 'null'
+          description: First threat iteration data (denormalized JSONB for performance)
+        created_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Created At
+        updated_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Updated At
+        extra_info:
+          additionalProperties: true
+          type: object
+          title: Extra Info
+          description: Extra information
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Stream schema version
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - job_id
+      - target_id
+      - goal_id
+      title: StreamSchema
+    StreamType:
+      type: string
+      enum:
+      - NORMAL
+      - ADVERSARIAL
+      title: StreamType
+    SubCategoryModel:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Unique identifier
+        display_name:
+          type: string
+          title: Display Name
+          description: Frontend display name
+        description:
+          type: string
+          title: Description
+          description: Description
+        preselect:
+          type: boolean
+          title: Preselect
+          description: Whether this subcategory should be preselected in UI
+          default: true
+        prerequisites:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/PrerequisiteModel'
+            type: array
+          - type: 'null'
+          title: Prerequisites
+          description: List of prerequisites for this subcategory
+        active:
+          type: boolean
+          title: Active
+          description: Whether this subcategory is active
+          default: true
+      type: object
+      required:
+      - id
+      - display_name
+      - description
+      title: SubCategoryModel
+      description: Pydantic model for subcategory data
+    SubCategoryStatsSchema:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Unique identifier
+        display_name:
+          type: string
+          title: Display Name
+          description: Frontend display name
+        description:
+          type: string
+          title: Description
+          description: Description
+        preselect:
+          type: boolean
+          title: Preselect
+          description: Whether this subcategory should be preselected in UI
+          default: true
+        prerequisites:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/PrerequisiteModel'
+            type: array
+          - type: 'null'
+          title: Prerequisites
+          description: List of prerequisites for this subcategory
+        active:
+          type: boolean
+          title: Active
+          description: Whether this subcategory is active
+          default: true
+        successful:
+          type: integer
+          title: Successful
+          description: Number of successful attacks (threat=True)
+        failed:
+          type: integer
+          title: Failed
+          description: Number of failed attacks (threat=False)
+        total:
+          type: integer
+          title: Total
+          description: Total attacks for this subcategory (successful + failed)
+          default: 0
+      type: object
+      required:
+      - id
+      - display_name
+      - description
+      - successful
+      - failed
+      title: SubCategoryStatsSchema
+      description: Statistics for a specific subcategory.
+    TargetAdditionalContext:
+      properties:
+        base_model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Base Model
+          description: Base model name (e.g., GPT-4, Claude)
+        core_architecture:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Core Architecture
+          description: Core architecture details
+        system_prompt:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: System Prompt
+          description: System prompt
+        languages_supported:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Languages Supported
+          description: Supported languages
+        banned_keywords:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Banned Keywords
+          description: Banned keywords/phrases
+        tools_accessible:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Tools Accessible
+          description: Accessible tools/capabilities
+      type: object
+      title: TargetAdditionalContext
+      description: 'Additional context - used in create/update API requests and stored
+        in DB/GCS.
+
+
+        Single value fields are strings.
+
+        List fields are lists of strings.
+
+        '
+    TargetBackground:
+      properties:
+        industry:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Industry
+          description: Target's industry (e.g., Healthcare, Finance)
+        use_case:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Use Case
+          description: Primary use case (e.g., Customer Support, Code Assistant)
+        competitors:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Competitors
+          description: Known competitor products
+      type: object
+      title: TargetBackground
+      description: 'Target background - used in create/update API requests and stored
+        in DB/GCS.
+
+
+        Required fields for activation:
+
+        - industry (string, required)
+
+        - use_case (string, required)
+
+
+        Optional field:
+
+        - competitors (list of strings)
+
+        '
+    TargetConnectionType:
+      type: string
+      enum:
+      - DATABRICKS
+      - BEDROCK
+      - OPENAI
+      - HUGGING_FACE
+      - CUSTOM
+      - REST
+      - STREAMING
+      title: TargetConnectionType
+      description: Connection type/provider for the target.
+    TargetJobRequest:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+          description: Target UUID
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Target configuration version
+      type: object
+      required:
+      - uuid
+      title: TargetJobRequest
+      description: Enhanced request schema for targeting specific targets.
+    TargetMetadata:
+      properties:
+        multi_turn:
+          type: boolean
+          title: Multi Turn
+          description: Whether target supports multi-turn conversations (Probe 2 result)
+          default: false
+        multi_turn_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Multi Turn Error Message
+          description: Concise error message if Probe 2 failed
+          examples:
+          - Session ID extraction failed
+          - Assistant role not configured
+        rate_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rate Limit
+          description: Current rate limit value
+          examples:
+          - 996
+        rate_limit_enabled:
+          type: boolean
+          title: Rate Limit Enabled
+          description: Whether rate limiting is enabled
+          default: false
+        rate_limit_error_code:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rate Limit Error Code
+          description: HTTP status code for rate limit errors
+          examples:
+          - 429
+        rate_limit_error_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rate Limit Error Json
+          description: JSON structure of rate limit error response
+          examples:
+          - error:
+              code: rate_limit_exceeded
+              message: 'Rate limit reached for o1-preview on requests per min (RPM):
+                Limit 20, Used 20, Requested 1. Please try again in 3s. Visit https://platform.openai.com/account/rate-limits
+                to learn more.'
+              param: 'null'
+              type: requests
+        rate_limit_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Rate Limit Error Message
+          description: Raw error message string for rate limit errors
+          examples:
+          - 'Rate limit reached for o1-preview on requests per min (RPM): Limit 20,
+            Used 20, Requested 1. Please try again in 3s.'
+        content_filter_enabled:
+          type: boolean
+          title: Content Filter Enabled
+          description: Whether content filtering is enabled
+          default: false
+        content_filter_error_code:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Content Filter Error Code
+          description: HTTP status code for content filter errors
+          examples:
+          - 400
+        content_filter_error_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Content Filter Error Json
+          description: JSON structure of content filter error response
+          examples:
+          - error:
+              code: invalid_prompt
+              message: 'Invalid prompt: your prompt was flagged as potentially violating
+                our usage policy. Please try again with a different prompt.'
+              type: invalid_request_error
+        content_filter_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Content Filter Error Message
+          description: Raw error message string for content filter errors
+          examples:
+          - 'Invalid prompt: your prompt was flagged as potentially violating our
+            usage policy. Please try again with a different prompt.'
+        probe_message:
+          type: string
+          title: Probe Message
+          default: Hello, this is a test message from the red team validation system.
+        request_timeout:
+          type: number
+          title: Request Timeout
+          description: Request timeout in seconds
+          default: 110
+          examples:
+          - 110
+      type: object
+      title: TargetMetadata
+      description: Metadata stored in the database for targets (user-provided + computed
+        fields).
+    TargetReferenceSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        name:
+          type: string
+          title: Name
+          description: Target name
+          examples:
+          - GPT 4.1 Nano
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Optional target description
+          default: null
+          examples:
+          - AI model for testing
+        target_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetType'
+          - type: 'null'
+          description: Type of target
+        connection_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetConnectionType'
+          - type: 'null'
+          description: Connection type/provider for the target
+          examples:
+          - CUSTOM
+          - OPENAI
+          - BEDROCK
+        api_endpoint_type:
+          anyOf:
+          - $ref: '#/components/schemas/ApiEndpointType'
+          - type: 'null'
+          description: Accessibility type of the API endpoint
+          examples:
+          - PUBLIC
+          - PRIVATE
+          - NETWORK_BROKER
+        response_mode:
+          anyOf:
+          - $ref: '#/components/schemas/ResponseMode'
+          - type: 'null'
+          description: Response mode for API interactions
+          examples:
+          - REST
+          - STREAMING
+        session_supported:
+          type: boolean
+          title: Session Supported
+          description: Whether target supports session for multi-turn conversations
+          default: false
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Additional configuration or metadata for the target
+          default: null
+          examples:
+          - custom_key: custom_value
+        status:
+          $ref: '#/components/schemas/TargetStatus'
+          description: Target status
+        active:
+          type: boolean
+          title: Active
+          description: Whether target is active
+        validated:
+          type: boolean
+          title: Validated
+          description: Whether target is validated
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Configuration version
+        secret_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Secret Version
+          description: Secret Manager version for connection_params. When present,
+            sensitive connection data is stored in Secret Manager. When None, connection_params
+            are stored in GCS (legacy).
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+          description: User ID of target creator
+        updated_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updated By User Id
+          description: User ID of last target updater
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Last update timestamp
+        target_metadata:
+          $ref: '#/components/schemas/TargetMetadata'
+          description: Target metadata and configuration options
+        target_background:
+          anyOf:
+          - $ref: '#/components/schemas/TargetBackground'
+          - type: 'null'
+          description: 'Target background info: industry, use_case, competitors'
+        profiling_status:
+          anyOf:
+          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: 'null'
+          description: Status of the profiling workflow
+        additional_context:
+          anyOf:
+          - $ref: '#/components/schemas/TargetAdditionalContext'
+          - type: 'null'
+          description: Additional context with source tracking (user + profiler)
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - name
+      - status
+      - active
+      - validated
+      - created_at
+      - updated_at
+      title: TargetReferenceSchema
+    TargetStatus:
+      type: string
+      enum:
+      - DRAFT
+      - VALIDATING
+      - VALIDATED
+      - ACTIVE
+      - INACTIVE
+      - FAILED
+      - PENDING_AUTH
+      title: TargetStatus
+      description: Status enumeration for scan targets.
+    TargetType:
+      type: string
+      enum:
+      - APPLICATION
+      - AGENT
+      - MODEL
+      title: TargetType
+      description: Target Types Available
+    TechniqueModel:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Technique unique identifier
+        display_name:
+          type: string
+          title: Display Name
+          description: Technique display name for frontend
+        compliance_id:
+          type: string
+          title: Compliance Id
+          description: Associated compliance framework ID
+        description:
+          type: string
+          title: Description
+          description: Technique description
+        link:
+          type: string
+          title: Link
+          description: Technique documentation link
+        version:
+          type: string
+          title: Version
+          description: Technique version
+        active:
+          type: boolean
+          title: Active
+          description: Whether technique is active
+      type: object
+      required:
+      - id
+      - display_name
+      - compliance_id
+      - description
+      - link
+      - version
+      - active
+      title: TechniqueModel
+      description: Pydantic model for technique data
+    ToxicContentGuardrailSchema:
+      properties:
+        moderate:
+          $ref: '#/components/schemas/GuardrailAction'
+          description: 'Action for moderate toxicity: ''allow'', ''block'''
+          default: BLOCK
+        high:
+          $ref: '#/components/schemas/GuardrailAction'
+          description: 'Action for high toxicity: ''allow'', ''block'''
+          default: BLOCK
+      type: object
+      title: ToxicContentGuardrailSchema
+      description: Guardrail configuration for toxic content with severity levels.
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+ExternalTags:
+  Categories:
+    title: Categories
+    description: Operations for managing scan categories.
+    tags:
+    - Categories
+  CustomAttack:
+    title: CustomAttack
+    description: Operations for custom attack configurations and prompts.
+    tags:
+    - CustomAttack
+  ErrorLogs:
+    title: ErrorLogs
+    description: Operations for retrieving and managing error logs.
+    tags:
+    - ErrorLogs
+  Dashboard:
+    title: Dashboard
+    description: Operations for dashboard data and statistics.
+    tags:
+    - Dashboard
+  HealthChecks:
+    title: HealthChecks
+    description: Operations related to health checks of the data plane service.
+    tags:
+    - HealthChecks
+  Quota:
+    title: Quota
+    description: Operations for quota management and limits.
+    tags:
+    - Quota
+  Scan:
+    title: Scan
+    description: Operations for creating and managing scan jobs.
+    tags:
+    - Scan
+  Report:
+    title: Report
+    description: Operations for generating and retrieving scan job reports for static
+      and dynamic.
+    tags:
+    - Report
+  Sentiment:
+    title: Sentiment
+    description: Operations for managing sentiment and scan report summaries.
+    tags:
+    - Sentiment
+paths:
+  /ready:
+    get:
+      summary: Readiness
+      description: Retrieve the ready details through this Application Programming
+        Interface endpoint.
+      operationId: readiness_ready_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                title: Response Readiness Ready Get
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - HealthChecks
+  /liveness:
+    get:
+      summary: Liveness
+      description: Retrieve the liveness details through this Application Programming
+        Interface endpoint.
+      operationId: liveness_liveness_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: boolean
+                type: object
+                title: Response Liveness Liveness Get
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - HealthChecks
+  /v1/scan:
+    post:
+      summary: Create scan
+      description: Create a new scan target.
+      operationId: create_job_v1_scan_post
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - Scan
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobCreateRequestSchema'
+    get:
+      summary: List scans
+      description: List jobs with filtering and pagination.
+      operationId: list_jobs_v1_scan_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Number of jobs to return (1-100)
+          default: 50
+          title: Limit
+        description: Number of jobs to return (1-100)
+      - name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of jobs to skip for pagination
+          default: 0
+          title: Skip
+        description: Number of jobs to skip for pagination
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/JobStatusFilter'
+          - type: 'null'
+          description: Filter by job status
+          title: Status
+        description: Filter by job status
+      - name: job_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/JobType'
+          - type: 'null'
+          description: Filter by job type
+          title: Job Type
+        description: Filter by job type
+      - name: search
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            maxLength: 255
+          - type: 'null'
+          description: Search jobs by name
+          title: Search
+        description: Search jobs by name
+      - name: target_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          description: Filter by target UUID
+          title: Target Id
+        description: Filter by target UUID
+      tags:
+      - Scan
+  /v1/scan/{job_id}:
+    get:
+      summary: Get scan details
+      description: Get a job by its ID.
+      operationId: get_job_v1_scan__job_id__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - Scan
+  /v1/scan/{job_id}/abort:
+    post:
+      summary: Abort scan
+      description: Abort a running job by cancelling its workflow and updating status.
+      operationId: abort_job_v1_scan__job_id__abort_post
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobAbortResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - Scan
+  /v1/categories:
+    get:
+      summary: Get all categories with subcategories
+      description: Get all available categories with their subcategories.
+      operationId: get_all_categories_v1_categories_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/CategoryModel'
+                type: array
+                title: Response Get All Categories V1 Categories Get
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - Categories
+  /v1/report/static/{job_id}/list-attacks:
+    get:
+      summary: List attacks for a scan
+      description: List attacks with filtering and pagination.
+      operationId: list_attacks_v1_report_static__job_id__list_attacks_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttackListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Number of attacks to return (1-100)
+          default: 50
+          title: Limit
+        description: Number of attacks to return (1-100)
+      - name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of attacks to skip for pagination
+          default: 0
+          title: Skip
+        description: Number of attacks to skip for pagination
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/AttackStatus'
+          - type: 'null'
+          description: Filter by attack status
+          title: Status
+        description: Filter by attack status
+      - name: attack_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/AttackType'
+          - type: 'null'
+          description: Filter by attack type
+          title: Attack Type
+        description: Filter by attack type
+      - name: category
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/Category'
+          - type: 'null'
+          description: Filter by attack category
+          title: Category
+        description: Filter by attack category
+      - name: sub_category
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/SecuritySubCategory'
+          - $ref: '#/components/schemas/SafetySubCategory'
+          - $ref: '#/components/schemas/BrandSubCategory'
+          - type: 'null'
+          description: Filter by attack subcategory
+          title: Sub Category
+        description: Filter by attack subcategory
+      - name: threat
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Filter by threat status
+          title: Threat
+        description: Filter by threat status
+      - name: severity
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/SeverityFilter'
+          - type: 'null'
+          description: Filter by severity level
+          title: Severity
+        description: Filter by severity level
+      tags:
+      - Report
+  /v1/report/static/{job_id}/attack/{attack_id}:
+    get:
+      summary: Get attack details
+      description: Get detailed attack information including outputs and framework
+        techniques.
+      operationId: get_attack_detail_v1_report_static__job_id__attack__attack_id__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttackDetailResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: attack_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Attack Id
+      tags:
+      - Report
+  /v1/report/static/{job_id}/report:
+    get:
+      summary: Get attack library report
+      description: Get attack library report for a job.  Raises ForbiddenError if
+        report is partially complete and locked.
+      operationId: get_attack_report_v1_report_static__job_id__report_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StaticJobReportSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - Report
+  /v1/report/static/{job_id}/remediation:
+    get:
+      summary: Get attack library scan remediation
+      description: Get other remediation measures for a static job.
+      operationId: get_static_remediations_v1_report_static__job_id__remediation_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemediationResponseSchema'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - Report
+  /v1/report/static/{job_id}/runtime-policy-config:
+    get:
+      summary: Get attack library runtime security profile
+      description: Get Runtime security profile for a static job.
+      operationId: get_static_runtime_security_policy_config_v1_report_static__job_id__runtime_policy_config_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeSecurityProfileResponseSchema'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - Report
+  /v1/report/dynamic/{job_id}/report:
+    get:
+      summary: Get agent scan report
+      description: Get dynamic job report for a job.
+      operationId: get_dynamic_job_report_v1_report_dynamic__job_id__report_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DynamicJobReportSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - Report
+  /v1/report/dynamic/{job_id}/remediation:
+    get:
+      summary: Get agent scan rememdiation
+      description: Get other remediation measures for a dynamic job.
+      operationId: get_dynamic_remediations_v1_report_dynamic__job_id__remediation_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemediationResponseSchema'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - Report
+  /v1/report/dynamic/{job_id}/runtime-policy-config:
+    get:
+      summary: Get agent scan runtime security profile
+      description: Get Runtime security profile for a dynamic job.
+      operationId: get_dynamic_runtime_security_policy_config_v1_report_dynamic__job_id__runtime_policy_config_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeSecurityProfileResponseSchema'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - Report
+  /v1/report/dynamic/{job_id}/list-goals:
+    get:
+      summary: List agent scan goals
+      description: Get the goals for a job.
+      operationId: list_dynamic_job_goals_v1_report_dynamic__job_id__list_goals_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GoalListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of goals to skip for pagination
+          default: 0
+          title: Skip
+        description: Number of goals to skip for pagination
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Number of goals to return (1-100)
+          default: 20
+          title: Limit
+        description: Number of goals to return (1-100)
+      - name: count
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Include total count of goals
+          default: true
+          title: Count
+        description: Include total count of goals
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/StatusQueryParam'
+          - type: 'null'
+          description: Filter by status
+          title: Status
+        description: Filter by status
+      - name: goal_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/GoalTypeQueryParam'
+          - type: 'null'
+          description: Filter by goal type
+          title: Goal Type
+        description: Filter by goal type
+      - name: search
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Search string to filter goals
+          title: Search
+        description: Search string to filter goals
+      tags:
+      - Report
+  /v1/report/dynamic/{job_id}/goal/{goal_id}/list-streams:
+    get:
+      summary: List agent scan goal deatils
+      description: Get streams for a specific goal in a job.
+      operationId: list_dynamic_job_streams_v1_report_dynamic__job_id__goal__goal_id__list_streams_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: goal_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Goal Id
+      tags:
+      - Report
+  /v1/report/dynamic/stream/{stream_id}:
+    get:
+      summary: List agent scan stream details
+      description: Retrieve the {stream id} details through this Application Programming
+        Interface endpoint.
+      operationId: get_stream_detail_v1_report_dynamic_stream__stream_id__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamDetailResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: stream_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Stream Id
+      tags:
+      - Report
+  /v1/report/{job_id}/download:
+    get:
+      summary: Download report
+      description: Download report files for a job.
+      operationId: download_report_v1_report__job_id__download_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: file_format
+        in: query
+        required: true
+        schema:
+          $ref: '#/components/schemas/FileFormat'
+          description: Format of the report file (CSV, JSON, or ALL)
+        description: Format of the report file (CSV, JSON, or ALL)
+      tags:
+      - Report
+  /v1/report/{job_id}/generate-partial-report:
+    post:
+      summary: Generate partial scan report
+      description: 'Unlock a partial report by consuming a quota credit.  This endpoint:
+        - Validates the job is PARTIALLY_COMPLETE - Consumes 1 quota credit of the
+        job type - Unlocks the report for viewing  **Returns:** - Updated job information
+        with unlocked report.'
+      operationId: generate_partial_job_report_v1_report__job_id__generate_partial_report_post
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - Report
+  /v1/report/static/{job_id}/attack-multi-turn/{attack_id}:
+    get:
+      summary: Get multi-turn attack details
+      description: Get detailed multi-turn attack information including outputs and
+        framework techniques.
+      operationId: get_attack_multi_turn_detail_v1_report_static__job_id__attack_multi_turn__attack_id__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttackMultiTurnDetailResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: attack_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Attack Id
+      tags:
+      - Report
+  /v1/metering/quota:
+    post:
+      summary: Get quota summary
+      description: Get aggregated quota summary for the current TSG (POST endpoint
+        for backward compatibility).
+      operationId: post_quota_summary_v1_metering_quota_post
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuotaSummarySchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - Quota
+  /v1/custom-attacks/report/{job_id}:
+    get:
+      summary: Get custom attack Report
+      description: Get comprehensive custom attack report.
+      operationId: get_custom_attack_report_v1_custom_attacks_report__job_id__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomAttackReportResponse'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - CustomAttack
+  /v1/custom-attacks/report/{job_id}/prompt-sets:
+    get:
+      summary: Get prompt sets
+      description: Get prompt sets with filtering and pagination.
+      operationId: get_prompt_sets_v1_custom_attacks_report__job_id__prompt_sets_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptSetsReportResponse'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: property_filters
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: JSON string of property filters
+          title: Property Filters
+        description: JSON string of property filters
+      - name: is_threat
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Filter by threat status
+          title: Is Threat
+        description: Filter by threat status
+      - name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Maximum number of records to return
+          default: 20
+          title: Limit
+        description: Maximum number of records to return
+      tags:
+      - CustomAttack
+  /v1/custom-attacks/report/{job_id}/prompt-set/{prompt_set_id}/prompts:
+    get:
+      summary: Get prompts by set
+      description: Get prompts for a specific prompt set with pagination.
+      operationId: get_prompts_by_set_v1_custom_attacks_report__job_id__prompt_set__prompt_set_id__prompts_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PromptDetailResponse'
+                title: Response Get Prompts By Set V1 Custom Attacks Report  Job Id  Prompt
+                  Set  Prompt Set Id  Prompts Get
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: prompt_set_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Id
+      - name: is_threat
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Filter by threat status
+          title: Is Threat
+        description: Filter by threat status
+      - name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Maximum number of records to return
+          default: 20
+          title: Limit
+        description: Maximum number of records to return
+      tags:
+      - CustomAttack
+  /v1/custom-attacks/report/{job_id}/prompt/{prompt_id}:
+    get:
+      summary: Get prompt details
+      description: Get detailed information for a specific prompt.
+      operationId: get_prompt_detail_v1_custom_attacks_report__job_id__prompt__prompt_id__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptDetailResponse'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: prompt_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Id
+      tags:
+      - CustomAttack
+  /v1/custom-attacks/job/{job_id}/list-custom-attacks:
+    get:
+      summary: List custom attacks
+      description: List custom attacks with V2 features.
+      operationId: list_custom_attacks_v1_custom_attacks_job__job_id__list_custom_attacks_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomAttacksListResponse'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          description: Maximum number of records to return
+          default: 100
+          title: Limit
+        description: Maximum number of records to return
+      - name: threat
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: 'Filter by threat status: true for successful attacks, false
+            for failed attacks'
+          title: Threat
+        description: 'Filter by threat status: true for successful attacks, false
+          for failed attacks'
+      - name: prompt_set_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by prompt set ID
+          title: Prompt Set Id
+        description: Filter by prompt set ID
+      - name: property_value
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: JSON string of property filters
+          title: Property Value
+        description: JSON string of property filters
+      tags:
+      - CustomAttack
+  /v1/custom-attacks/job/{job_id}/attack/{attack_id}/list-outputs:
+    get:
+      summary: Get attack outputs
+      description: Get outputs for a specific attack.
+      operationId: get_attack_outputs_v1_custom_attacks_job__job_id__attack__attack_id__list_outputs_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CustomAttackOutputSchema'
+                title: Response Get Attack Outputs V1 Custom Attacks Job  Job Id  Attack  Attack
+                  Id  List Outputs Get
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: attack_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Attack Id
+      tags:
+      - CustomAttack
+  /v1/custom-attacks/job/{job_id}/property-stats:
+    get:
+      summary: Get property stats
+      description: Get property-based statistics for custom attacks.
+      operationId: get_property_stats_v1_custom_attacks_job__job_id__property_stats_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: true
+                title: Response Get Property Stats V1 Custom Attacks Job  Job Id  Property
+                  Stats Get
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - CustomAttack
+  /v1/error-log/job/{job_id}:
+    get:
+      summary: List error logs for a scan
+      description: List error logs for a specific job.
+      operationId: list_error_logs_for_job_v1_error_log_job__job_id__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorLogListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Number of attacks to return (1-100)
+          default: 5
+          title: Limit
+        description: Number of attacks to return (1-100)
+      - name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of attacks to skip for pagination
+          default: 0
+          title: Skip
+        description: Number of attacks to skip for pagination
+      tags:
+      - ErrorLogs
+  /v1/dashboard/scan-statistics:
+    get:
+      summary: Get scan statistics and risk profile
+      description: Returns scan counts, target statistics, status breakdown, and risk
+        profile for dashboard display.
+      operationId: get_scan_statistics_v1_dashboard_scan_statistics_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanStatisticsResponseSchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - Dashboard
+  /v1/dashboard/score-trend:
+    get:
+      summary: Get score trend for a target
+      description: Returns time-series risk scores grouped by job type for chart display.
+      operationId: get_score_trend_v1_dashboard_score_trend_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScoreTrendResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: target_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          description: Target UUID to fetch scores for
+          title: Target Id
+        description: Target UUID to fetch scores for
+      - name: date_range
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/DateRangeFilter'
+          description: Predefined date range filter
+          default: LAST_7_DAYS
+        description: Predefined date range filter
+      - name: start_date
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date
+          - type: 'null'
+          description: Custom start date (overrides date_range if both provided)
+          title: Start Date
+        description: Custom start date (overrides date_range if both provided)
+      - name: end_date
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date
+          - type: 'null'
+          description: Custom end date (overrides date_range if both provided)
+          title: End Date
+        description: Custom end date (overrides date_range if both provided)
+      tags:
+      - Dashboard
+  /v1/sentiment:
+    post:
+      summary: Update sentiment scan report
+      description: Create or update sentiment for a job report.
+      operationId: create_or_update_sentiment_v1_sentiment_post
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SentimentResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - Sentiment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SentimentRequestSchema'
+        required: true
+  /v1/sentiment/{job_id}:
+    get:
+      summary: Get sentiment for a scan report
+      description: Guardrail configuration for toxic content with severity levels.
+      operationId: get_job_sentiment_v1_sentiment__job_id__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SentimentResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      tags:
+      - Sentiment

--- a/specs/PaloAltoNetworks-AIRS-RedTeam-management.yaml
+++ b/specs/PaloAltoNetworks-AIRS-RedTeam-management.yaml
@@ -1,0 +1,4081 @@
+openapi: 3.1.0
+info:
+  title: Prisma AIRS Red Teaming Management API
+  version: 0.5.20
+  description: "Red Teaming Management API - Configure and manage security groups\
+    \ and rules for AI/ML model scanning. \xA9 2025 Palo Alto Networks, Inc This Open\
+    \ API spec file was created on February 25, 2026. \xA9 2026 Palo Alto Networks,\
+    \ Inc. Palo Alto Networks is a registered trademark of Palo Alto Networks. A list\
+    \ of our trademarks can be found at [https://www.paloaltonetworks.com/company/trademarks.html](https://www.paloaltonetworks.com/company/trademarks.html).\
+    \ All other marks mentioned herein may be trademarks of their respective companies."
+servers:
+- url: https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane
+security:
+- bearerAuth: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    ApiEndpointType:
+      type: string
+      enum:
+      - PUBLIC
+      - PRIVATE
+      - NETWORK_BROKER
+      title: ApiEndpointType
+      description: API endpoint accessibility type.
+    AuthType:
+      type: string
+      enum:
+      - OAUTH
+      - ACCESS_TOKEN
+      title: AuthType
+    BaseResponseSchema:
+      properties:
+        message:
+          type: string
+          title: Message
+          description: Response message
+        status:
+          type: integer
+          title: Status
+          description: HTTP status code
+      type: object
+      required:
+      - message
+      - status
+      title: BaseResponseSchema
+      description: Standard response schema for simple operations like create, update,
+        delete.
+    BedrockAccessConnectionParams:
+      properties:
+        access_id:
+          type: string
+          title: Access Id
+          description: AWS access key ID
+        access_secret:
+          type: string
+          title: Access Secret
+          description: AWS secret access key
+        session_token:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Session Token
+          description: AWS session token (optional)
+        region:
+          type: string
+          title: Region
+          description: AWS region
+        model_id:
+          type: string
+          title: Model Id
+          description: Bedrock model ID
+      type: object
+      required:
+      - access_id
+      - access_secret
+      - region
+      - model_id
+      title: BedrockAccessConnectionParams
+      description: AWS Bedrock access parameters stored in target_metadata.
+    BedrockAccessConnectionRedactParams:
+      properties:
+        access_id:
+          type: string
+          format: password
+          title: Access Id
+          description: AWS access key ID
+          writeOnly: true
+        access_secret:
+          type: string
+          format: password
+          title: Access Secret
+          description: AWS secret access key
+          writeOnly: true
+        session_token:
+          anyOf:
+          - type: string
+            format: password
+            writeOnly: true
+          - type: 'null'
+          title: Session Token
+          description: AWS session token (optional)
+        region:
+          type: string
+          title: Region
+          description: AWS region
+        model_id:
+          type: string
+          title: Model Id
+          description: Bedrock model ID
+      type: object
+      required:
+      - access_id
+      - access_secret
+      - region
+      - model_id
+      title: BedrockAccessConnectionRedactParams
+      description: AWS Bedrock access parameters stored in target_metadata.
+    Body_upload_prompts_csv_v1_custom_attack_upload_custom_prompts_csv_post:
+      properties:
+        file:
+          type: string
+          format: binary
+          title: File
+      type: object
+      required:
+      - file
+      title: Body_upload_prompts_csv_v1_custom_attack_upload_custom_prompts_csv_post
+    CountByNameSchema:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Name of the item (e.g., target type, status)
+        count:
+          type: integer
+          minimum: 0.0
+          title: Count
+          description: Count of items
+      type: object
+      required:
+      - name
+      - count
+      title: CountByNameSchema
+      description: 'Generic count schema with name field for extensible list structures.
+
+
+        Used in dashboard and other endpoints to provide counts grouped by a name
+        field.
+
+        Frontend-friendly list format for easy iteration.
+
+        '
+    CustomPromptCreateRequestSchema:
+      properties:
+        prompt:
+          type: string
+          title: Prompt
+          description: The prompt text
+        goal:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal
+          description: Goal of the prompt (user-defined or AI-generated)
+        properties:
+          additionalProperties:
+            type: string
+          type: object
+          title: Properties
+          description: Property assignments (property_name -> property_value)
+        prompt_set_id:
+          type: string
+          format: uuid
+          title: Prompt Set Id
+          description: The UUID of the prompt set
+      additionalProperties: false
+      type: object
+      required:
+      - prompt
+      - prompt_set_id
+      title: CustomPromptCreateRequestSchema
+      description: Schema for creating a new custom prompt.
+    CustomPromptListItemSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+          description: Unique identifier
+        prompt:
+          type: string
+          title: Prompt
+          description: The prompt text
+        goal:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal
+          description: Goal of the prompt
+        user_defined_goal:
+          type: boolean
+          title: User Defined Goal
+          description: Whether the goal was user-defined
+        status:
+          type: string
+          title: Status
+          description: Status of the prompt
+        active:
+          type: boolean
+          title: Active
+          description: Whether the prompt is active
+        properties:
+          additionalProperties:
+            type: string
+          type: object
+          title: Properties
+          description: Property assignments
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Last update timestamp
+      type: object
+      required:
+      - uuid
+      - prompt
+      - user_defined_goal
+      - status
+      - active
+      - created_at
+      - updated_at
+      title: CustomPromptListItemSchema
+      description: Schema for custom prompt items in list responses.
+    CustomPromptListSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        data:
+          items:
+            $ref: '#/components/schemas/CustomPromptListItemSchema'
+          type: array
+          title: Data
+          description: List of custom prompts
+      type: object
+      required:
+      - pagination
+      title: CustomPromptListSchema
+      description: Schema for custom prompt list responses.
+    CustomPromptResponseSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+          description: Unique identifier
+        prompt:
+          type: string
+          title: Prompt
+          description: The prompt text
+        goal:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal
+          description: Goal of the prompt
+        user_defined_goal:
+          type: boolean
+          title: User Defined Goal
+          description: Whether the goal was user-defined
+        detector_category:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Detector Category
+          description: Detector category
+        severity:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Severity
+          description: Severity level
+        status:
+          type: string
+          title: Status
+          description: Status of the prompt
+        active:
+          type: boolean
+          title: Active
+          description: Whether the prompt is active
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Additional information
+        prompt_set_id:
+          type: string
+          format: uuid
+          title: Prompt Set Id
+          description: The UUID of the prompt set this prompt belongs to
+        properties:
+          additionalProperties:
+            type: string
+          type: object
+          title: Properties
+          description: Property assignments
+        property_assignments:
+          items:
+            $ref: '#/components/schemas/PropertyAssignmentSchema'
+          type: array
+          title: Property Assignments
+          description: Detailed property assignments
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Last update timestamp
+      type: object
+      required:
+      - uuid
+      - prompt
+      - user_defined_goal
+      - status
+      - active
+      - prompt_set_id
+      - created_at
+      - updated_at
+      title: CustomPromptResponseSchema
+      description: Schema for custom prompt responses.
+    CustomPromptSetArchiveRequestSchema:
+      properties:
+        archive:
+          type: boolean
+          title: Archive
+          description: True to archive, False to unarchive
+      additionalProperties: false
+      type: object
+      required:
+      - archive
+      title: CustomPromptSetArchiveRequestSchema
+      description: Schema for archiving/unarchiving prompt sets.
+    CustomPromptSetCreateRequestSchema:
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          title: Name
+          description: Name of the custom prompt set
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Description of the custom prompt set
+          default: null
+        property_names:
+          items:
+            type: string
+          type: array
+          maxItems: 2
+          title: Property Names
+          description: Property names for this prompt set (max 2)
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      title: CustomPromptSetCreateRequestSchema
+      description: Schema for creating a new custom prompt set.
+    CustomPromptSetListActiveSchema:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/CustomPromptSetReferenceSchema'
+          type: array
+          title: Data
+          description: List of active custom prompt set references
+      type: object
+      title: CustomPromptSetListActiveSchema
+      description: 'Schema for listing active custom prompt sets available for use.
+
+
+        Used by data plane to discover available prompt sets for job creation.
+
+        '
+    CustomPromptSetListItemSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+          description: Unique identifier
+        name:
+          type: string
+          title: Name
+          description: Name of the prompt set
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Description of the prompt set
+          default: null
+        active:
+          type: boolean
+          title: Active
+          description: Whether the prompt set is active
+        archive:
+          type: boolean
+          title: Archive
+          description: Whether the prompt set is archived
+        status:
+          type: string
+          title: Status
+          description: Status of the prompt set
+        stats:
+          anyOf:
+          - $ref: '#/components/schemas/PromptSetStatsSchema'
+          - type: 'null'
+          description: Statistics about the prompt set
+        property_names:
+          items:
+            type: string
+          type: array
+          title: Property Names
+          description: Property names
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+          description: User ID who created the prompt set
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Last update timestamp
+      type: object
+      required:
+      - uuid
+      - name
+      - active
+      - archive
+      - status
+      - created_at
+      - updated_at
+      title: CustomPromptSetListItemSchema
+      description: Schema for custom prompt set items in list responses.
+    CustomPromptSetListSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        data:
+          items:
+            $ref: '#/components/schemas/CustomPromptSetListItemSchema'
+          type: array
+          title: Data
+          description: List of custom prompt sets
+      type: object
+      required:
+      - pagination
+      title: CustomPromptSetListSchema
+      description: Schema for custom prompt set list responses.
+    CustomPromptSetReferenceSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+          description: UUID of the custom prompt set
+        name:
+          type: string
+          title: Name
+          description: Name of the prompt set
+        version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Version
+          description: GCS generation number for snapshot versioning
+        status:
+          type: string
+          title: Status
+          description: Current status of the prompt set
+        active:
+          type: boolean
+          title: Active
+          description: Whether the prompt set is active
+        tsg_id:
+          type: string
+          title: Tsg Id
+          description: Tenant Security Group ID
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Last update timestamp
+      type: object
+      required:
+      - uuid
+      - name
+      - status
+      - active
+      - tsg_id
+      - created_at
+      - updated_at
+      title: CustomPromptSetReferenceSchema
+      description: 'Reference schema for custom prompt sets used by data plane.
+
+
+        Contains minimal information needed for data plane to fetch
+
+        configurations from GCS using the GCS-first pattern.
+
+        '
+    CustomPromptSetResponseSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+          description: Unique identifier
+        name:
+          type: string
+          title: Name
+          description: Name of the prompt set
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Description of the prompt set
+          default: null
+        active:
+          type: boolean
+          title: Active
+          description: Whether the prompt set is active
+        archive:
+          type: boolean
+          title: Archive
+          description: Whether the prompt set is archived
+        status:
+          type: string
+          title: Status
+          description: Status of the prompt set
+        version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Version
+          description: GCS generation number for snapshot versioning
+        stats:
+          anyOf:
+          - $ref: '#/components/schemas/PromptSetStatsSchema'
+          - type: 'null'
+          description: Statistics about the prompt set
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Additional information
+        property_names:
+          items:
+            type: string
+          type: array
+          title: Property Names
+          description: Property names
+        properties:
+          items:
+            $ref: '#/components/schemas/PropertyDefinitionSchema'
+          type: array
+          title: Properties
+          description: Property definitions
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+          description: User ID who created the prompt set
+        updated_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updated By User Id
+          description: User ID who last updated the prompt set
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Last update timestamp
+      type: object
+      required:
+      - uuid
+      - name
+      - active
+      - archive
+      - status
+      - created_at
+      - updated_at
+      title: CustomPromptSetResponseSchema
+      description: Schema for custom prompt set responses.
+    CustomPromptSetUpdateRequestSchema:
+      properties:
+        name:
+          anyOf:
+          - type: string
+            maxLength: 255
+          - type: 'null'
+          title: Name
+          description: Updated name
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Updated description
+        archive:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Archive
+          description: Archive status
+        property_names:
+          anyOf:
+          - items:
+              type: string
+            type: array
+            maxItems: 2
+          - type: 'null'
+          title: Property Names
+          description: Updated property names (max 2)
+      additionalProperties: false
+      type: object
+      title: CustomPromptSetUpdateRequestSchema
+      description: Schema for updating a custom prompt set.
+    CustomPromptSetVersionInfoSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+          description: UUID of the custom prompt set
+        version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Version
+          description: GCS generation number for this version
+        status:
+          type: string
+          title: Status
+          description: Status when this version was created
+        stats:
+          anyOf:
+          - $ref: '#/components/schemas/PromptSetStatsSchema'
+          - type: 'null'
+          description: Prompt statistics when version was created
+        snapshot_created_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Snapshot Created At
+          description: When the snapshot was created
+        is_latest:
+          type: boolean
+          title: Is Latest
+          description: Whether this is the latest version
+      type: object
+      required:
+      - uuid
+      - status
+      - is_latest
+      title: CustomPromptSetVersionInfoSchema
+      description: 'Version information for a custom prompt set snapshot.
+
+
+        Provides metadata about a specific version without full configuration data.
+
+        '
+    CustomPromptUpdateRequestSchema:
+      properties:
+        prompt:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Prompt
+          description: Updated prompt text
+        goal:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal
+          description: Updated goal
+        properties:
+          anyOf:
+          - additionalProperties:
+              type: string
+            type: object
+          - type: 'null'
+          title: Properties
+          description: Updated property assignments
+      additionalProperties: false
+      type: object
+      title: CustomPromptUpdateRequestSchema
+      description: Schema for updating a custom prompt.
+    DashboardOverviewResponseSchema:
+      properties:
+        total_targets:
+          type: integer
+          minimum: 0.0
+          title: Total Targets
+          description: Total number of targets
+        targets_by_type:
+          items:
+            $ref: '#/components/schemas/CountByNameSchema'
+          type: array
+          title: Targets By Type
+          description: Target counts grouped by type (APPLICATION, AGENT, MODEL)
+      type: object
+      required:
+      - total_targets
+      title: DashboardOverviewResponseSchema
+      description: 'Dashboard overview response with target counts.
+
+
+        Endpoint: GET /api/v1/dashboard/overview
+
+        Returns target counts by type in list format for easy frontend iteration.
+
+        '
+    DatabricksConnectionParams:
+      properties:
+        auth_type:
+          $ref: '#/components/schemas/AuthType'
+          description: Auth type
+        access_token:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Access Token
+          description: Databricks access token
+        client_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Client Id
+          description: Databricks client_id
+        secret:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Secret
+          description: Databricks secret
+        workspace_url:
+          type: string
+          title: Workspace Url
+          description: Databricks workscpace_url
+        model_name:
+          type: string
+          title: Model Name
+          description: Databricks model name
+      type: object
+      required:
+      - auth_type
+      - workspace_url
+      - model_name
+      title: DatabricksConnectionParams
+    DatabricksConnectionRedactParams:
+      properties:
+        auth_type:
+          $ref: '#/components/schemas/AuthType'
+          description: Auth type
+        access_token:
+          anyOf:
+          - type: string
+            format: password
+            writeOnly: true
+          - type: 'null'
+          title: Access Token
+          description: Databricks access token
+        client_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Client Id
+          description: Databricks client_id
+        secret:
+          anyOf:
+          - type: string
+            format: password
+            writeOnly: true
+          - type: 'null'
+          title: Secret
+          description: Databricks secret
+        workspace_url:
+          type: string
+          title: Workspace Url
+          description: Databricks workscpace_url
+        model_name:
+          type: string
+          title: Model Name
+          description: Databricks model name
+      type: object
+      required:
+      - auth_type
+      - workspace_url
+      - model_name
+      title: DatabricksConnectionRedactParams
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    HuggingfaceConnectionParams:
+      properties:
+        api_key:
+          type: string
+          title: Api Key
+          description: Huggingface API key for authentication
+          examples:
+          - sk-abxx
+        model_name:
+          type: string
+          title: Model Name
+          description: Huggingface model name for API requests
+          examples:
+          - gpt-4.1-nano
+      type: object
+      required:
+      - api_key
+      - model_name
+      title: HuggingfaceConnectionParams
+      description: Connection parameters specific to huggingface targets
+    HuggingfaceConnectionRedactParams:
+      properties:
+        api_key:
+          type: string
+          format: password
+          title: Api Key
+          description: Huggingface API key for authentication
+          writeOnly: true
+          examples:
+          - sk-abxx
+        model_name:
+          type: string
+          title: Model Name
+          description: Huggingface model name for API requests
+          examples:
+          - gpt-4.1-nano
+      type: object
+      required:
+      - api_key
+      - model_name
+      title: HuggingfaceConnectionRedactParams
+      description: Connection parameters specific to huggingface targets
+    MultiTurnStatefulConfig:
+      properties:
+        type:
+          type: string
+          const: stateful
+          title: Type
+          default: stateful
+        response_id_field:
+          type: string
+          title: Response Id Field
+          description: JSON path to extract session ID from target response (e.g.,
+            'id' for OpenAI responses API)
+          examples:
+          - id
+          - conversation_id
+          - session.id
+        request_id_field:
+          type: string
+          title: Request Id Field
+          description: JSON path to inject session ID in next request (e.g., 'previous_response_id'
+            for OpenAI)
+          examples:
+          - previous_response_id
+          - conversation_id
+          - session_id
+      type: object
+      required:
+      - response_id_field
+      - request_id_field
+      title: MultiTurnStatefulConfig
+      description: 'Configuration for stateful multi-turn targets (session_supported=true).
+
+
+        Stateful targets maintain conversation state on the server side using session
+        IDs.
+
+        The session ID is extracted from responses and injected into subsequent requests.
+
+        '
+    MultiTurnStatelessConfig:
+      properties:
+        type:
+          type: string
+          const: stateless
+          title: Type
+          default: stateless
+        assistant_role:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Assistant Role
+          description: Role name for assistant messages in conversation history (e.g.,
+            'assistant', 'bot', 'model')
+          examples:
+          - assistant
+          - bot
+          - model
+          - ai
+      type: object
+      title: MultiTurnStatelessConfig
+      description: 'Configuration for stateless multi-turn targets (session_supported=false).
+
+
+        Stateless targets require the client to maintain and send conversation history.
+
+        The assistant_role specifies the role name used for assistant messages in
+        the history.
+
+        '
+    OpenAIConnectionParams:
+      properties:
+        api_key:
+          type: string
+          title: Api Key
+          description: OpenAI API key for authentication
+          examples:
+          - sk-abxx
+        model_name:
+          type: string
+          title: Model Name
+          description: OpenAI model name for API requests
+          examples:
+          - gpt-4.1-nano
+      type: object
+      required:
+      - api_key
+      - model_name
+      title: OpenAIConnectionParams
+      description: Connection parameters specific to OpenAI targets
+    OpenAIConnectionRedactParams:
+      properties:
+        api_key:
+          type: string
+          format: password
+          title: Api Key
+          description: OpenAI API key for authentication
+          writeOnly: true
+          examples:
+          - sk-abxx
+        model_name:
+          type: string
+          title: Model Name
+          description: OpenAI model name for API requests
+          examples:
+          - gpt-4.1-nano
+      type: object
+      required:
+      - api_key
+      - model_name
+      title: OpenAIConnectionRedactParams
+      description: Connection parameters specific to OpenAI targets
+    OtherDetails:
+      properties:
+        items:
+          additionalProperties: true
+          type: object
+          title: Items
+      type: object
+      title: OtherDetails
+      description: 'Additional profiler discoveries. Read-only key-value pairs.
+
+
+        Examples: code_execution_capability, internet_access, etc.
+
+        '
+    PaginationSchema:
+      properties:
+        total_items:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Total Items
+      type: object
+      title: PaginationSchema
+    ProfilingStatus:
+      type: string
+      enum:
+      - INIT
+      - QUEUED
+      - IN_PROGRESS
+      - COMPLETED
+      - FAILED
+      title: ProfilingStatus
+      description: Status of target profiling workflow.
+    PromptSetStatsSchema:
+      properties:
+        total_prompts:
+          type: integer
+          title: Total Prompts
+          description: Total number of prompts
+        active_prompts:
+          type: integer
+          title: Active Prompts
+          description: Number of active prompts
+        failed_prompts:
+          type: integer
+          title: Failed Prompts
+          description: Number of failed prompts
+          default: 0
+        validation_prompts:
+          type: integer
+          title: Validation Prompts
+          description: Number of validation prompts
+          default: 0
+        inactive_prompts:
+          type: integer
+          title: Inactive Prompts
+          description: Number of inactive prompts
+      type: object
+      required:
+      - total_prompts
+      - active_prompts
+      - inactive_prompts
+      title: PromptSetStatsSchema
+      description: Schema for prompt set statistics.
+    PropertyAssignmentSchema:
+      properties:
+        property_name:
+          type: string
+          title: Property Name
+          description: Property name (e.g., 'industry', 'role')
+        property_value:
+          type: string
+          title: Property Value
+          description: Property value (e.g., 'healthcare', 'CEO')
+      type: object
+      required:
+      - property_name
+      - property_value
+      title: PropertyAssignmentSchema
+      description: Schema for property name-value assignments.
+    PropertyDefinitionSchema:
+      properties:
+        property_name:
+          type: string
+          title: Property Name
+          description: Property name
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: When the property was created
+      type: object
+      required:
+      - property_name
+      - created_at
+      title: PropertyDefinitionSchema
+      description: Schema for property definitions in a prompt set.
+    PropertyNameCreateRequestSchema:
+      properties:
+        name:
+          type: string
+          maxLength: 256
+          title: Name
+          description: Name of the property
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      title: PropertyNameCreateRequestSchema
+      description: Schema for creating a new property name.
+    PropertyNamesListResponseSchema:
+      properties:
+        data:
+          items:
+            type: string
+          type: array
+          title: Data
+          description: List of property names
+      type: object
+      title: PropertyNamesListResponseSchema
+      description: Schema for property names list responses.
+    PropertyValueCreateRequestSchema:
+      properties:
+        property_name:
+          type: string
+          title: Property Name
+          description: Name of the property
+        property_value:
+          type: string
+          maxLength: 256
+          title: Property Value
+          description: Value for the property
+      additionalProperties: false
+      type: object
+      required:
+      - property_name
+      - property_value
+      title: PropertyValueCreateRequestSchema
+      description: Schema for creating a new property value.
+    PropertyValuesMultipleResponseSchema:
+      properties:
+        data:
+          additionalProperties:
+            items:
+              type: string
+            type: array
+          type: object
+          title: Data
+          description: Dictionary mapping property names to their values
+      type: object
+      title: PropertyValuesMultipleResponseSchema
+      description: Schema for property values for multiple property names.
+    PropertyValuesResponseSchema:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Property name
+        values:
+          items:
+            type: string
+          type: array
+          title: Values
+          description: List of values for this property
+      type: object
+      required:
+      - name
+      title: PropertyValuesResponseSchema
+      description: Schema for property values for a specific property name.
+    ResponseMode:
+      type: string
+      enum:
+      - REST
+      - STREAMING
+      title: ResponseMode
+      description: Response mode for target interactions.
+    RestConnectionParamsBase-Input:
+      properties:
+        api_endpoint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Api Endpoint
+          description: API endpoint URL
+          examples:
+          - https://api.openai.com/v1/responses
+        request_headers:
+          additionalProperties: true
+          type: object
+          title: Request Headers
+          description: Request headers
+          default: null
+          examples:
+          - Authorization: Bearer sk-xxx
+            Content-Type: application/json
+        request_json:
+          additionalProperties: true
+          type: object
+          title: Request Json
+          description: Request JSON
+          default: null
+          examples:
+          - input:
+            - content:
+              - text: '{INPUT}'
+                type: input_text
+              role: user
+            model: gpt-4.1-nano
+        response_json:
+          additionalProperties: true
+          type: object
+          title: Response Json
+          description: Response JSON
+          default: null
+          examples:
+          - content: '{RESPONSE}'
+        response_key:
+          type: string
+          title: Response Key
+          description: Response key
+          default: null
+          examples:
+          - content
+        target_connection_config:
+          anyOf:
+          - $ref: '#/components/schemas/OpenAIConnectionParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionParams'
+          - $ref: '#/components/schemas/DatabricksConnectionParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - type: 'null'
+          title: Target Connection Config
+          description: Target Connection config of type openai/huggingface ..
+        curl:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Curl
+          description: Generated cURL command ready to use (redacted for security)
+          examples:
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
+            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+        multi_turn_config:
+          anyOf:
+          - oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi turn config for stateful or stateless target
+          examples:
+          - 'assistant_role: assistant'
+      type: object
+      title: RestConnectionParamsBase
+      description: Base connection parameters without generated fields.
+    RestConnectionParamsBase-Output:
+      properties:
+        api_endpoint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Api Endpoint
+          description: API endpoint URL
+          examples:
+          - https://api.openai.com/v1/responses
+        request_headers:
+          additionalProperties: true
+          type: object
+          title: Request Headers
+          description: Request headers
+          default: null
+          examples:
+          - Authorization: Bearer sk-xxx
+            Content-Type: application/json
+        request_json:
+          additionalProperties: true
+          type: object
+          title: Request Json
+          description: Request JSON
+          default: null
+          examples:
+          - input:
+            - content:
+              - text: '{INPUT}'
+                type: input_text
+              role: user
+            model: gpt-4.1-nano
+        response_json:
+          additionalProperties: true
+          type: object
+          title: Response Json
+          description: Response JSON
+          default: null
+          examples:
+          - content: '{RESPONSE}'
+        response_key:
+          type: string
+          title: Response Key
+          description: Response key
+          default: null
+          examples:
+          - content
+        target_connection_config:
+          anyOf:
+          - $ref: '#/components/schemas/OpenAIConnectionParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionParams'
+          - $ref: '#/components/schemas/DatabricksConnectionParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - type: 'null'
+          title: Target Connection Config
+          description: Target Connection config of type openai/huggingface ..
+        curl:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Curl
+          description: Generated cURL command ready to use (redacted for security)
+          examples:
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
+            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+        multi_turn_config:
+          anyOf:
+          - oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi turn config for stateful or stateless target
+          examples:
+          - 'assistant_role: assistant'
+      type: object
+      title: RestConnectionParamsBase
+      description: Base connection parameters without generated fields.
+    RestConnectionParamsRedactBase:
+      properties:
+        api_endpoint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Api Endpoint
+          description: API endpoint URL
+          examples:
+          - https://api.openai.com/v1/responses
+        request_headers:
+          additionalProperties: true
+          type: object
+          title: Request Headers
+          description: Request headers
+          default: null
+          examples:
+          - Authorization: Bearer sk-xxx
+            Content-Type: application/json
+        request_json:
+          additionalProperties: true
+          type: object
+          title: Request Json
+          description: Request JSON
+          default: null
+          examples:
+          - input:
+            - content:
+              - text: '{INPUT}'
+                type: input_text
+              role: user
+            model: gpt-4.1-nano
+        response_json:
+          additionalProperties: true
+          type: object
+          title: Response Json
+          description: Response JSON
+          default: null
+          examples:
+          - content: '{RESPONSE}'
+        response_key:
+          type: string
+          title: Response Key
+          description: Response key
+          default: null
+          examples:
+          - content
+        target_connection_config:
+          anyOf:
+          - $ref: '#/components/schemas/OpenAIConnectionRedactParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionRedactParams'
+          - $ref: '#/components/schemas/DatabricksConnectionRedactParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionRedactParams'
+          - type: 'null'
+          title: Target Connection Config
+          description: Target Connection config of type openai/huggingface ..
+        curl:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Curl
+          description: Generated cURL command ready to use (redacted for security)
+          examples:
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
+            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+        multi_turn_config:
+          anyOf:
+          - oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi turn config for stateful or stateless target
+          examples:
+          - 'assistant_role: assistant'
+      type: object
+      title: RestConnectionParamsRedactBase
+    StreamingConnectionParamsBase-Input:
+      properties:
+        api_endpoint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Api Endpoint
+          description: API endpoint URL
+          examples:
+          - https://api.openai.com/v1/responses
+        request_headers:
+          additionalProperties: true
+          type: object
+          title: Request Headers
+          description: Request headers
+          default: null
+          examples:
+          - Authorization: Bearer sk-xxx
+            Content-Type: application/json
+        request_json:
+          additionalProperties: true
+          type: object
+          title: Request Json
+          description: Request JSON
+          default: null
+          examples:
+          - input:
+            - content:
+              - text: '{INPUT}'
+                type: input_text
+              role: user
+            model: gpt-4.1-nano
+        response_json:
+          additionalProperties: true
+          type: object
+          title: Response Json
+          description: Response JSON
+          default: null
+          examples:
+          - content: '{RESPONSE}'
+        response_key:
+          type: string
+          title: Response Key
+          description: Response key
+          default: null
+          examples:
+          - content
+        target_connection_config:
+          anyOf:
+          - $ref: '#/components/schemas/OpenAIConnectionParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionParams'
+          - $ref: '#/components/schemas/DatabricksConnectionParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - type: 'null'
+          title: Target Connection Config
+          description: Target Connection config of type openai/huggingface ..
+        curl:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Curl
+          description: Generated cURL command ready to use (redacted for security)
+          examples:
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
+            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+        multi_turn_config:
+          anyOf:
+          - oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi turn config for stateful or stateless target
+          examples:
+          - 'assistant_role: assistant'
+        response_stop_key:
+          type: string
+          title: Response Stop Key
+        response_stop_value:
+          type: string
+          title: Response Stop Value
+      type: object
+      required:
+      - response_stop_key
+      - response_stop_value
+      title: StreamingConnectionParamsBase
+      description: Base streaming connection parameters without generated fields.
+    StreamingConnectionParamsBase-Output:
+      properties:
+        api_endpoint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Api Endpoint
+          description: API endpoint URL
+          examples:
+          - https://api.openai.com/v1/responses
+        request_headers:
+          additionalProperties: true
+          type: object
+          title: Request Headers
+          description: Request headers
+          default: null
+          examples:
+          - Authorization: Bearer sk-xxx
+            Content-Type: application/json
+        request_json:
+          additionalProperties: true
+          type: object
+          title: Request Json
+          description: Request JSON
+          default: null
+          examples:
+          - input:
+            - content:
+              - text: '{INPUT}'
+                type: input_text
+              role: user
+            model: gpt-4.1-nano
+        response_json:
+          additionalProperties: true
+          type: object
+          title: Response Json
+          description: Response JSON
+          default: null
+          examples:
+          - content: '{RESPONSE}'
+        response_key:
+          type: string
+          title: Response Key
+          description: Response key
+          default: null
+          examples:
+          - content
+        target_connection_config:
+          anyOf:
+          - $ref: '#/components/schemas/OpenAIConnectionParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionParams'
+          - $ref: '#/components/schemas/DatabricksConnectionParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - type: 'null'
+          title: Target Connection Config
+          description: Target Connection config of type openai/huggingface ..
+        curl:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Curl
+          description: Generated cURL command ready to use (redacted for security)
+          examples:
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
+            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+        multi_turn_config:
+          anyOf:
+          - oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi turn config for stateful or stateless target
+          examples:
+          - 'assistant_role: assistant'
+        response_stop_key:
+          type: string
+          title: Response Stop Key
+        response_stop_value:
+          type: string
+          title: Response Stop Value
+      type: object
+      required:
+      - response_stop_key
+      - response_stop_value
+      title: StreamingConnectionParamsBase
+      description: Base streaming connection parameters without generated fields.
+    StreamingConnectionParamsRedactBase:
+      properties:
+        api_endpoint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Api Endpoint
+          description: API endpoint URL
+          examples:
+          - https://api.openai.com/v1/responses
+        request_headers:
+          additionalProperties: true
+          type: object
+          title: Request Headers
+          description: Request headers
+          default: null
+          examples:
+          - Authorization: Bearer sk-xxx
+            Content-Type: application/json
+        request_json:
+          additionalProperties: true
+          type: object
+          title: Request Json
+          description: Request JSON
+          default: null
+          examples:
+          - input:
+            - content:
+              - text: '{INPUT}'
+                type: input_text
+              role: user
+            model: gpt-4.1-nano
+        response_json:
+          additionalProperties: true
+          type: object
+          title: Response Json
+          description: Response JSON
+          default: null
+          examples:
+          - content: '{RESPONSE}'
+        response_key:
+          type: string
+          title: Response Key
+          description: Response key
+          default: null
+          examples:
+          - content
+        target_connection_config:
+          anyOf:
+          - $ref: '#/components/schemas/OpenAIConnectionRedactParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionRedactParams'
+          - $ref: '#/components/schemas/DatabricksConnectionRedactParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionRedactParams'
+          - type: 'null'
+          title: Target Connection Config
+          description: Target Connection config of type openai/huggingface ..
+        curl:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Curl
+          description: Generated cURL command ready to use (redacted for security)
+          examples:
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
+            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+        multi_turn_config:
+          anyOf:
+          - oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi turn config for stateful or stateless target
+          examples:
+          - 'assistant_role: assistant'
+        response_stop_key:
+          type: string
+          title: Response Stop Key
+        response_stop_value:
+          type: string
+          title: Response Stop Value
+      type: object
+      required:
+      - response_stop_key
+      - response_stop_value
+      title: StreamingConnectionParamsRedactBase
+    TargetAdditionalContext:
+      properties:
+        base_model:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Base Model
+          description: Base model name (e.g., GPT-4, Claude)
+        core_architecture:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Core Architecture
+          description: Core architecture details
+        system_prompt:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: System Prompt
+          description: System prompt
+        languages_supported:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Languages Supported
+          description: Supported languages
+        banned_keywords:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Banned Keywords
+          description: Banned keywords/phrases
+        tools_accessible:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Tools Accessible
+          description: Accessible tools/capabilities
+      type: object
+      title: TargetAdditionalContext
+      description: 'Additional context - used in create/update API requests and stored
+        in DB/GCS.
+
+
+        Single value fields are strings.
+
+        List fields are lists of strings.
+
+        '
+    TargetBackground:
+      properties:
+        industry:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Industry
+          description: Target's industry (e.g., Healthcare, Finance)
+        use_case:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Use Case
+          description: Primary use case (e.g., Customer Support, Code Assistant)
+        competitors:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Competitors
+          description: Known competitor products
+      type: object
+      title: TargetBackground
+      description: 'Target background - used in create/update API requests and stored
+        in DB/GCS.
+
+
+        Required fields for activation:
+
+        - industry (string, required)
+
+        - use_case (string, required)
+
+
+        Optional field:
+
+        - competitors (list of strings)
+
+        '
+    TargetConnectionType:
+      type: string
+      enum:
+      - DATABRICKS
+      - BEDROCK
+      - OPENAI
+      - HUGGING_FACE
+      - CUSTOM
+      - REST
+      - STREAMING
+      title: TargetConnectionType
+      description: Connection type/provider for the target.
+    TargetContextUpdateSchema:
+      properties:
+        target_background:
+          anyOf:
+          - $ref: '#/components/schemas/TargetBackground'
+          - type: 'null'
+          description: 'Target background: industry, use_case, competitors'
+        additional_context:
+          anyOf:
+          - $ref: '#/components/schemas/TargetAdditionalContext'
+          - type: 'null'
+          description: 'Additional context: base_model, system_prompt, languages,
+            etc.'
+      type: object
+      title: TargetContextUpdateSchema
+      description: 'Request schema for updating target profile (background + additional
+        context).
+
+
+        Used by PUT /{target_uuid}/profile endpoint.
+
+        User provides plain values which are saved directly to DB and GCS.
+
+        '
+    TargetCreateRequestSchema:
+      properties:
+        connection_params:
+          anyOf:
+          - $ref: '#/components/schemas/RestConnectionParamsBase-Input'
+          - $ref: '#/components/schemas/StreamingConnectionParamsBase-Input'
+          - type: 'null'
+          title: Connection Params
+          description: API connection parameters (sensitive data masked for security)
+        network_broker_channel_uuid:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Network Broker Channel Uuid
+          description: Network broker channel UUID for routing requests. Required
+            when api_endpoint_type is NETWORK_BROKER.
+          examples:
+          - 550e8400-e29b-41d4-a716-446655440000
+        name:
+          type: string
+          title: Name
+          description: Target name
+          examples:
+          - GPT 4.1 Nano
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Optional target description
+          default: null
+          examples:
+          - AI model for testing
+        target_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetType'
+          - type: 'null'
+          description: Type of target
+        connection_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetConnectionType'
+          - type: 'null'
+          description: Connection type/provider for the target
+          examples:
+          - CUSTOM
+          - OPENAI
+          - BEDROCK
+        api_endpoint_type:
+          anyOf:
+          - $ref: '#/components/schemas/ApiEndpointType'
+          - type: 'null'
+          description: Accessibility type of the API endpoint
+          examples:
+          - PUBLIC
+          - PRIVATE
+          - NETWORK_BROKER
+        response_mode:
+          anyOf:
+          - $ref: '#/components/schemas/ResponseMode'
+          - type: 'null'
+          description: Response mode for API interactions
+          examples:
+          - REST
+          - STREAMING
+        session_supported:
+          type: boolean
+          title: Session Supported
+          description: Whether target supports session for multi-turn conversations
+          default: false
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Additional configuration or metadata for the target
+          default: null
+          examples:
+          - custom_key: custom_value
+        target_metadata:
+          $ref: '#/components/schemas/TargetMetadata'
+          description: Target metadata and configuration options
+        target_background:
+          anyOf:
+          - $ref: '#/components/schemas/TargetBackground'
+          - type: 'null'
+          description: 'Target background: industry, use_case, competitors'
+        additional_context:
+          anyOf:
+          - $ref: '#/components/schemas/TargetAdditionalContext'
+          - type: 'null'
+          description: 'Additional context: base_model, system_prompt, languages,
+            etc.'
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      title: TargetCreateRequestSchema
+      description: Target create request schema for validating and defining target
+        creation parameters.
+    TargetListItemSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        name:
+          type: string
+          title: Name
+          description: Target name
+          examples:
+          - GPT 4.1 Nano
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Optional target description
+          default: null
+          examples:
+          - AI model for testing
+        target_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetType'
+          - type: 'null'
+          description: Type of target
+        connection_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetConnectionType'
+          - type: 'null'
+          description: Connection type/provider for the target
+          examples:
+          - CUSTOM
+          - OPENAI
+          - BEDROCK
+        api_endpoint_type:
+          anyOf:
+          - $ref: '#/components/schemas/ApiEndpointType'
+          - type: 'null'
+          description: Accessibility type of the API endpoint
+          examples:
+          - PUBLIC
+          - PRIVATE
+          - NETWORK_BROKER
+        response_mode:
+          anyOf:
+          - $ref: '#/components/schemas/ResponseMode'
+          - type: 'null'
+          description: Response mode for API interactions
+          examples:
+          - REST
+          - STREAMING
+        session_supported:
+          type: boolean
+          title: Session Supported
+          description: Whether target supports session for multi-turn conversations
+          default: false
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Additional configuration or metadata for the target
+          default: null
+          examples:
+          - custom_key: custom_value
+        status:
+          $ref: '#/components/schemas/TargetStatus'
+          description: Target status
+        active:
+          type: boolean
+          title: Active
+          description: Whether target is active
+        validated:
+          type: boolean
+          title: Validated
+          description: Whether target is validated
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Configuration version
+        secret_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Secret Version
+          description: Secret Manager version for connection_params. When present,
+            sensitive connection data is stored in Secret Manager. When None, connection_params
+            are stored in GCS (legacy).
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+          description: User ID of target creator
+        updated_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updated By User Id
+          description: User ID of last target updater
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Last update timestamp
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - name
+      - status
+      - active
+      - validated
+      - created_at
+      - updated_at
+      title: TargetListItemSchema
+    TargetListSchema:
+      properties:
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+        data:
+          items:
+            $ref: '#/components/schemas/TargetListItemSchema'
+          type: array
+          title: Data
+          description: List of targets
+      type: object
+      required:
+      - pagination
+      title: TargetListSchema
+      description: Schema returned by API for list target operations.
+    TargetMetadata:
+      properties:
+        multi_turn:
+          type: boolean
+          title: Multi Turn
+          description: Whether target supports multi-turn conversations (Probe 2 result)
+          default: false
+        multi_turn_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Multi Turn Error Message
+          description: Concise error message if Probe 2 failed
+          examples:
+          - Session ID extraction failed
+          - Assistant role not configured
+        rate_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rate Limit
+          description: Current rate limit value
+          examples:
+          - 996
+        rate_limit_enabled:
+          type: boolean
+          title: Rate Limit Enabled
+          description: Whether rate limiting is enabled
+          default: false
+        rate_limit_error_code:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Rate Limit Error Code
+          description: HTTP status code for rate limit errors
+          examples:
+          - 429
+        rate_limit_error_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Rate Limit Error Json
+          description: JSON structure of rate limit error response
+          examples:
+          - error:
+              code: rate_limit_exceeded
+              message: 'Rate limit reached for o1-preview on requests per min (RPM):
+                Limit 20, Used 20, Requested 1. Please try again in 3s. Visit https://platform.openai.com/account/rate-limits
+                to learn more.'
+              param: 'null'
+              type: requests
+        rate_limit_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Rate Limit Error Message
+          description: Raw error message string for rate limit errors
+          examples:
+          - 'Rate limit reached for o1-preview on requests per min (RPM): Limit 20,
+            Used 20, Requested 1. Please try again in 3s.'
+        content_filter_enabled:
+          type: boolean
+          title: Content Filter Enabled
+          description: Whether content filtering is enabled
+          default: false
+        content_filter_error_code:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Content Filter Error Code
+          description: HTTP status code for content filter errors
+          examples:
+          - 400
+        content_filter_error_json:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Content Filter Error Json
+          description: JSON structure of content filter error response
+          examples:
+          - error:
+              code: invalid_prompt
+              message: 'Invalid prompt: your prompt was flagged as potentially violating
+                our usage policy. Please try again with a different prompt.'
+              type: invalid_request_error
+        content_filter_error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Content Filter Error Message
+          description: Raw error message string for content filter errors
+          examples:
+          - 'Invalid prompt: your prompt was flagged as potentially violating our
+            usage policy. Please try again with a different prompt.'
+        probe_message:
+          type: string
+          title: Probe Message
+          default: Hello, this is a test message from the red team validation system.
+        request_timeout:
+          type: number
+          title: Request Timeout
+          description: Request timeout in seconds
+          default: 110
+          examples:
+          - 110
+      type: object
+      title: TargetMetadata
+      description: Metadata stored in the database for targets (user-provided + computed
+        fields).
+    TargetProbeRequest:
+      properties:
+        connection_params:
+          anyOf:
+          - $ref: '#/components/schemas/RestConnectionParamsBase-Input'
+          - $ref: '#/components/schemas/StreamingConnectionParamsBase-Input'
+          - type: 'null'
+          title: Connection Params
+          description: API connection parameters (sensitive data masked for security)
+        network_broker_channel_uuid:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Network Broker Channel Uuid
+          description: Network broker channel UUID for routing requests. Required
+            when api_endpoint_type is NETWORK_BROKER.
+          examples:
+          - 550e8400-e29b-41d4-a716-446655440000
+        name:
+          type: string
+          title: Name
+          description: Target name
+          examples:
+          - GPT 4.1 Nano
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Optional target description
+          default: null
+          examples:
+          - AI model for testing
+        target_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetType'
+          - type: 'null'
+          description: Type of target
+        connection_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetConnectionType'
+          - type: 'null'
+          description: Connection type/provider for the target
+          examples:
+          - CUSTOM
+          - OPENAI
+          - BEDROCK
+        api_endpoint_type:
+          anyOf:
+          - $ref: '#/components/schemas/ApiEndpointType'
+          - type: 'null'
+          description: Accessibility type of the API endpoint
+          examples:
+          - PUBLIC
+          - PRIVATE
+          - NETWORK_BROKER
+        response_mode:
+          anyOf:
+          - $ref: '#/components/schemas/ResponseMode'
+          - type: 'null'
+          description: Response mode for API interactions
+          examples:
+          - REST
+          - STREAMING
+        session_supported:
+          type: boolean
+          title: Session Supported
+          description: Whether target supports session for multi-turn conversations
+          default: false
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Additional configuration or metadata for the target
+          default: null
+          examples:
+          - custom_key: custom_value
+        target_metadata:
+          $ref: '#/components/schemas/TargetMetadata'
+          description: Target metadata and configuration options
+        target_background:
+          anyOf:
+          - $ref: '#/components/schemas/TargetBackground'
+          - type: 'null'
+          description: 'Target background: industry, use_case, competitors'
+        additional_context:
+          anyOf:
+          - $ref: '#/components/schemas/TargetAdditionalContext'
+          - type: 'null'
+          description: 'Additional context: base_model, system_prompt, languages,
+            etc.'
+        uuid:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Uuid
+          description: Target UUID. If provided, will be returned in response.
+        probe_fields:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Probe Fields
+          description: 'Specific probes to run. If None, runs all probes. Valid: industry,
+            use_case, competitors, base_model, core_architecture, languages_supported,
+            tools_accessible, system_prompt, banned_keywords'
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      title: TargetProbeRequest
+      description: 'Request to run profiling probes on a target.
+
+
+        Inherits all target creation fields (connection params, metadata, etc.)
+
+        If probe_fields is None, runs all 9 probes. Otherwise runs only specified
+        probes.
+
+        '
+    TargetProfileResponse:
+      properties:
+        target_id:
+          type: string
+          format: uuid
+          title: Target Id
+        target_version:
+          type: integer
+          title: Target Version
+        status:
+          type: string
+          title: Status
+        target_background:
+          anyOf:
+          - $ref: '#/components/schemas/TargetBackground'
+          - type: 'null'
+        additional_context:
+          anyOf:
+          - $ref: '#/components/schemas/TargetAdditionalContext'
+          - type: 'null'
+        other_details:
+          anyOf:
+          - $ref: '#/components/schemas/OtherDetails'
+          - type: 'null'
+        ai_generated_fields:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Ai Generated Fields
+          description: Field names populated by AI profiler (e.g., competitors, base_model,
+            system_prompt)
+        profiling_status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Profiling Status
+          description: Status of the profiling workflow
+      type: object
+      required:
+      - target_id
+      - target_version
+      - status
+      title: TargetProfileResponse
+      description: Combined response for profile view.
+    TargetRedactSchema:
+      properties:
+        connection_params:
+          anyOf:
+          - $ref: '#/components/schemas/RestConnectionParamsRedactBase'
+          - $ref: '#/components/schemas/StreamingConnectionParamsRedactBase'
+          - type: 'null'
+          title: Connection Params
+          description: API connection parameters (sensitive data masked for security)
+        network_broker_channel_uuid:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Network Broker Channel Uuid
+          description: Network broker channel UUID for routing requests. Required
+            when api_endpoint_type is NETWORK_BROKER.
+          examples:
+          - 550e8400-e29b-41d4-a716-446655440000
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        name:
+          type: string
+          title: Name
+          description: Target name
+          examples:
+          - GPT 4.1 Nano
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Optional target description
+          default: null
+          examples:
+          - AI model for testing
+        target_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetType'
+          - type: 'null'
+          description: Type of target
+        connection_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetConnectionType'
+          - type: 'null'
+          description: Connection type/provider for the target
+          examples:
+          - CUSTOM
+          - OPENAI
+          - BEDROCK
+        api_endpoint_type:
+          anyOf:
+          - $ref: '#/components/schemas/ApiEndpointType'
+          - type: 'null'
+          description: Accessibility type of the API endpoint
+          examples:
+          - PUBLIC
+          - PRIVATE
+          - NETWORK_BROKER
+        response_mode:
+          anyOf:
+          - $ref: '#/components/schemas/ResponseMode'
+          - type: 'null'
+          description: Response mode for API interactions
+          examples:
+          - REST
+          - STREAMING
+        session_supported:
+          type: boolean
+          title: Session Supported
+          description: Whether target supports session for multi-turn conversations
+          default: false
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Additional configuration or metadata for the target
+          default: null
+          examples:
+          - custom_key: custom_value
+        status:
+          $ref: '#/components/schemas/TargetStatus'
+          description: Target status
+        active:
+          type: boolean
+          title: Active
+          description: Whether target is active
+        validated:
+          type: boolean
+          title: Validated
+          description: Whether target is validated
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Configuration version reference for encrypted config
+        secret_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Secret Version
+          description: Secret Manager version for connection_params. When present,
+            sensitive connection data is stored in Secret Manager. When None, connection_params
+            are stored in GCS (legacy).
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+          description: User ID of target creator
+        updated_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updated By User Id
+          description: User ID of last target updater
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Last update timestamp
+        target_metadata:
+          $ref: '#/components/schemas/TargetMetadata'
+          description: Target metadata and configuration options
+        target_background:
+          anyOf:
+          - $ref: '#/components/schemas/TargetBackground'
+          - type: 'null'
+          description: 'Target background info: industry, use_case, competitors'
+        profiling_status:
+          anyOf:
+          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: 'null'
+          description: Status of the profiling workflow
+        additional_context:
+          anyOf:
+          - $ref: '#/components/schemas/TargetAdditionalContext'
+          - type: 'null'
+          description: Additional context with source tracking (user + profiler)
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - name
+      - status
+      - active
+      - validated
+      - created_at
+      - updated_at
+      title: TargetRedactSchema
+      description: Target redact Schema
+    TargetResponseSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        name:
+          type: string
+          title: Name
+          description: Target name
+          examples:
+          - GPT 4.1 Nano
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Optional target description
+          default: null
+          examples:
+          - AI model for testing
+        target_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetType'
+          - type: 'null'
+          description: Type of target
+        connection_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetConnectionType'
+          - type: 'null'
+          description: Connection type/provider for the target
+          examples:
+          - CUSTOM
+          - OPENAI
+          - BEDROCK
+        api_endpoint_type:
+          anyOf:
+          - $ref: '#/components/schemas/ApiEndpointType'
+          - type: 'null'
+          description: Accessibility type of the API endpoint
+          examples:
+          - PUBLIC
+          - PRIVATE
+          - NETWORK_BROKER
+        response_mode:
+          anyOf:
+          - $ref: '#/components/schemas/ResponseMode'
+          - type: 'null'
+          description: Response mode for API interactions
+          examples:
+          - REST
+          - STREAMING
+        session_supported:
+          type: boolean
+          title: Session Supported
+          description: Whether target supports session for multi-turn conversations
+          default: false
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Additional configuration or metadata for the target
+          default: null
+          examples:
+          - custom_key: custom_value
+        status:
+          $ref: '#/components/schemas/TargetStatus'
+          description: Target status
+        active:
+          type: boolean
+          title: Active
+          description: Whether target is active
+        validated:
+          type: boolean
+          title: Validated
+          description: Whether target is validated
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Configuration version
+        secret_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Secret Version
+          description: Secret Manager version for connection_params. When present,
+            sensitive connection data is stored in Secret Manager. When None, connection_params
+            are stored in GCS (legacy).
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+          description: User ID of target creator
+        updated_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updated By User Id
+          description: User ID of last target updater
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Last update timestamp
+        target_metadata:
+          $ref: '#/components/schemas/TargetMetadata'
+          description: Target metadata and configuration options
+        target_background:
+          anyOf:
+          - $ref: '#/components/schemas/TargetBackground'
+          - type: 'null'
+          description: 'Target background info: industry, use_case, competitors'
+        profiling_status:
+          anyOf:
+          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: 'null'
+          description: Status of the profiling workflow
+        additional_context:
+          anyOf:
+          - $ref: '#/components/schemas/TargetAdditionalContext'
+          - type: 'null'
+          description: Additional context with source tracking (user + profiler)
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - name
+      - status
+      - active
+      - validated
+      - created_at
+      - updated_at
+      title: TargetResponseSchema
+    TargetSchema:
+      properties:
+        connection_params:
+          anyOf:
+          - $ref: '#/components/schemas/RestConnectionParamsBase-Output'
+          - $ref: '#/components/schemas/StreamingConnectionParamsBase-Output'
+          - type: 'null'
+          title: Connection Params
+          description: API connection parameters (sensitive data masked for security)
+        network_broker_channel_uuid:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Network Broker Channel Uuid
+          description: Network broker channel UUID for routing requests. Required
+            when api_endpoint_type is NETWORK_BROKER.
+          examples:
+          - 550e8400-e29b-41d4-a716-446655440000
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        name:
+          type: string
+          title: Name
+          description: Target name
+          examples:
+          - GPT 4.1 Nano
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Optional target description
+          default: null
+          examples:
+          - AI model for testing
+        target_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetType'
+          - type: 'null'
+          description: Type of target
+        connection_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetConnectionType'
+          - type: 'null'
+          description: Connection type/provider for the target
+          examples:
+          - CUSTOM
+          - OPENAI
+          - BEDROCK
+        api_endpoint_type:
+          anyOf:
+          - $ref: '#/components/schemas/ApiEndpointType'
+          - type: 'null'
+          description: Accessibility type of the API endpoint
+          examples:
+          - PUBLIC
+          - PRIVATE
+          - NETWORK_BROKER
+        response_mode:
+          anyOf:
+          - $ref: '#/components/schemas/ResponseMode'
+          - type: 'null'
+          description: Response mode for API interactions
+          examples:
+          - REST
+          - STREAMING
+        session_supported:
+          type: boolean
+          title: Session Supported
+          description: Whether target supports session for multi-turn conversations
+          default: false
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Additional configuration or metadata for the target
+          default: null
+          examples:
+          - custom_key: custom_value
+        status:
+          $ref: '#/components/schemas/TargetStatus'
+          description: Target status
+        active:
+          type: boolean
+          title: Active
+          description: Whether target is active
+        validated:
+          type: boolean
+          title: Validated
+          description: Whether target is validated
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Configuration version reference for encrypted config
+        secret_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Secret Version
+          description: Secret Manager version for connection_params. When present,
+            sensitive connection data is stored in Secret Manager. When None, connection_params
+            are stored in GCS (legacy).
+        created_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Created By User Id
+          description: User ID of target creator
+        updated_by_user_id:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Updated By User Id
+          description: User ID of last target updater
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Last update timestamp
+        target_metadata:
+          $ref: '#/components/schemas/TargetMetadata'
+          description: Target metadata and configuration options
+        target_background:
+          anyOf:
+          - $ref: '#/components/schemas/TargetBackground'
+          - type: 'null'
+          description: 'Target background info: industry, use_case, competitors'
+        profiling_status:
+          anyOf:
+          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: 'null'
+          description: Status of the profiling workflow
+        additional_context:
+          anyOf:
+          - $ref: '#/components/schemas/TargetAdditionalContext'
+          - type: 'null'
+          description: Additional context with source tracking (user + profiler)
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - name
+      - status
+      - active
+      - validated
+      - created_at
+      - updated_at
+      title: TargetSchema
+      description: 'Target Get Schema with profiling fields.
+
+
+        Inherits from TargetDetailSchema which includes:
+
+        - target_background: industry, use_case, competitors
+
+        - profiling_status: INIT, QUEUED, IN_PROGRESS, COMPLETED, FAILED
+
+        - additional_context: merged user + profiler values with source tracking
+
+        '
+    TargetStatus:
+      type: string
+      enum:
+      - DRAFT
+      - VALIDATING
+      - VALIDATED
+      - ACTIVE
+      - INACTIVE
+      - FAILED
+      - PENDING_AUTH
+      title: TargetStatus
+      description: Status enumeration for scan targets.
+    TargetType:
+      type: string
+      enum:
+      - APPLICATION
+      - AGENT
+      - MODEL
+      title: TargetType
+      description: Target Types Available
+    TargetUpdateRequestSchema:
+      properties:
+        connection_params:
+          anyOf:
+          - $ref: '#/components/schemas/RestConnectionParamsBase-Input'
+          - $ref: '#/components/schemas/StreamingConnectionParamsBase-Input'
+          - type: 'null'
+          title: Connection Params
+          description: API connection parameters (sensitive data masked for security)
+        network_broker_channel_uuid:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Network Broker Channel Uuid
+          description: Network broker channel UUID for routing requests. Required
+            when api_endpoint_type is NETWORK_BROKER.
+          examples:
+          - 550e8400-e29b-41d4-a716-446655440000
+        name:
+          type: string
+          title: Name
+          description: Target name
+          examples:
+          - GPT 4.1 Nano
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Optional target description
+          default: null
+          examples:
+          - AI model for testing
+        target_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetType'
+          - type: 'null'
+          description: Type of target
+        connection_type:
+          anyOf:
+          - $ref: '#/components/schemas/TargetConnectionType'
+          - type: 'null'
+          description: Connection type/provider for the target
+          examples:
+          - CUSTOM
+          - OPENAI
+          - BEDROCK
+        api_endpoint_type:
+          anyOf:
+          - $ref: '#/components/schemas/ApiEndpointType'
+          - type: 'null'
+          description: Accessibility type of the API endpoint
+          examples:
+          - PUBLIC
+          - PRIVATE
+          - NETWORK_BROKER
+        response_mode:
+          anyOf:
+          - $ref: '#/components/schemas/ResponseMode'
+          - type: 'null'
+          description: Response mode for API interactions
+          examples:
+          - REST
+          - STREAMING
+        session_supported:
+          type: boolean
+          title: Session Supported
+          description: Whether target supports session for multi-turn conversations
+          default: false
+        extra_info:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Additional configuration or metadata for the target
+          default: null
+          examples:
+          - custom_key: custom_value
+        target_metadata:
+          $ref: '#/components/schemas/TargetMetadata'
+          description: Target metadata and configuration options
+        target_background:
+          anyOf:
+          - $ref: '#/components/schemas/TargetBackground'
+          - type: 'null'
+          description: 'Target background: industry, use_case, competitors'
+        additional_context:
+          anyOf:
+          - $ref: '#/components/schemas/TargetAdditionalContext'
+          - type: 'null'
+          description: 'Additional context: base_model, system_prompt, languages,
+            etc.'
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      title: TargetUpdateRequestSchema
+      description: Schema for both create and update operations.
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+ExternalTags:
+  CustomAttack:
+    title: CustomAttack
+    description: Operations for managing custom prompt sets, prompts, and properties.
+    tags:
+    - CustomAttack
+  Dashboard:
+    title: Dashboard
+    description: Operations for retrieving dashboard overview and statistics.
+    tags:
+    - Dashboard
+  HealthChecks:
+    title: HealthChecks
+    description: Operations related to health checks of the management plane service.
+    tags:
+    - HealthChecks
+  Target:
+    title: Target
+    description: Operations for managing scan targets (create, update, delete, list).
+    tags:
+    - Target
+paths:
+  /ready:
+    get:
+      summary: Readiness
+      description: Retrieve the ready details through this Application Programming
+        Interface endpoint.
+      operationId: readiness_ready_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                title: Response Readiness Ready Get
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - HealthChecks
+  /liveness:
+    get:
+      summary: Liveness
+      description: Retrieve the liveness details through this Application Programming
+        Interface endpoint.
+      operationId: liveness_liveness_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: boolean
+                type: object
+                title: Response Liveness Liveness Get
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - HealthChecks
+  /v1/target:
+    post:
+      summary: Create target
+      description: Create a new scan target.
+      operationId: create_target_v1_target_post
+      responses:
+        201:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: validate
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Whether to validate target configuration
+          examples:
+          - true
+          title: Validate
+        description: Whether to validate target configuration
+      tags:
+      - Target
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TargetCreateRequestSchema'
+    get:
+      summary: List targets
+      description: List all scan targets with pagination and filtering support.
+      operationId: list_targets_v1_target_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetListSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Maximum records to return
+          default: 10
+          title: Limit
+        description: Maximum records to return
+      - name: target_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/TargetType'
+          - type: 'null'
+          description: Filter by target type
+          title: Target Type
+        description: Filter by target type
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/TargetStatus'
+          - type: 'null'
+          description: Filter by status
+          title: Status
+        description: Filter by status
+      - name: search
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Search target by name
+          title: Search
+        description: Search target by name
+      tags:
+      - Target
+  /v1/target/{target_uuid}:
+    get:
+      summary: Get target details
+      description: Retrieve a specific target by UUID with complete configuration
+        details and masked connection parameters.
+      operationId: get_target_v1_target__target_uuid__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetRedactSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      tags:
+      - Target
+    put:
+      summary: Update target
+      description: Update an existing target with new configuration and optional validation
+        control.
+      operationId: update_target_v1_target__target_uuid__put
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      - name: validate
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Whether to validate target configuration
+          default: true
+          title: Validate
+        description: Whether to validate target configuration
+      tags:
+      - Target
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TargetUpdateRequestSchema'
+    delete:
+      summary: Delete target
+      description: Permanently delete a target and its encrypted configuration data.
+      operationId: delete_target_v1_target__target_uuid__delete
+      responses:
+        204:
+          description: Successful Response
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      tags:
+      - Target
+  /v1/target/{target_uuid}/profile:
+    put:
+      summary: Update target profile
+      description: Update target background and additional context fields without
+        connection validation.
+      operationId: update_target_profile_v1_target__target_uuid__profile_put
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      tags:
+      - Target
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TargetContextUpdateSchema'
+    get:
+      summary: Get profiling results
+      description: Get profiling results including merged user and profiler data.
+      operationId: get_profiling_results_v1_target__target_uuid__profile_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetProfileResponse'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      tags:
+      - Target
+  /v1/target/probe:
+    post:
+      summary: Run profiling probes on target
+      description: Send profiling questions to a target using provided connection
+        parameters. Returns TargetResponseSchema with target_background and additional_context
+        populated from probe responses.
+      operationId: run_target_probes_v1_target_probe_post
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - Target
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TargetProbeRequest'
+        required: true
+  /v1/custom-attack/custom-prompt-set:
+    post:
+      summary: Create a new custom prompt set
+      description: Create a new custom prompt set.
+      operationId: create_prompt_set_v1_custom_attack_custom_prompt_set_post
+      responses:
+        201:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - CustomAttack
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomPromptSetCreateRequestSchema'
+        required: true
+  /v1/custom-attack/list-custom-prompt-sets:
+    get:
+      summary: List custom prompt sets
+      description: List all custom prompt sets with pagination and filtering support.
+      operationId: list_prompt_sets_v1_custom_attack_list_custom_prompt_sets_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetListSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Maximum records to return
+          default: 10
+          title: Limit
+        description: Maximum records to return
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by status
+          title: Status
+        description: Filter by status
+      - name: active
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Filter by active status
+          title: Active
+        description: Filter by active status
+      - name: archive
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Filter by archive status (None=non-archived only, True=archived
+            only, False=non-archived only)
+          title: Archive
+        description: Filter by archive status (None=non-archived only, True=archived
+          only, False=non-archived only)
+      - name: search
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Search in name and description
+          title: Search
+        description: Search in name and description
+      tags:
+      - CustomAttack
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}:
+    get:
+      summary: Get prompt set details
+      description: Retrieve a specific prompt set by UUID with complete details including
+        properties.
+      operationId: get_prompt_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      tags:
+      - CustomAttack
+    put:
+      summary: Update prompt set
+      description: Update prompt set details including name, description, and properties.
+      operationId: update_prompt_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__put
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      tags:
+      - CustomAttack
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomPromptSetUpdateRequestSchema'
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/archive:
+    put:
+      summary: Archive or unarchive a prompt set
+      description: Archive or unarchive a prompt set to manage its lifecycle.
+      operationId: archive_prompt_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__archive_put
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      tags:
+      - CustomAttack
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomPromptSetArchiveRequestSchema'
+  /v1/custom-attack/custom-prompt-set/custom-prompt:
+    post:
+      summary: Create prompt in a prompt set
+      description: Create a new prompt in a prompt set.
+      operationId: create_prompt_v1_custom_attack_custom_prompt_set_custom_prompt_post
+      responses:
+        201:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - CustomAttack
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomPromptCreateRequestSchema'
+        required: true
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/list-custom-prompts:
+    get:
+      summary: List prompts in a prompt set
+      description: List all prompts within a specific prompt set with pagination and
+        filtering.
+      operationId: list_prompts_in_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__list_custom_prompts_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptListSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      - name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Maximum records to return
+          default: 10
+          title: Limit
+        description: Maximum records to return
+      - name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by status
+          title: Status
+        description: Filter by status
+      - name: active
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Filter by active status
+          title: Active
+        description: Filter by active status
+      - name: search
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Search in prompt text
+          title: Search
+        description: Search in prompt text
+      tags:
+      - CustomAttack
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/custom-prompt/{prompt_uuid}:
+    get:
+      summary: Get prompt details
+      description: Get a specific prompt by UUID.
+      operationId: get_prompt_v1_custom_attack_custom_prompt_set__prompt_set_uuid__custom_prompt__prompt_uuid__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      - name: prompt_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Uuid
+      tags:
+      - CustomAttack
+    put:
+      summary: Update prompt
+      description: Update an existing prompt.
+      operationId: update_prompt_v1_custom_attack_custom_prompt_set__prompt_set_uuid__custom_prompt__prompt_uuid__put
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      - name: prompt_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Uuid
+      tags:
+      - CustomAttack
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomPromptUpdateRequestSchema'
+    delete:
+      summary: Delete prompt
+      description: Delete a prompt.
+      operationId: delete_prompt_v1_custom_attack_custom_prompt_set__prompt_set_uuid__custom_prompt__prompt_uuid__delete
+      responses:
+        204:
+          description: Successful Response
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      - name: prompt_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Uuid
+      tags:
+      - CustomAttack
+  /v1/custom-attack/property-names:
+    get:
+      summary: Get property names
+      description: Get all available property names for use in prompt sets.
+      operationId: get_property_names_v1_custom_attack_property_names_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PropertyNamesListResponseSchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - CustomAttack
+    post:
+      summary: Create property name
+      description: Create a new property name that can be used in prompt sets.
+      operationId: create_property_name_v1_custom_attack_property_names_post
+      responses:
+        201:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PropertyNamesListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - CustomAttack
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PropertyNameCreateRequestSchema'
+        required: true
+  /v1/custom-attack/property-values/{property_name}:
+    get:
+      summary: Get property name
+      description: Get all available values for a specific property name.
+      operationId: get_property_values_v1_custom_attack_property_values__property_name__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PropertyValuesResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: property_name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Property Name
+      tags:
+      - CustomAttack
+  /v1/custom-attack/property-values:
+    post:
+      summary: Create property value
+      description: Create a new value for an existing property name.
+      operationId: create_property_value_v1_custom_attack_property_values_post
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - CustomAttack
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PropertyValueCreateRequestSchema'
+    get:
+      summary: Get values for multiple property names
+      description: Get values for multiple property names in a single request.
+      operationId: get_property_values_multiple_v1_custom_attack_property_values_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PropertyValuesMultipleResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: property_names
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Comma-separated list of property names
+          title: Property Names
+        description: Comma-separated list of property names
+      tags:
+      - CustomAttack
+  /v1/custom-attack/upload-custom-prompts-csv:
+    post:
+      summary: Upload custom prompts
+      description: Upload a CSV file containing custom prompts with properties for
+        a specific prompt set.
+      operationId: upload_prompts_csv_v1_custom_attack_upload_custom_prompts_csv_post
+      responses:
+        201:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          description: UUID of the prompt set
+          title: Prompt Set Uuid
+        description: UUID of the prompt set
+      tags:
+      - CustomAttack
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_upload_prompts_csv_v1_custom_attack_upload_custom_prompts_csv_post'
+  /v1/custom-attack/download-template/{prompt_set_uuid}:
+    get:
+      summary: Download template for a prompt set
+      description: Download a CSV template with columns for the prompt set's properties.
+      operationId: download_template_v1_custom_attack_download_template__prompt_set_uuid__get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      tags:
+      - CustomAttack
+  /v1/custom-attack/active-custom-prompt-sets:
+    get:
+      summary: List active custom prompt sets
+      description: List all active custom prompt sets available for use by data plane.
+        Returns only sets with snapshots.
+      operationId: list_active_prompt_sets_v1_custom_attack_active_custom_prompt_sets_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetListActiveSchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - CustomAttack
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/reference:
+    get:
+      summary: Resolve prompt set reference
+      description: Get current reference information for a prompt set including latest
+        version.
+      operationId: resolve_prompt_set_reference_v1_custom_attack_custom_prompt_set__prompt_set_uuid__reference_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetReferenceSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      tags:
+      - CustomAttack
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/version-info:
+    get:
+      summary: Get prompt set version information
+      description: Get detailed version information for a specific prompt set version.
+      operationId: get_prompt_set_version_info_v1_custom_attack_custom_prompt_set__prompt_set_uuid__version_info_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetVersionInfoSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters:
+      - name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      - name: version
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Specific version ID
+          title: Version
+        description: Specific version ID
+      tags:
+      - CustomAttack
+  /v1/dashboard/overview:
+    get:
+      summary: Get dashboard
+      description: Returns target counts by type for dashboard display.
+      operationId: get_overview_v1_dashboard_overview_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardOverviewResponseSchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      parameters: []
+      tags:
+      - Dashboard

--- a/specs/ScanService_Oct2025.yaml
+++ b/specs/ScanService_Oct2025.yaml
@@ -1,0 +1,1442 @@
+openapi: 3.0.3
+info:
+  contact:
+    email: https://www.paloaltonetworks.com/company/contact-support
+  title: Prisma AIRS AI Runtime API Intercept
+  description:
+    "This Open API spec file represents the APIs available for the Prisma AIRS AI Runtime: API Intercept.\n
+    \nThese APIs use the API key authentication and base URL.\n
+    \nTo use the APIs, you must first activate and associate a deployment profile in Customer Support Portal for Prisma AIRS AI Runtime API intercept and then onboard the API intercept in Strata Cloud Manager.\
+    For licensing, onboarding, activation, and to obtain the API authentication key and profile name, refer to the Prisma AIRS AI Runtime API intercept [Administration guide](https://docs.paloaltonetworks.com/ai-runtime-security/activation-and-onboarding/ai-runtime-security-api-intercept-overview).\n\n
+    This Open API spec file was created on June 04, 2024.\
+    \n\n© 2024 Palo Alto Networks, Inc. Palo Alto Networks is a registered trademark of Palo Alto Networks.\
+    A list of our trademarks can be found at https://www.paloaltonetworks.com/company/trademarks.html. \
+    All other marks mentioned herein may be trademarks of their respective companies.\n"
+  license:
+    name: Palo Alto Networks EULA
+    url: https://www.paloaltonetworks.com/content/dam/pan/en_US/assets/pdf/legal/palo-alto-networks-end-user-license-agreement-eula.pdf
+  version: 0.0.0
+
+servers:
+  - url: "https://service.api.aisecurity.paloaltonetworks.com"
+    description: Prisma AIRS API service URL for US regions
+  - url: "https://service-de.api.aisecurity.paloaltonetworks.com"
+    description: Prisma AIRS API service URL for EU (Germany) regions
+  - url: "https://service-in.api.aisecurity.paloaltonetworks.com"
+    description: Prisma AIRS API service URL for India regions
+  - url: "https://service-sg.api.aisecurity.paloaltonetworks.com"
+    description: Prisma AIRS API service URL for Singapore regions
+
+tags:
+  - name: Scans
+    description: Operations for performing AI content scans
+  - name: Scan Results
+    description: Operations for retrieving scan results
+  - name: Scan Reports
+    description: Operations for retrieving detailed scan reports
+
+paths:
+  /v1/scan/sync/request:
+    post:
+      summary: Send a Synchronous Scan Request
+      description: Post a scan request containing prompt or model response that returns a synchronous scan response
+      security:
+        - x-pan-token: []
+      operationId: ScanSyncRequest
+      tags:
+        - Scans
+      requestBody:
+        description: Scan request object
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ScanRequest"
+      responses:
+        "200":
+          description: successfully scanned request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScanResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "413":
+          $ref: "#/components/responses/RequestTooLarge"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        default:
+          description: error
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                  error:
+                    type: string
+
+  /v1/scan/async/request:
+    post:
+      summary: Send an Asynchronous Scan Request
+      description: Post a scan request that returns an asynchronous scan response with the scan_id and report_id
+      security:
+        - x-pan-token: []
+      operationId: ScanAsyncRequest
+      tags:
+        - Scans
+      requestBody:
+        description: A list of scan request objects
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/AsyncScanRequest"
+      responses:
+        "200":
+          description: successfully scanned request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AsyncScanResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "413":
+          $ref: "#/components/responses/RequestTooLarge"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        default:
+          description: error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /v1/scan/results:
+    get:
+      summary: Retrieve Scan results by ScanIDs
+      description: Get the scan results for a scan_id, for up to a maximum of 5 scan IDs
+      security:
+        - x-pan-token: []
+      operationId: GetScanResultsByScanIDs
+      tags:
+        - Scan Results
+      parameters:
+        - name: scan_ids
+          in: query
+          description: Scan Ids for Results
+          required: true
+          allowEmptyValue: false
+          schema:
+            type: array
+            items:
+              type: string
+              nullable: false
+            maximum: 5
+          style: form # Serialize as scan_ids=id1,id2,id3
+          explode: false
+      responses:
+        200:
+          description: Successfully returned records for scan results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ScanIdResult"
+              examples:
+                ExampleAsyncScanResults:
+                  $ref: "#/components/examples/ExampleAsyncScanResults"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "413":
+          $ref: "#/components/responses/RequestTooLarge"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        default:
+          description: error occurred
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/scan/reports:
+    get:
+      summary: Retrieve Threat Scan Reports by Report IDs
+      description: Get the threat scan reports for a given list of report_ids
+      security:
+        - x-pan-token: []
+      tags:
+        - Scan Reports
+      operationId: GetThreatScanReports
+      parameters:
+        - name: report_ids
+          in: query
+          description: Report Ids for results
+          required: true
+          allowEmptyValue: false
+          schema:
+            type: array
+            items:
+              type: string
+              nullable: false
+            maximum: 5
+          style: form # Serialize as report_ids=id1,id2,id3
+          explode: false
+      responses:
+        200:
+          description: Successfully returned threat scan reports
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ThreatScanReportObjects"
+              examples:
+                ExampleAsyncReports:
+                  $ref: "#/components/examples/ExampleMultipleThreatScanReports"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "405":
+          $ref: "#/components/responses/MethodNotAllowed"
+        "413":
+          $ref: "#/components/responses/RequestTooLarge"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        default:
+          description: error occurred
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  securitySchemes:
+    x-pan-token:
+      description: API key token generated during [onboarding Prisma AIRS AI Runtime API intercept](https://docs.paloaltonetworks.com/ai-runtime-security/activation-and-onboarding/ai-runtime-security-api-intercept-overview/onboard-api-runtime-security-api-intercept-in-scm) in Strata Cloud Manager.
+      in: header
+      name: x-pan-token
+      type: apiKey
+  schemas:
+    ScanRequest:
+      type: object
+      properties:
+        tr_id:
+          type: string
+          description: Provide any unique identifier string for correlating the prompt and response transactions. This is an optional field. The tr_id value received for scan request is returned in the scan response along with the scan ID.
+        session_id:
+          type: string
+          description: Provide any unique identifier string for tracking Sessions. This is an optional field. The session_id value received for scan request is returned in the scan response along with the scan ID.
+        ai_profile:
+          $ref: "#/components/schemas/AiProfile"
+        metadata:
+          $ref: "#/components/schemas/Metadata"
+        contents:
+          description: List of prompt or response or prompt/response pairs. The last element is the one that needs to be scanned, and the previous elements are the context for the scan.
+          type: array
+          items:
+            type: object
+            properties:
+              prompt:
+                type: string
+                description: The prompt content that you want to scan
+              response:
+                type: string
+                description: The response content that you want to scan
+              code_prompt:
+                type: string
+                description: Code snippet extracted from Prompt content that you want to scan
+              code_response:
+                type: string
+                description: Code snippet extracted from Response content that you want to scan
+              context:
+                type: string
+                description: The data context for contextual grounding
+              tool_event:
+                $ref: "#/components/schemas/ToolEvent"
+                description:  Tool or function call event details
+      required:
+        - contents
+        - ai_profile
+
+    AiProfile:
+      type: object
+      properties:
+        profile_id:
+          description: Unique identifier for the profile. If not provided, then profile_name is required.
+          type: string
+          format: uuid
+        profile_name:
+          description: Name of the profile. If not provided, then profile_id is required.
+          type: string
+
+    Metadata:
+      type: object
+      properties:
+        app_name:
+          type: string
+          description: AI application requesting the content scan
+        app_user:
+          type: string
+          description: End user using the AI application
+        ai_model:
+          type: string
+          description: AI model serving the AI application
+        user_ip:
+          type: string
+          description: End user IP using the AI application
+        agent_meta:
+          $ref: "#/components/schemas/AgentMeta"
+          description: Additional metadata about the agent used in the scan request
+
+    AgentMeta:
+      type: object
+      properties:
+        agent_id:
+          type: string
+          description: Agent identifier
+        agent_version:
+          type: string
+          description: Agent version
+        agent_arn:
+          type: string
+          description: Agent ARN
+
+    ToolEvent:
+      type: object
+      properties:
+        metadata:
+          $ref: "#/components/schemas/ToolEventMetadata"
+          description: Metadata associated with the tool or function call event
+        input:
+          type: string
+          description: Raw JSON string of input to the server
+          example: '{"file_key":"abc123"}'
+        output:
+          type: string
+          description: Raw JSON string of output from the server
+          example: '{"content":[{"type":"text","text":"Fetched file"}]}'
+      anyOf:
+        - required: ["input"]
+        - required: ["output"]
+
+    ScanResponse:
+      type: object
+      properties:
+        source:
+          type: string
+          description: Source of the scan request (e.g., 'AI-Runtime-MCP-Server' or 'AI-Runtime-API')
+        report_id:
+          type: string
+          description: Unique identifier for the scan report
+        scan_id:
+          type: string
+          format: uuid
+          description: Unique identifier for the scan
+        tr_id:
+          type: string
+          description: Unique identifier for the transaction
+        session_id:
+          type: string
+          description: Unique identifier for tracking Sessions
+        profile_id:
+          type: string
+          format: uuid
+          description: Unique identifier of the AI security profile used for scanning
+        profile_name:
+          type: string
+          description: AI security profile name used for scanning
+        category:
+          type: string
+          description: Category of the scanned content verdicts such as "malicious", "benign", "error" or "timeout"
+        action:
+          type: string
+          description: The action is set to "block" or "allow" based on AI security profile used for scanning
+        timeout:
+          type: boolean
+          description: Indicates whether any detection service timed out during scanning
+        error:
+          type: boolean
+          description: Indicates whether any detection service encountered an error during scanning
+        errors:
+          type: array
+          description: List of detection service errors or timeouts
+          items:
+            $ref: "#/components/schemas/ContentErrors"
+        prompt_detected:
+          $ref: "#/components/schemas/PromptDetected"
+        response_detected:
+          $ref: "#/components/schemas/ResponseDetected"
+        prompt_masked_data:
+          $ref: "#/components/schemas/MaskedData"
+        response_masked_data:
+          $ref: "#/components/schemas/MaskedData"
+        prompt_detection_details:
+          $ref: "#/components/schemas/PromptDetectionDetails"
+        response_detection_details:
+          $ref: "#/components/schemas/ResponseDetectionDetails"
+        tool_detected:
+          $ref: "#/components/schemas/ToolDetected"
+        created_at:
+          type: string
+          format: date-time
+          description: Scan request timestamp
+        completed_at:
+          type: string
+          format: date-time
+          description: Scan completion timestamp
+      required:
+        - report_id
+        - scan_id
+        - category
+        - action
+        - timeout
+        - error
+        - errors
+
+    ContentErrors:
+      type: object
+      description: Errors information for prompt and response detection services
+      properties:
+        content_type:
+          $ref: "#/components/schemas/ContentErrorType"
+        feature:
+          $ref: "#/components/schemas/DetectionServiceName"
+        status:
+          $ref: "#/components/schemas/ErrorStatus"
+
+    ContentErrorType:
+      type: string
+      description: Type of content that encountered an error
+      enum:
+        - prompt
+        - response
+
+    ErrorStatus:
+      type: string
+      description: Status indicating error or timeout
+      enum:
+        - error
+        - timeout
+
+    DetectionServiceName:
+      type: string
+      description: Name of detection service
+      enum:
+        - dlp
+        - injection
+        - url_cats
+        - toxic_content
+        - malicious_code
+        - agent
+        - topic_violation
+        - db_security
+        - ungrounded
+
+    PromptDetected:
+      type: object
+      properties:
+        url_cats:
+          type: boolean
+          description: Indicates whether prompt contains any malicious URLs
+        dlp:
+          type: boolean
+          description: Indicates whether prompt contains any sensitive information
+        injection:
+          type: boolean
+          description: Indicates whether prompt contains any injection threats
+        toxic_content:
+          type: boolean
+          description: Indicates whether prompt contains any harmful content
+        malicious_code:
+          type: boolean
+          description: Indicates whether prompt contains any malicious code
+        agent:
+          type: boolean
+          description: Indicates whether prompt contains any Agent related threats
+        topic_violation:
+          type: boolean
+          description: Indicates whether prompt contains any content violates topic guardrails
+
+    ResponseDetected:
+      type: object
+      properties:
+        url_cats:
+          type: boolean
+          description: Indicates whether response contains any malicious URLs
+        dlp:
+          type: boolean
+          description: Indicates whether response contains any sensitive information
+        db_security:
+          type: boolean
+          description: Indicates whether response contains any database security threats
+        toxic_content:
+          type: boolean
+          description: Indicates whether response contains any harmful content
+        malicious_code:
+          type: boolean
+          description: Indicates whether response contains any malicious code
+        agent:
+          type: boolean
+          description: Indicates whether response contains any Agent related threats
+        ungrounded:
+          type: boolean
+          description: Indicates whether response contains any ungrounded content
+        topic_violation:
+          type: boolean
+          description: Indicates whether response contains any content violates topic guardrails
+
+    PromptDetectionDetails:
+      type: object
+      properties:
+        topic_guardrails_details:
+          $ref: "#/components/schemas/TopicGuardRails"
+
+    ResponseDetectionDetails:
+      type: object
+      properties:
+        topic_guardrails_details:
+          $ref: "#/components/schemas/TopicGuardRails"
+
+    ToolDetectionDetails:
+      type: object
+      properties:
+        topic_guardrails_details:
+          $ref: "#/components/schemas/TopicGuardRails"
+
+    TopicGuardRails:
+      type: object
+      properties:
+        allowed_topics:
+          type: array
+          items:
+            type: string
+          description: Indicates the list of allowed topics if there was a content match for the topic allow list
+        blocked_topics:
+          type: array
+          items:
+            type: string
+          description: Indicates the list of blocked topics if there was a content match for the topic block list
+
+    MaskedData:
+      type: object
+      properties:
+        data:
+          type: string
+          description: Original data with sensitive pattern masked
+        pattern_detections:
+          type: array
+          items:
+            $ref: "#/components/schemas/PatternDetections"
+
+    PatternDetections:
+      type: object
+      properties:
+        pattern:
+          type: string
+          description: Matched pattern
+        locations:
+          $ref: "#/components/schemas/OffsetObject"
+
+    OffsetObject:
+      type: array
+      description: Array of start, end offsets
+      items:
+        type: array
+        items:
+          type: integer
+
+    ToolDetected:
+      type: object
+      additionalProperties: false
+      properties:
+        verdict:
+          type: string
+          example: malicious
+        metadata:
+          $ref: "#/components/schemas/ToolEventMetadata"
+        summary:
+          $ref: "#/components/schemas/ScanSummary"
+        input_detected:
+          $ref: "#/components/schemas/IODetected"
+        output_detected:
+          $ref: "#/components/schemas/IODetected"
+
+    ToolEventMetadata:
+      type: object
+      additionalProperties: false
+      required: [ecosystem, method, server_name]
+      properties:
+        ecosystem:
+          type: string
+          description: Ecosystem or protocol of the tool
+          example: "mcp"
+        method:
+          type: string
+          description: Method type of the tool event
+          example: "tools/list"
+        server_name:
+          type: string
+          description: Name of the MCP server
+          example: "Internal MCP server"
+        tool_invoked:
+          type: string
+          description: Name of the tool
+          example: "get_file"
+
+    ScanSummary:
+      type: object
+      additionalProperties: false
+      required: [detections, threats]
+      properties:
+        detections:
+          $ref: "#/components/schemas/ToolDetectionFlags"
+        threats:
+          type: array
+          items: {type: string}
+          example: ["credential leakage", "context poisoning"]
+
+    ToolDetectionFlags:
+      type: object
+      additionalProperties: false
+      properties:
+        injection:
+          type: boolean
+          description: Indicates whether the content contains any injection threats
+        url_cats:
+          type: boolean
+          description: Indicates whether response contains any malicious URLs
+        dlp:
+          type: boolean
+          description: Indicates whether response contains any sensitive information
+        db_security:
+          type: boolean
+          description: Indicates whether response contains any database security threats
+        toxic_content:
+          type: boolean
+          description: Indicates whether response contains any harmful content
+        malicious_code:
+          type: boolean
+          description: Indicates whether response contains any malicious code
+        agent:
+          type: boolean
+          description: Indicates whether response contains any Agent related threats
+        topic_violation:
+          type: boolean
+          description: Indicates whether prompt contains any content violates topic guardrails
+
+    IODetected:
+      type: object
+      additionalProperties: false
+      properties:
+        detection_entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/ToolDetectionEntry"
+
+    ToolDetectionEntry:
+      type: object
+      additionalProperties: false
+      properties:
+        tool_invoked:
+          type: string
+          example: "get_file"
+        detections:
+          $ref: "#/components/schemas/ToolDetectionFlags"
+        threats:
+          type: array
+          items: {type: string}
+          example: ["credential leakage", "context poisoning"]
+        details:
+          $ref: "#/components/schemas/ToolDetectionDetails"
+        masked_data:
+          $ref: "#/components/schemas/MaskedData"
+
+    AsyncScanRequest:
+      type: array
+      items:
+        $ref: "#/components/schemas/AsyncScanObject"
+
+    AsyncScanObject:
+      type: object
+      properties:
+        req_id:
+          type: integer
+          format: uint32
+          description: Unique identifier of an individual element sent in the batch scan request
+        scan_req:
+          $ref: "#/components/schemas/ScanRequest"
+      required:
+        - req_id
+        - scan_req
+
+    AsyncScanResponse:
+      type: object
+      properties:
+        received:
+          type: string
+          format: date-time
+          description: Asynchronous scan received timestamp
+        scan_id:
+          type: string
+          description: Unique identifier for the asynchronous scan request
+        report_id:
+          type: string
+          description: Unique identifier for the asynchronous scan report
+        source:
+          type: string
+          description: Source of the scan request (e.g., 'AI-Runtime-MCP-Server' or 'AI-Runtime-API')
+      required:
+        - received
+        - scan_id
+
+    ScanIdResult:
+      type: object
+      properties:
+        source:
+          type: string
+          description: Source of the scan request (e.g., 'AI-Runtime-MCP-Server' or 'AI-Runtime-API')
+        req_id:
+          type: integer
+          description: Unique identifier of an individual element sent in the batch scan request
+        status:
+          type: string
+          description: Scan request processing state such as "complete" or "pending"
+        scan_id:
+          type: string
+          description: Unique identifier for the scan
+        result:
+          $ref: "#/components/schemas/ScanResponse"
+
+    ThreatScanReportObjects:
+      type: array
+      items:
+        $ref: "#/components/schemas/ThreatScanReportObject"
+
+    ThreatScanReportObject:
+      type: object
+      properties:
+        source:
+          type: string
+          description: Source of the scan request (e.g., 'AI-Runtime-MCP-Server' or 'AI-Runtime-API')
+        report_id:
+          type: string
+          description: Unique identifier for the scan report
+        scan_id:
+          type: string
+          description: Unique identifier for the scan
+        req_id:
+          type: integer
+          format: uint32
+          description: Unique identifier of an individual element sent in the batch scan request
+        transaction_id:
+          type: string
+          description: Unique identifier for the transaction
+        session_id:
+          type: string
+          description: Unique identifier for tracking Sessions
+        detection_results:
+          type: array
+          items:
+            $ref: "#/components/schemas/DetectionServiceResultObject"
+
+    DetectionServiceResultObject:
+      type: object
+      properties:
+        data_type:
+          type: string
+          description: Content type such as "prompt", "response" or "tool_event"
+        detection_service:
+          type: string
+          description: Detection service name generating the results such as "urlf", "dlp", and "prompt injection"
+        verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+        action:
+          type: string
+          description: The action is set to "block" or "allow" based on AI security profile used for scanning
+        metadata:
+          $ref: "#/components/schemas/DSResultMetadata"
+        result_detail:
+          $ref: "#/components/schemas/DSDetailResultObject"
+
+    DSResultMetadata:
+      type: object
+      properties:
+        ecosystem:
+          type: string
+          example: "mcp"
+        method:
+          type: string
+          example: "tools/call"
+        server_name:
+          type: string
+          example: "MCP server"
+        tool_invoked:
+          type: string
+          example: "get_file"
+        direction:
+          type: string
+          enum: ["input", "output"]
+          description: Indicates the direction of data flow, either input to or output from a tool or service
+
+    DSDetailResultObject:
+      type: object
+      properties:
+        urlf_report:
+          $ref: "#/components/schemas/UrlFilterReportObject"
+        dlp_report:
+          $ref: "#/components/schemas/DlpReportObject"
+        dbs_report:
+          $ref: "#/components/schemas/DbsReportObject"
+        tc_report:
+          $ref: "#/components/schemas/TcReportObject"
+        mc_report:
+          $ref: "#/components/schemas/McReportObject"
+        agent_report:
+          $ref: "#/components/schemas/AgentReportObject"
+        topic_guardrails_report:
+          $ref: "#/components/schemas/TgReportObject"
+        cg_report:
+          $ref: "#/components/schemas/CgReportObject"
+
+    DbsReportObject:
+      type: array
+      items:
+        $ref: "#/components/schemas/DbsEntryObject"
+
+    DbsEntryObject:
+      type: object
+      properties:
+        sub_type:
+          type: string
+          description: Database security sql query sub-type, such as "create", "read", "update", or "delete"
+        verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+        action:
+          type: string
+          description: The action is set to "block" or "allow" based on AI security profile used for scanning
+
+    TcReportObject:
+      type: object
+      properties:
+        confidence:
+          type: string
+          description: Confidence level of the threat classification ("high" and "moderate")
+        verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+
+    McReportObject:
+      type: object
+      properties:
+        all_code_blocks:
+          type: array
+          items:
+            type: string
+            description: Code blocks extracted from prompt or response content
+        code_analysis_by_type:
+          type: array
+          items:
+            $ref: "#/components/schemas/McEntryObject"
+        verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+        malware_script_report:
+          $ref: "#/components/schemas/MalwareReportObject"
+          description: Malware script scanning report details
+        command_injection_report:
+          $ref: "#/components/schemas/CmdInjectReportObject"
+          description: Command injection scanning report details
+
+    MalwareReportObject:
+      type: object
+      properties:
+        verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+
+    McEntryObject:
+      type: object
+      properties:
+        file_type:
+          type: string
+          description: code file type, such as "javascript", "Python", "VBScript" and others
+        code_sha256:
+          type: string
+          description: SHA256 of the code file that was analyzed, such as a code snippet containing the potentially malicious code
+
+    CmdInjectReportObject:
+      type: array
+      items:
+        $ref: "#/components/schemas/CmdEntryObject"
+
+    CmdEntryObject:
+      type: object
+      properties:
+        code_block:
+          type: string
+          description: Code block extracted from prompt or response content
+        verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+
+    AgentReportObject:
+      type: object
+      properties:
+        model_verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+        agent_framework:
+          type: string
+          description: Agent builder framework used to build Agents such as "AWS_Agent_Builder", "Microsoft_copilot_studio" and others
+        agent_patterns:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentEntryObject"
+
+    AgentEntryObject:
+      type: object
+      properties:
+        category_type:
+          type: string
+          description: Agent threat category type, such as "tools misuse", "memory manipulation" and others
+        verdict:
+          type: string
+          description: Verdict associated with the Agent threat Category, such as "malicious" or "benign"
+
+    UrlFilterReportObject:
+      type: array
+      items:
+        $ref: "#/components/schemas/UrlfEntryObject"
+
+    UrlfEntryObject:
+      type: object
+      properties:
+        url:
+          type: string
+          description: URL in the scan request
+        risk_level:
+          type: string
+          description: Risk level associated with the URL, such as "high", "medium", or "low"
+        action:
+          type: string
+          description: Action associated with the URL Category, such as "allow", "block", or "unknown"
+        categories:
+          type: array
+          description: Categories associated with the URL
+          items:
+            type: string
+
+    DlpReportObject:
+      type: object
+      properties:
+        dlp_report_id:
+          type: string
+          description: Unique identifier for the DLP report
+        dlp_profile_name:
+          type: string
+          description: DLP profile name used for the scan
+        dlp_profile_id:
+          type: string
+          description: Unique identifier for the DLP profile used for the scan
+        dlp_profile_version:
+          type: integer
+          format: int32
+          description: Version of the DLP profile used for the scan
+        data_pattern_rule1_verdict:
+          type: string
+          description: Indicates whether there was a content match for this rule such as "MATCHED" or "NOT MATCHED"
+        data_pattern_rule2_verdict:
+          type: string
+          description: Indicates whether there was a content match for this rule such as "MATCHED" or "NOT MATCHED"
+        data_pattern_detection_offsets:
+          type: array
+          description: Matched patterns and their byte locations
+          items:
+            $ref: "#/components/schemas/DlpPatternDetectionsObject"
+
+    DlpPatternDetectionsObject:
+      type: object
+      properties:
+        data_pattern_id:
+          type: string
+          description: Unique identifier for the data pattern matched
+        version:
+          type: integer
+          description: Version of the data pattern matched
+        name:
+          type: string
+          description: Name of the data pattern matched
+        high_confidence_detections:
+          $ref: "#/components/schemas/OffsetObject"
+        medium_confidence_detections:
+          $ref: "#/components/schemas/OffsetObject"
+        low_confidence_detections:
+          $ref: "#/components/schemas/OffsetObject"
+
+    TgReportObject:
+      type: object
+      properties:
+        allowed_topic_list:
+          type: string
+          description: Indicates whether there was a content match for the topic allow list such as "MATCHED" or "NOT MATCHED"
+        blocked_topic_list:
+          type: string
+          description: Indicates whether there was a content match for the topic block list such as "MATCHED" or "NOT MATCHED"
+        allowedTopics:
+          type: array
+          items:
+            type: string
+          description: Indicates the list of allowed topics if there was a content match for the topic allow list
+        blockedTopics:
+          type: array
+          items:
+            type: string
+          description: Indicates the list of blocked topics if there was a content match for the topic allow list
+
+    CgReportObject:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Indicates the status of cg explanation such as  "completed" or "pending"
+        explanation:
+          type: string
+          description: Indicates the the contextual grounding explanation given by the model
+        category:
+          type: string
+          description: Indicates the predefined category of contextual grounding results
+
+    Error:
+      type: object
+      properties:
+        status_code:
+          type: integer
+          format: int32
+          description: The HTTP status code for the error
+        message:
+          type: string
+          description: The error message
+      required:
+        - status_code
+        - message
+  responses:
+    BadRequest:
+      description: Bad Request - Request data is invalid or malformed
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Request data is invalid or malformed"
+    Unauthenticated:
+      description: Unauthenticated - Not Authenticated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Not Authenticated"
+    Forbidden:
+      description: Forbidden - Invalid API Key
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Invalid API Key"
+    NotFound:
+      description: Not Found - Resource is not found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Resource is not found"
+    MethodNotAllowed:
+      description: Method Not Allowed - The method is not allowed
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "The method is not allowed"
+    RequestTooLarge:
+      description: Request Too Large - The request body is too large
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "The request body is too large"
+    UnsupportedMediaType:
+      description: Unsupported Media Type - The media type is not supported
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "The media type is not supported"
+    TooManyRequests:
+      description: Too Many Requests - Request exceeds limit
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Request exceeds limit"
+                  retry_after:
+                    type: object
+                    properties:
+                      interval:
+                        type: integer
+                        example: 5
+                      unit:
+                        type: string
+                        example: "minute"
+  examples:
+    ExampleMultipleThreatScanReports:
+      summary: Example response with multiple threat scan report entries
+      value:
+        - detection_results:
+            - action: allow
+              data_type: prompt
+              detection_service: malicious_code
+              result_detail:
+                mc_report:
+                  code_analysis_by_type: []
+                  verdict: benign
+              verdict: benign
+            - action: allow
+              data_type: prompt
+              detection_service: pi
+              result_detail: {}
+              verdict: benign
+            - action: allow
+              data_type: response
+              detection_service: malicious_code
+              result_detail:
+                mc_report:
+                  code_analysis_by_type: []
+                  verdict: benign
+              verdict: benign
+          report_id: R46ea2f2b-0000-42e1-9972-bbc444628a26
+          req_id: 1
+          scan_id: 46ea2f2b-0000-42e1-9972-bbc444628a26
+          transaction_id: "2882"
+        - detection_results:
+            - action: allow
+              data_type: prompt
+              detection_service: dlp
+              result_detail:
+                dlp_report:
+                  data_pattern_rule1_verdict: NOT_MATCHED
+                  data_pattern_rule2_verdict: ""
+                  dlp_profile_id: "11995043"
+                  dlp_profile_name: Sensitive Content
+                  dlp_report_id: 3550C248655A559664EF2C5A2F905D4E1C29DF04818616D52B2FD3884A86F3F3
+              verdict: benign
+            - action: allow
+              data_type: prompt
+              detection_service: pi
+              result_detail: {}
+              verdict: benign
+            - action: allow
+              data_type: prompt
+              detection_service: tc
+              result_detail:
+                tc_report:
+                  confidence: ""
+                  verdict: benign
+              verdict: benign
+            - action: allow
+              data_type: prompt
+              detection_service: uf
+              result_detail:
+                urlf_report: []
+              verdict: benign
+            - action: allow
+              data_type: response
+              detection_service: dbs
+              result_detail:
+                dbs_report: []
+              verdict: benign
+            - action: allow
+              data_type: response
+              detection_service: dlp
+              result_detail:
+                dlp_report:
+                  data_pattern_rule1_verdict: NOT_MATCHED
+                  data_pattern_rule2_verdict: ""
+                  dlp_profile_id: "11995043"
+                  dlp_profile_name: Sensitive Content
+                  dlp_report_id: 1163C2B1618398358DE8DB8789C405AE87FECA33BECADF4BCE94780BD51C9A5C
+              verdict: benign
+            - action: block
+              data_type: response
+              detection_service: tc
+              result_detail:
+                tc_report:
+                  confidence: high
+                  verdict: malicious
+              verdict: malicious
+            - action: allow
+              data_type: response
+              detection_service: uf
+              result_detail:
+                urlf_report: []
+              verdict: benign
+          report_id: R46ea2f2b-0000-42e1-9972-bbc444628a26
+          req_id: 2
+          scan_id: 46ea2f2b-0000-42e1-9972-bbc444628a26
+          transaction_id: "2082"
+    ExampleAsyncScanResults:
+      summary: Example response showing multiple async scan results
+      value:
+        - req_id: 1
+          result:
+            action: "allow"
+            category: "benign"
+            completed_at: "2025-04-17T07:38:34Z"
+            profile_id: "6e06ec5b-a128-4a4f-a393-ff5da75203d9"
+            profile_name: "malicious-code-profile"
+            prompt_detected:
+              injection: false
+              malicious_code: false
+            report_id: "Ra43e8177-9776-465b-8ef3-a95c5a9607f8"
+            response_detected:
+              malicious_code: false
+            scan_id: "a43e8177-9776-465b-8ef3-a95c5a9607f8"
+            tr_id: "2882"
+          scan_id: "a43e8177-9776-465b-8ef3-a95c5a9607f8"
+          status: "complete"
+        - req_id: 2
+          result:
+            action: "block"
+            category: "malicious"
+            completed_at: "2025-04-17T07:38:35Z"
+            profile_id: "7b4a9de9-09e9-4ce5-b090-7f99fdffc9a5"
+            profile_name: "detect-toxic-content-profile"
+            prompt_detected:
+              dlp: false
+              injection: false
+              toxic_content: false
+              url_cats: false
+            report_id: "Ra43e8177-9776-465b-8ef3-a95c5a9607f8"
+            response_detected:
+              db_security: false
+              dlp: false
+              toxic_content: true
+              url_cats: false
+            scan_id: "a43e8177-9776-465b-8ef3-a95c5a9607f8"
+            tr_id: "2082"
+          scan_id: "a43e8177-9776-465b-8ef3-a95c5a9607f8"
+          status: "complete"
+    ExampleToolsListScan:
+      summary: Example sync scan response for MCP tools/list method
+      value:
+        source: "AI-Runtime-MCP-Server"
+        report_id: "R8d3f7a2e-1234-4b5c-9e8f-a1b2c3d4e5f6"
+        scan_id: "8d3f7a2e-1234-4b5c-9e8f-a1b2c3d4e5f6"
+        tr_id: "txn-5001"
+        session_id: "session-abc123"
+        profile_id: "7b4a9de9-09e9-4ce5-b090-7f99fdffc9a5"
+        profile_name: "mcp-security-profile"
+        category: "benign"
+        action: "allow"
+        tool_detected:
+          verdict: "benign"
+          metadata:
+            ecosystem: "mcp"
+            method: "tools/list"
+            server_name: "file-system-mcp-server"
+          summary:
+            detections:
+              injection: false
+              url_cats: false
+              dlp: false
+              db_security: false
+              toxic_content: false
+              malicious_code: false
+              agent: false
+              topic_violation: false
+            threats: []
+          output_detected:
+            detection_entries:
+              - tool_invoked: "read_file"
+                detections:
+                  injection: false
+                  url_cats: false
+                  dlp: false
+                  db_security: false
+                  toxic_content: false
+                  malicious_code: false
+                  agent: false
+                  topic_violation: false
+                threats: []
+              - tool_invoked: "write_file"
+                detections:
+                  injection: false
+                  url_cats: false
+                  dlp: false
+                  db_security: false
+                  toxic_content: false
+                  malicious_code: false
+                  agent: false
+                  topic_violation: false
+                threats: []
+        created_at: "2025-04-17T10:15:20Z"
+        completed_at: "2025-04-17T10:15:21Z"
+    ExampleToolsCallScan:
+      summary: Example sync scan response for MCP tools/call method with detected threats
+      value:
+        source: "AI-Runtime-MCP-Server"
+        report_id: "R9e4f8b3f-2345-5c6d-af9g-b2c3d4e5f6g7"
+        scan_id: "9e4f8b3f-2345-5c6d-af9g-b2c3d4e5f6g7"
+        tr_id: "txn-5002"
+        session_id: "session-xyz789"
+        profile_id: "7b4a9de9-09e9-4ce5-b090-7f99fdffc9a5"
+        profile_name: "mcp-security-profile"
+        category: "malicious"
+        action: "block"
+        tool_detected:
+          verdict: "malicious"
+          metadata:
+            ecosystem: "mcp"
+            method: "tools/call"
+            server_name: "database-mcp-server"
+            tool_invoked: "execute_query"
+          summary:
+            detections:
+              injection: true
+              url_cats: false
+              dlp: true
+              db_security: false
+              toxic_content: false
+              malicious_code: false
+              agent: false
+              topic_violation: false
+            threats:
+              - "credential leakage"
+          input_detected:
+            detection_entries:
+              - tool_invoked: "execute_query"
+                detections:
+                  injection: true
+                  url_cats: false
+                  dlp: false
+                  db_security: false
+                  toxic_content: false
+                  malicious_code: false
+                  agent: false
+                  topic_violation: false
+                threats:
+                details:
+                  topic_guardrails_details:
+                    allowed_topics: []
+                    blocked_topics: []
+          output_detected:
+            detection_entries:
+              - tool_invoked: "execute_query"
+                detections:
+                  injection: false
+                  url_cats: false
+                  dlp: true
+                  db_security: false
+                  toxic_content: false
+                  malicious_code: false
+                  agent: false
+                  topic_violation: false
+                threats:
+                  - "credential leakage"
+                details:
+                  topic_guardrails_details:
+                    allowed_topics: []
+                    blocked_topics: []
+                masked_data:
+                  data: "SELECT * FROM users WHERE password='***REDACTED***'"
+                  pattern_detections:
+                    - pattern: "password"
+                      locations:
+                        - [35, 54]
+        created_at: "2025-04-17T10:20:30Z"
+        completed_at: "2025-04-17T10:20:32Z"

--- a/specs/mgmt_service_docs.yaml
+++ b/specs/mgmt_service_docs.yaml
@@ -1,0 +1,2065 @@
+openapi: 3.0.3
+info:
+ title: Prisma AIRS API Management service
+ description: OpenAPI Specification for Prisma AIRS AI Runtime API Management Service
+ version: 0.0.0
+servers:
+ - url: 'https://api.sase.paloaltonetworks.com/aisec'
+   description: Prisma AIRS API service URL
+tags:
+ - name: API key
+   description: Operations related to API key management
+ - name: AI Sec Profile
+   description: Operations related to AI security profile management
+ - name: DLP Profiles
+   description: Operations related to DLP profile management
+ - name: Deployment Profiles
+   description: Operations related to deployment profile management
+ - name: Customer App
+   description: Operations related to customer application management
+ - name: Scan Logs
+   description: Operations related to scan log retrieval
+ - name: Oauth
+   description: Operations related to OAuth tokens
+ - name: Custom Topic
+   description: Operations related to custom topic management
+paths:
+ /v1/mgmt/apikey:
+   post:
+     summary: Create A New API KeyRequest to create a new API key
+     description: Post a new API key
+     tags:
+       - API key
+     security:
+       - Auth: []
+     operationId: CreateNewAPIKey
+     requestBody:
+       description: API key creation request object
+       required: true
+       content:
+         application/json:
+           schema:
+             $ref: '#/components/schemas/APIKeyCreationObject'
+     responses:
+       '200':
+         description: Successfully created a new API key
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/APIKeyObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/apikeys/tsg/{tsg_id}:
+   get:
+     summary: Retrieve All API Keys And Their Metadata By TSG ID
+     description: Get all API keys and their metadata for a given TSG ID
+     tags:
+       - API key
+     security:
+       - Auth: []
+     operationId: GetAllAPIKeysByTSGId
+     parameters:
+       - name: tsg_id
+         in: path
+         description: encoded TSG ID
+         required: true
+         schema:
+           type: string
+       - name: offset
+         in: query
+         description: The offset at which to start fetching more records
+         required: true
+         schema:
+           type: integer
+           format: int32
+       - name: limit
+         in: query
+         description: The number of records to return.
+         required: true
+         schema:
+           type: integer
+           format: int32
+     responses:
+       '200':
+         description: Successfully returned metadata for a given API key
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/PaginatedAPIKeyObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/apikey/delete/{api_key_name}:
+   delete:
+     summary: Delete an API Key
+     description: Delete a given API key and its associated customer app
+     tags:
+       - API key
+     security:
+       - Auth: []
+     operationId: DeleteAPIKey
+     parameters:
+       - name: api_key_name
+         in: path
+         description: API key Name to delete
+         required: true
+         schema:
+           type: string
+       - name: updated_by
+         in: query
+         description: The email address of the person who performed the deletion
+         required: true
+         schema:
+           type: string
+     responses:
+       '200':
+         description: Successfully deleted a given API key and associated customer app
+         content:
+           application/json:
+             schema:
+               type: object
+               properties:
+                 message:
+                   type: string
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/apikey/regenerate/{api_key_id}:
+   post:
+     summary: Regenerate an API Key
+     description: Regenerate an API key with the given uuid of apikey
+     tags:
+       - API key
+     security:
+       - Auth: []
+     operationId: RegenerateAPIKeyById
+     requestBody:
+       description: 'Request to regenerate an API key with the given uuid and optional rotation time interval and unit'
+       required: true
+       content:
+         application/json:
+           schema:
+             type: object
+             properties:
+               rotation_time_interval:
+                 type: integer
+                 format: int32
+               rotation_time_unit:
+                 type: string
+               updated_by:
+                 type: string
+             required:
+               - rotation_time_interval
+               - rotation_time_unit
+     parameters:
+       - name: api_key_id
+         in: path
+         description: API key uuid to regenerate
+         required: true
+         schema:
+           type: string
+     responses:
+       '200':
+         description: Successfully regenerated API key
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/APIKeyObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+
+ /v1/mgmt/profile:
+   post:
+     summary: Create A New AI Security Profile
+     description: Post a new AI Sec Profile
+     tags:
+       - AI Sec Profile
+     security:
+       - Auth: []
+     operationId: CreateNewAIProfile
+     requestBody:
+       description: AI Sec Profile creation request object
+       required: true
+       content:
+         application/json:
+           schema:
+             $ref: '#/components/schemas/AIProfileObject'
+     responses:
+       '200':
+         description: Successfully created a new AI Sec Profile
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/AIProfileObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/profile/{profile_id}:
+   delete:
+     summary: Delete An AI Security Profile
+     description: Delete a given AI Sec Profile
+     tags:
+       - AI Sec Profile
+     security:
+       - Auth: []
+     operationId: DeleteAIProfile
+     parameters:
+       - name: profile_id
+         in: path
+         description: AI Sec ProfileId to delete
+         required: true
+         schema:
+           type: string
+     responses:
+       '200':
+         description: Successfully deleted a given AI Sec Profile
+         content:
+           application/json:
+             schema:
+               type: object
+               properties:
+                 message:
+                   type: string
+       '409':
+         description: conflict occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/DeleteAIProfileResponse'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/profile/uuid/{profile_id}:
+   put:
+     summary: Modify AI Security Profile Details
+     description: Update metadata for a given AI Sec Profile Id.
+     tags:
+       - AI Sec Profile
+     security:
+       - Auth: []
+     operationId: UpdateProfileByProfileId
+     parameters:
+       - name: profile_id
+         in: path
+         description: encoded AI Sec Profile Id
+         required: true
+         schema:
+           type: string
+     requestBody:
+       description: AI SEC profile object
+       required: true
+       content:
+         application/json:
+           schema:
+             $ref: '#/components/schemas/AIProfileObject'
+     responses:
+       '200':
+         description: Successfully updated metadata for a given AI Sec Profile Id
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/AIProfileObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/profiles/tsg/{tsg_id}:
+   get:
+     summary: Retrieve All AI Security Profiles By TSG ID
+     description: Get all AI Sec Profiles and their metadata for a given CSP ID and TSG ID
+     tags:
+       - AI Sec Profile
+     security:
+       - Auth: []
+     operationId: GetAllAIProfilesByTsgId
+     parameters:
+       - name: tsg_id
+         in: path
+         description: encoded TSG ID
+         required: true
+         schema:
+           type: string
+       - name: offset
+         in: query
+         description: The offset at which to start fetching more records
+         required: true
+         schema:
+           type: integer
+           format: int32
+       - name: limit
+         in: query
+         description: The number of records to return.
+         required: true
+         schema:
+           type: integer
+           format: int32
+     responses:
+       '200':
+         description: Successfully returned metadata for all AI Sec Profiles for a given CSP Id and TSG Id.
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/PaginatedAIProfileObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/profile/{profile_id}/force:
+    delete:
+      summary: Request to force delete a given AI Sec Profile
+      description: Force delete a given AI Sec Profile, bypassing any safety checks
+      tags:
+       - AI Sec Profile
+      operationId: ForceDeleteAIProfile
+      parameters:
+        - name: profile_id
+          in: path
+          description: ProfileId to force delete
+          required: true
+          schema:
+            type: string
+        - name: updated_by
+          in: query
+          description: User performing the force deletion
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Successfully force deleted the AI Sec Profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        default:
+          description: error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+ /v1/mgmt/dlpprofiles:
+   get:
+     summary: Retrieve All DLP Profiles By TSG ID
+     description: Get all DLP Profiles and their metadata for a TSG ID
+     tags:
+       - DLP Profiles
+     security:
+       - Auth: []
+     operationId: GetAllDlpProfilesByTsgId
+     responses:
+       '200':
+         description: Successfully returned metadata for all DLP Profiles for a given TsgId.
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/ArrayDlpProfileObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/deploymentprofiles:
+   get:
+     summary: Retrieve All Deployment Profiles By TSG ID
+     description: Get all Deployment Profiles for a given TSG ID.
+     tags:
+       - Deployment Profiles
+     security:
+       - Auth: []
+     operationId: GetDeploymentProfilesByTsgId
+     parameters:
+       - name: unactivated
+         in: query
+         description: Get available and unactivated Deployment Profiles. Also include previously activated DP that do not have any associated apps or api keys.
+         required: false
+         schema:
+           type: boolean
+     responses:
+       '200':
+         description: Successfully returned Deployment Profiles for TSG Id
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/DeploymentProfilesObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/scanlogs:
+   post:
+     summary: Retrieve Scan Logs By TSG ID And Time Interval
+     description: Get the Scan logs for a TSG in the specified time interval
+     tags:
+       - Scan Logs
+     security:
+       - Auth: []
+     operationId: GetScanLogsByTime
+     parameters:
+       - name: time_interval
+         in: query
+         description: Time interval between which to return results
+         required: true
+         schema:
+           type: integer
+           format: int64
+       - name: time_unit
+         in: query
+         description: Indicates whether time_interval is in hour or days etc.
+         required: true
+         schema:
+           type: string
+       - name: pageNumber
+         in: query
+         description: The pageNumber requested
+         required: true
+         schema:
+           type: integer
+           format: int32
+       - name: pageSize
+         in: query
+         description: The number of records to return per page
+         required: true
+         schema:
+           type: integer
+           format: int32
+       - name: filter
+         in: query
+         description: The filter to be applied to the scan logs (all|benign|threat)
+         required: true
+         schema:
+           type: string
+     requestBody:
+       description: Encrypted page token
+       content:
+         application/json:
+           schema:
+             $ref: '#/components/schemas/PageTokenJsonObject'
+     responses:
+       '200':
+         description: Successfully returned records for Scan Requests
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/PaginatedScanResultsObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+
+ /v1/mgmt/customerapp:
+   get:
+     summary: Retrieve Customer Application Details
+     description: Get the customer app details for a given TSG ID and app name
+     tags:
+       - Customer App
+     security:
+       - Auth: []
+     operationId: GetCustomerApp
+     parameters:
+       - name: app_name
+         in: query
+         description: The customer app name for which to fetch details
+         required: true
+         schema:
+           type: string
+     responses:
+       '200':
+         description: Successfully returned metadata for a Customer App
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/CustomerAppObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+   delete:
+      summary: Delete a Customer App for a given TSG ID and app name
+      description: Delete a customer app for the specified TSG ID and app name
+      tags:
+        - Customer App
+      operationId: DeleteCustomerApp
+      parameters:
+        - name: app_name
+          in: query
+          description: The customer app name for which to delete
+          required: true
+          schema:
+            type: string
+        - name: updated_by
+          in: query
+          description: The email address of the user who is deleting the Customer App
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Successfully deleted Customer App
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerAppObject'
+        default:
+          description: error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+   put:
+      summary: Update Customer App
+      description: Update Customer App information for a given TSG ID and App name
+      tags:
+        - Customer App
+      operationId: updateCustomerAppById
+      parameters:
+        - name: customer_app_id
+          in: query
+          description: The uuid of the Customer App to update
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CustomerApp object
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomerAppObject'
+      responses:
+        200:
+          description: Successfully updated Customer App
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerAppObject'
+        default:
+          description: error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+ /v1/mgmt/customerapp/tsg/{tsg_id}:
+   get:
+     summary: Retrieve All Customer Applications By TSG ID
+     description: Get all Customer Apps and their metadata for a given TSG ID
+     tags:
+       - Customer App
+     security:
+       - Auth: []
+     operationId: GetAllCustomerAppsByTsgID
+     parameters:
+       - name: tsg_id
+         in: path
+         description: encoded TSG ID
+         required: true
+         schema:
+           type: string
+       - name: offset
+         in: query
+         description: The offset at which to start fetching more records
+         required: true
+         schema:
+           type: integer
+           format: int32
+       - name: limit
+         in: query
+         description: The number of records to return.
+         required: true
+         schema:
+           type: integer
+           format: int32
+     responses:
+       '200':
+         description: Successfully returned metadata for all Customer Apps for a given TSG ID
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/PaginatedCustomerAppObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/topic:
+   post:
+     summary: Create a New Custom Topic
+     description: Post a new Custom Topic
+     tags:
+       - Custom Topic
+     security:
+       - Auth: []
+     operationId: CreateNewCustomTopic
+     requestBody:
+       description: Custom Topic creation request object
+       required: true
+       content:
+         application/json:
+           schema:
+             $ref: '#/components/schemas/CustomTopicObject'
+     responses:
+       '200':
+         description: Successfully created a new Custom Topic
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/CustomTopicObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/topic/{topic_id}:
+   delete:
+     summary: Delete a Custom Topic
+     description: Delete a given Custom Topic
+     tags:
+       - Custom Topic
+     security:
+       - Auth: []
+     operationId: DeleteCustomTopic
+     parameters:
+       - name: topic_id
+         in: path
+         description: Custom TopicId to delete
+         required: true
+         schema:
+           type: string
+     responses:
+       '200':
+         description: Successfully deleted a given Custom Topic
+         content:
+           application/json:
+             schema:
+               type: object
+               properties:
+                 message:
+                   type: string
+       '409':
+         description: conflict occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/DeleteCustomTopicResponse'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+ /v1/mgmt/topic/{topic_id}/force:
+   delete:
+     summary: Force Delete a Custom Topic
+     description: Force delete a given Custom Topic, bypassing any safety checks
+     tags:
+       - Custom Topic
+     security:
+       - Auth: []
+     operationId: ForceDeleteCustomTopic
+     parameters:
+       - name: topic_id
+         in: path
+         description: Custom TopicId to force delete
+         required: true
+         schema:
+           type: string
+       - name: updated_by
+         in: query
+         description: User performing the force deletion
+         required: true
+         schema:
+           type: string
+     responses:
+       '200':
+         description: Successfully force deleted the Custom Topic
+         content:
+           application/json:
+             schema:
+               type: object
+               properties:
+                 message:
+                   type: string
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+
+ /v1/mgmt/topic/uuid/{topic_id}:
+   put:
+     summary: Mdify Custom Topic Details
+     description: Update metadata for a given Custom Topic Id.
+     tags:
+       - Custom Topic
+     security:
+       - Auth: []
+     operationId: UpdateTopicByTopicId
+     parameters:
+       - name: topic_id
+         in: path
+         description: encoded Custom Topic Id
+         required: true
+         schema:
+           type: string
+     requestBody:
+       description: Custom Topic object
+       required: true
+       content:
+         application/json:
+           schema:
+             $ref: '#/components/schemas/CustomTopicObject'
+     responses:
+       '200':
+         description: Successfully updated metadata for a given Custom Topic Id
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/CustomTopicObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+
+ /v1/mgmt/topics/tsg/{tsg_id}:
+   get:
+     summary: Retrieve All Custom Topics By TSG ID
+     description: Get all Custom Topics and their metadata for a given CSP ID and TSG ID
+     tags:
+       - Custom Topic
+     security:
+       - Auth: []
+     operationId: GetAllCustomTopicsByTsgId
+     parameters:
+       - name: tsg_id
+         in: path
+         description: encoded TSG ID
+         required: true
+         schema:
+           type: string
+       - name: offset
+         in: query
+         description: The offset at which to start fetching more records
+         required: true
+         schema:
+           type: integer
+           format: int32
+       - name: limit
+         in: query
+         description: The number of records to return.
+         required: true
+         schema:
+           type: integer
+           format: int32
+     responses:
+       '200':
+         description: Successfully returned metadata for all Custom Topics for a given CspId and TsgId.
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/PaginatedCustomTopicObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+
+ /v1/mgmt/oauth/invalidateToken:
+   post:
+     summary: Invalidate An OAuth 2.0 Token
+     description: Invalidate oauth2.0 token
+     tags:
+       - Oauth
+     security:
+       - Auth: []
+     operationId: InvalidateApigeeOauthToken
+     parameters:
+       - name: token
+         in: query
+         description: the oauth token to invalidate
+         required: true
+         schema:
+           type: string
+     requestBody:
+       description: ClientId and Customer App Name object
+       content:
+         application/json:
+           schema:
+             $ref: '#/components/schemas/ClientIdAndCustomerApp'
+     responses:
+       '200':
+         description: Successfully invalidated oauth2.0 token
+         content:
+           application/json:
+             schema:
+               type: string
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+
+ /v1/mgmt/oauth/client_credential/accesstoken:
+   post:
+     summary: Get An OAuth 2.0 Token For Client Credentials
+     description: Get oauth2.0 token for a given set of client credentials
+     tags:
+       - Oauth
+     security:
+       - Auth: []
+     operationId: GetApigeeOauthToken
+     parameters:
+       - name: tokenTtlInterval
+         in: query
+         description: The token time-to-live (TTL) interval (1h, 3h, 24h, 1 day, 7 days, 30 days) in the OAuth token request
+         required: false
+         schema:
+           type: integer
+           format: int32
+       - name: tokenTtlUnit
+         in: query
+         description: The token time-to-live (TTL) unit (hours) in the OAuth token request
+         required: false
+         schema:
+           type: string
+     requestBody:
+       description: ClientId and Customer App Name object
+       content:
+         application/json:
+           schema:
+             $ref: '#/components/schemas/ClientIdAndCustomerApp'
+     responses:
+       '200':
+         description: Successfully returned Oauth2 token for a given set of client credentials for a given TSG ID.
+           Default duration is 24 hour.
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Oauth2TokenObject'
+       default:
+         description: error occurred
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/Error'
+components:
+ securitySchemes:
+   Auth:
+     type: http
+     scheme: bearer
+     bearerFormat: JWT
+ schemas:
+    APIKeyObject:
+      type: object
+      description: API Key Object Structure
+      properties:
+        api_key_id:
+          type: string
+          description: API Key Id Value
+        api_key_last8:
+          type: string
+          description: Last eight Characters of api key
+        api_key_name:
+          type: string
+          description: API Key Name
+        auth_code:
+          type: string
+          description: Auth Code Associated with deployment profile
+        csp_id:
+          type: string
+          description: Customer Service Portal ID
+        tsg_id:
+          type: string
+          description: Tenant Service group ID
+        expiration:
+          type: string
+          format: date-time
+          description: Api Key Expiration Time Stamp
+        revoked:
+          type: boolean
+          description: Indicates if the API Key has been revoked
+        revoke_reason:
+          type: string
+          description: If API Key is Revoked, captures the reason for revocation
+        cust_app:
+          type: string
+          description: Customer app associated with the API Key
+        cust_env:
+          type: string
+          description: Environment refers to customer app environment like production, staging, etc
+        cust_ai_agent_framework:
+          type: string
+          description: Customer App AI Agent Framework
+        cust_cloud_provider:
+          type: string
+          description: Cloud provide refers to the customer's APPs LLM model cloud provider
+        created_by:
+          type: string
+          description: Email of the user that created the API Key
+        updated_by:
+          type: string
+          description: Email of the user that updated the API Key
+        last_modified_ts:
+          type: string
+          format: date-time
+          description: Api key last modified Time Stamp
+        rotation_time_interval:
+          type: integer
+          format: int32
+          description: Api Key Rotation time interval
+        rotation_time_unit:
+          type: string
+          description: Api Key Rotation time unit
+        dp_name:
+          type: string
+          description: Deployment Profile Name
+        status:
+          type: string
+          description: Api key status
+        api_key:
+          type: string
+          description: Api key Value
+        lic_expiration:
+          type: string
+          format: date-time
+          description: License Expiration Time stamp
+        avg_text_records:
+          type: integer
+          format: int32
+          description: Text Records
+        creation_ts:
+          type: string
+          format: date-time
+          description: API Key creation timestamp
+        customer_appId: 
+          type: string
+          description: Customer appId associated with the key  
+      required:
+        - api_key_id
+        - api_key_last8
+        - auth_code
+        - expiration
+        - revoked
+    APIKeyCreationObject:
+      type: object
+      properties:
+        dp_name:
+          type: string
+          description: Deployment Profile Name
+        auth_code:
+          type: string
+          description: Auth Code Associated with deployment profile
+        cust_app:
+          type: string
+          description: Customer app under deployment profile 
+        cust_env:
+          type: string
+          description: Environment refers to customer app environment like production, staging, etc
+        cust_cloud_provider:
+          type: string
+          description: Cloud provide refers to the customer's APPs LLM model cloud provider
+        cust_ai_agent_framework:
+          type: string
+          description: Customer App AI Agent Framework
+        revoked:
+          type: boolean
+          description: Revoke the current API key
+        created_by:
+          type: string
+          description: Api Key Created Time Stamp
+        api_key_name:
+          type: string
+          description: Api Key Name
+        rotation_time_interval:
+          type: integer
+          format: int32
+          description: Api Key Rotation time interval
+        rotation_time_unit:
+          type: string
+          description: Api Key Rotation time unit
+      required:
+        - auth_code
+        - revoked
+        - cust_app
+        - created_by
+        - api_key_name
+        - rotation_time_interval
+        - rotation_time_unit
+
+    PaginatedAPIKeyObject:
+      type: object
+      properties:
+        api_keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/APIKeyObject'
+            description: Type of object in the array.
+        next_offset:
+          type: integer
+          format: int32
+          description: Next offset from which to fetch the records
+    AIProfileObject:
+      type: object
+      properties:
+        profile_id:
+          type: string
+          description: Unique identifier for the profile. 
+        profile_name:
+          type: string
+          description: Name of the profile. 
+        revision:
+          type: integer
+          format: int32
+          description: AI Profile Revision
+        active:
+          type: boolean
+          description: Indicates if AI profile is active
+        policy:
+          type: object
+          properties:
+            dlp-data-profiles:
+              type: array
+              items:
+                $ref: '#/components/schemas/DLPDataProfileObject'
+            ai-security-profiles:
+              type: array
+              items:
+                $ref: '#/components/schemas/AiSecurityProfileObject'
+        created_by:
+          type: string
+          description: Email of the user who created the Profile
+        updated_by:
+          type: string
+          description: Email of the user who updated the Profile
+        last_modified_ts:
+          type: string
+          format: date-time
+          description: Profile Last Modified Time Stamp
+      required:
+        - profile_name
+        - revision
+        - policy
+    AiSecurityProfileObject:
+      type: object
+      properties:
+        model-type:
+          type: string
+          description: AI LLM model type
+        content-type:
+          type: string
+          description: Content for AI profile
+        model-configuration:
+          type: object
+          description: AI LLM model configuration
+          properties:
+            mask-data-in-storage:
+              type: boolean
+              description: Boolean flag to determine whether data is masked in storage
+            latency:
+              $ref: '#/components/schemas/LatencyObject'
+              description: Latency configuration for AI profile
+            data-protection:
+              $ref: '#/components/schemas/DataProtectionObject'
+              description: Data protection configuration for AI profile
+            app-protection:
+              $ref: '#/components/schemas/AppProtectionObject'
+              description: App protection configuration for AI profile
+            model-protection:
+              $ref: '#/components/schemas/ModelProtectionObject'
+              description: Model protection configuration for AI profile
+            agent-protection:
+              $ref: '#/components/schemas/AgentProtectionObject'
+              description: Agent protection configuration for AI profile 
+    DLPDataProfileObject:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the DLP data profile
+        uuid:
+          type: string
+          description: Unique identifier for the DLP data profile
+        id:
+          type: string
+          description: DLP data profile id
+        version:
+          type: string
+          description: DLP version 
+        rule1:
+          type: object
+          description: First DLP data profile rule configuration
+          properties:
+            action:
+              type: string
+              description: Action to be taken for the first DLP data profile rule
+        rule2:
+          type: object
+          description: Second DLP data profile rule configuration
+          properties:
+            action:
+              type: string
+              description: Action to be taken for the second DLP data profile rule
+        log-severity:
+          type: string
+          description: Severity level for data leak detection logging
+        non-file-based:
+          type: string
+          description: Non-file based data leak detection configuration
+        file-based:
+          type: string
+          description: File-based data leak detection configuration
+      required:
+        - name
+        - uuid
+    ModelProtectionObject:
+        type: array
+        items:
+          type: object
+          description: Model protection configuration details
+          properties:
+            name:
+              type: string
+              description: Name of the model protection configuration
+            action:
+              type: string
+              description: Action to be taken for model protection
+            topic-list:
+              type: array
+              description: List of topics for model protection configuration
+            items:
+              $ref: '#/components/schemas/TopicArray'
+        required:
+          - name
+          - action
+    DataProtectionObject:
+     type: object
+     properties:
+       data-leak-detection:
+         type: object
+         properties:
+           member:
+             type: array
+             items:
+               type: object
+               properties:
+                 text:
+                   type: string
+                 id:
+                   type: string
+                 version:
+                   type: string
+               required:
+                 - text
+           action:
+            type: string
+            description: Action to be taken for data leak detection
+           mask-data-inline:
+              type: boolean
+              description: Boolean flag to determine whether data is masked inline
+         required:
+           - member
+           - action
+
+    database-security:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Database security configuration name
+              action:
+                type: string
+                description: Action for DB security configuration
+            required:
+              - name
+              - action
+    AppProtectionObject:
+      type: object
+      properties:
+        alert-url-category:
+          type: object
+          description: URL categories for raising alerts
+          properties:
+            member:
+              type: array
+              items:
+                type: string
+        block-url-category:
+          type: object
+          description: URL categories to be blocked
+          properties:
+            member:
+              type: array
+              items:
+                type: string
+        allow-url-category:
+          type: object
+          description: URL categories to be allowed
+          properties:
+            member:
+              type: array
+              items:
+                type: string
+    default-url-category:
+          type: object
+          description: Default URL category configuration
+          properties:
+            member:
+              type: array
+              items:
+                type: string
+          required:
+            - member
+    url-detected-action:
+          type: string
+          description: Action to be taken when a URL matches the above categories
+    malicious-code-protection:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of malicious code protection configuration
+            action:
+              type: string
+              description: Action to be taken for malicious code protection
+          required:
+            - name
+            - action
+    AgentProtectionObject:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+            description: Name of agent protection configuration
+          action:
+            type: string
+            description: Action to be taken for agent protection configuration
+        required:
+          - name
+          - action
+    LatencyObject:
+      type: object
+      properties:
+        inline-timeout-action:
+          type: string
+          description: Action to be taken when inline timeout occurs
+        max-inline-latency:
+          type: integer
+          format: int32
+          description: Maximum allowed inline latency in seconds
+    TopicObject:
+      type: object
+      properties:
+        topic_name:
+          type: string
+          description: Name of the topic for topic guardrail configuration
+        topic_id:
+          type: string
+          description: Unique identifier for the topic
+        revision:
+          type: integer
+          format: int64
+          description: Revision number for the topic
+      required:
+        - topic_name
+        - topic_id
+        - revision
+    TopicArray:
+      type: object
+      description: Topic Array for Topic Guardrail
+      properties:
+        action:
+          type: string
+          description: Action to be taken for topic guardrails configuration
+        topic:
+          type: array
+          description: Custom Topic array
+          items:
+            $ref: '#/components/schemas/TopicObject'
+      required:
+        - action
+        - topic
+    PaginatedAIProfileObject:
+      type: object
+      properties:
+        ai_profiles:
+          type: array
+          items:
+            $ref: '#/components/schemas/AIProfileObject'
+        next_offset:
+          type: integer
+          format: int32
+    ArrayDlpProfileObject:
+      type: object
+      properties:
+        dlp_profiles:
+          type: array
+          items:
+            $ref: '#/components/schemas/DLPDataProfileObject'
+
+    PaginatedScanResultsObject:
+      type: object
+      properties:
+        scan_result_for_dashboard:
+          $ref: '#/components/schemas/ScanResultForDashboard'
+        total_pages:
+          type: integer
+          format: int32
+        page_number:
+          type: integer
+          format: int32
+        page_size:
+          type: integer
+          format: int32
+        page_token:
+          type: string
+        revision:
+          type: integer
+          format: int32
+          description: AI Profile Revision
+    ScanResultForDashboard:
+      type: object
+      properties:
+        text_records_count:
+          type: integer
+          format: int32
+          description: Total number of text-based records processed during scanning time interval selected in the dashboard
+        api_calls_count:
+          type: integer
+          format: int32
+          description: API calls counts processed during scanning time interval selected in the dashboard
+        threats_count:
+          type: integer
+          format: int32
+          description: Total number of threat instances detected during scanning time interval selected in the dashboard
+        all_transactions_count:
+          type: integer
+          format: int32
+          description: Total number of transactions processed during scanning time interval selected in the dashboard
+        benign_transaction_count:
+          type: integer
+          format: int32
+          description: Total number of benign transactions processed during scanning time interval selected in the dashboard
+        scan_result_entries:
+          type: array
+          description: List of scan logs
+          items:
+            $ref: '#/components/schemas/ScanResultEntryFromView'
+
+
+    ScanResultEntryFromView:
+      type: object
+      properties:
+        csp_id:
+          type: string
+          description: Cloud Service Portal ID associated with the scan 
+        tsg_id:
+          type: string
+          description: Tenant services groupId associated with the scan
+        scan_id:
+          type: string
+          description: Unique identifier for the specific scan 
+        scan_sub_req_id:
+          type: integer
+          format: int32
+          description: Scan sub request unique identifier
+        transaction_id:
+          type: string
+          description: Unique identifier for the transaction associated with the scan 
+        api_key_name:
+          type: string
+          description: API key used for this scan
+        profile_id:
+          type: string
+          description: Unique identifier of the AI security profile used for for this scan
+        profile_name:
+          type: string
+          description: Name of the AI security profile used for this scan
+        app_name:
+          type: string
+          description: Name of the customer app used in the scan
+        model_name:
+          type: string
+          description: Name of the AI model used in the scan 
+        user:
+          type: string
+          description: User identifier associated with the scan 
+        environment:
+          type: string
+          description: Cloud environment of the customer app associated with this scan
+        cloud_provider:
+          type: string
+          description: Cloud provider of the LLM associated with the scan
+        agent_framework:
+          type: string
+          description: Agent framework associated with the customer app associated with this scan
+        tokens:
+          type: integer
+          format: int32
+          description: Number of tokens processed during the scan
+        text_records:
+          type: integer
+          format: int32
+          description: Number of text records processed during the scan
+        report_id:
+          type: string
+          description: Unique identifier for the scan report generated
+        received_ts:
+          type: string
+          format: date-time
+          description: Timestamp when the scan was received
+        completed_ts:
+          type: string
+          format: date-time
+          description: Timestamp when the scan was completed
+        status:
+          type: string
+          description: Scan status indicating if scan was complete or pending
+        verdict:
+          type: string
+          description: Final Verdict of the scan 
+        action:
+          type: string
+          description: Final action of the scan
+        is_prompt:
+          type: boolean
+          description: Indicates whether prompt was present in the scan
+        is_response:
+          type: boolean
+          description: Indicates whether response was present in the scan
+        pi_final_verdict:
+          type: string
+          description: Final verdict for Prompt Injection detection 
+        uf_final_verdict:
+          type: string
+          description: Final verdict for URL filtering
+        dlp_final_verdict:
+          type: string
+          description: Final verdict for Data Loss Prevention detection
+        dbs_final_verdict:
+          type: string
+          description: Final verdict for Database Security detection
+        tc_final_verdict:
+          type: string
+          description: Final verdict for toxic content detection
+        mc_final_verdict:
+          type: string
+          description: Final verdict for Malicious Code detection
+        agent_final_verdict:
+          type: string
+          description: Final verdict for Agent security detection
+        cg_final_verdict:
+          type: string
+          description: Final verdict for contextual grounding detection
+        tg_final_verdict:
+          type: string
+          description: Final verdict for topic guardrails detection
+        prompt_pi_verdict:
+          type: string
+          description: Prompt Injection verdict for prompt scan 
+        prompt_uf_verdict:
+          type: string
+          description: URL filtering verdict for prompt scan
+        prompt_dlp_verdict:
+          type: string
+          description: Data Loss Protection verdict for prompt scan
+        prompt_tc_verdict:
+          type: string
+          description: Toxic Content verdict for prompt scan
+        prompt_mc_verdict:
+          type: string
+          description: Malicious Code verdict for prompt scan
+        prompt_agent_verdict:
+          type: string
+          description: Agent security verdict for prompt scan
+        prompt_tg_verdict:
+          type: string
+          description: Topic guardrails verdict for prompt scan
+        prompt_verdict:
+          type: string
+          description: Final verdict for prompt scan
+        prompt_pi_action:
+          type: string
+          description: Prompt Injection action for prompt scan
+        prompt_uf_action:
+          type: string
+          description: URL filtering action for prompt scan
+        prompt_dlp_action:
+          type: string
+          description: Data Loss Protection action for prompt scan
+        prompt_tc_action:
+          type: string
+          description: Toxic Content action for prompt scan
+        prompt_mc_action:
+          type: string
+          description: Malicious Code action for prompt scan
+        prompt_agent_action:
+          type: string
+          description: Agent security action for prompt scan
+        prompt_tg_action:
+          type: string
+          description: Topic guardrails action for prompt scan
+        response_uf_verdict:
+          type: string
+          description: URL filtering verdict for response scan
+        response_dlp_verdict:
+          type: string
+          description: Data Loss Prevention verdict for response scan
+        response_dbs_verdict:
+          type: string
+          description: Database Security verdict for response scan
+        response_tc_verdict:
+          type: string
+          description: Toxic Content verdict for response scan
+        response_mc_verdict:
+          type: string
+          description: Malicious Code verdict for response scan
+        response_agent_verdict:
+          type: string
+          description: Agent security verdict for response scan
+        response_cg_verdict:
+          type: string
+          description: Contextual Grounding verdict for response scan
+        response_tg_verdict:
+          type: string
+          description: Topic guardrails verdict for response scan
+        response_uf_action:
+          type: string
+          description: URL filtering action for response scan
+        response_dlp_action:
+          type: string
+          description: Data Loss Prevention action for response scan
+        response_dbs_action:
+          type: string
+          description: Database Security action for response scan
+        response_tc_action:
+          type: string
+          description: Toxic Content action for response scan
+        response_mc_action:
+          type: string
+          description: Malicious Code action for response scan
+        response_agent_action:
+          type: string
+          description: Agent security action for response scan
+        response_cg_action:
+          type: string
+          description: Contextual Grounding action for response scan
+        response_tg_action:
+          type: string
+          description: Topic guardrails action for response scan
+        response_verdict:
+          type: string
+          description: Final verdict for response scan
+        detection_service_flags:
+          type: integer
+          format: int32
+          description: Bitwise flags for detection service settings
+        content_masked:
+          type: boolean
+          description: Indicates whether content was masked when we returned the results
+        user_ip:
+          type: string
+          description: IP address of the user initiating the request
+      required:
+        - csp_id
+        - tsg_id
+        - scan_id
+        - scan_sub_req_id
+        - api_key_name
+        - app_name
+        - tokens
+        - text_records
+    DeploymentProfilesObject:
+     type: object
+     properties:
+       deployment_profiles:
+         type: array
+         items:
+           $ref: '#/components/schemas/DeploymentProfileEntryObject'
+       status:
+         type: string
+     required:
+       - deployment_profiles
+       - status
+    DeploymentProfileEntryObject:
+     type: object
+     properties:
+       dp_name:
+         type: string
+       auth_code:
+         type: string
+       tsg_id:
+         type: string
+       status:
+         type: string
+       expiration_date:
+         type: string
+       ave_text_records:
+         type: integer
+         format: int32
+     required:
+       - dp_name
+       - auth_code
+    ThreatScanReportObjects:
+     type: array
+     items:
+       $ref: '#/components/schemas/ThreatScanReportObject'
+    ThreatScanReportObject:
+     type: object
+     properties:
+       report_id:
+         type: string
+       scan_id:
+         type: string
+       sub_scan_req_id:
+         type: integer
+         format: uint32
+       transaction_id:
+         type: string
+       detection_results:
+         type: array
+         items:
+           $ref: '#/components/schemas/DetectionServiceResultObject'
+    DetectionServiceResultObject:
+     type: object
+     properties:
+       data_type:
+         type: string
+       detection_service:
+         type: string
+       verdict:
+         type: string
+       action:
+         type: string
+       result_detail:
+         $ref: '#/components/schemas/DSDetailResultObject'
+    DSDetailResultObject:
+     type: object
+     properties:
+       pi_report:
+         $ref: '#/components/schemas/PiReportObject'
+       urlf_report:
+         $ref: '#/components/schemas/UrlFilterReportObject'
+       dlp_report:
+         $ref: '#/components/schemas/DlpReportObject'
+       dbs_report:
+         $ref: '#/components/schemas/DbsReportObject'
+       tc_report:
+         $ref: '#/components/schemas/TcReportObject'
+       mc_report:
+         $ref: '#/components/schemas/McReportObject'
+       agent_report:
+         $ref: '#/components/schemas/AgentReportObject'
+    DbsReportObject:
+     type: array
+     items:
+       $ref: '#/components/schemas/DbsEntryObject'
+    DbsEntryObject:
+      type: object
+      properties:
+        sub_type:
+          type: string
+          description: Database security sql query sub-type, such as "create", "read", "update", or "delete"
+        verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+        action:
+          type: string
+          description: The action is set to "block" or "allow" based on AI security profile used for scanning
+        probability:
+          type: number
+          format: float
+    TcReportObject:
+      type: object
+      properties:
+        confidence:
+          type: string
+          description: Confidence level of the threat classification (“high" and "moderate")
+        verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+        probability:
+          type: number
+          format: float
+
+
+    McReportObject:
+      type: object
+      properties:
+        verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+        code_info:
+          type: array
+          items:
+            $ref: '#/components/schemas/McEntryObject'
+
+
+    McEntryObject:
+      type: object
+      properties:
+        file_type:
+          type: string
+          description: code file type, such as "javascript", "Python", "VBScript" and others
+        code_sha256:
+          type: string
+          description: SHA256 of the code file that was analyzed, such as a code snippet containing the potentially malicious code
+
+
+    AgentReportObject:
+      type: object
+      properties:
+        model_verdict:
+          type: string
+          description: Detection service verdict such as "malicious" or "benign"
+        agent_framework:
+          type: string
+          description: Agent builder framework used to build Agents such as "AWS_Agent_Builder", "Microsoft_copilot_studio" and others
+        agent_patterns:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentEntryObject'
+
+
+    AgentEntryObject:
+      type: object
+      properties:
+        category_type:
+          type: string
+          description: Agent threat category type, such as "tools misuse", "memory manipulation" and others
+        verdict:
+          type: string
+          description: Verdict associated with the Agent threat Category, such as "malicious" or "benign"
+
+
+    PiReportObject:
+      type: object
+      properties:
+        probability:
+          type: number
+          format: float
+
+
+    UrlFilterReportObject:
+      type: array
+      items:
+        $ref: '#/components/schemas/UrlfEntryObject'
+
+
+    UrlfEntryObject:
+      type: object
+      properties:
+        url:
+          type: string
+          description: URL in the Scan request
+        risk_level:
+          type: string
+          description: Risk level associated with the URL, such as "high", "medium", or "low"
+        categories:
+          type: array
+          description: Categories associated with the URL
+          items:
+            type: string
+
+
+    DlpReportObject:
+      type: object
+      properties:
+        report_id:
+          type: string
+          description: Unique identifier for the DLP report
+        dlp_profile_name:
+          type: string
+          description: DLP profile name used for the scan
+        dlp_profile_id:
+          type: string
+          description: Unique identifier for the DLP profile used for the scan
+        dlp_profile_version:
+          type: integer
+          format: int32
+          description: Version of the DLP profile used for the scan
+        data_pattern_rule1_verdict:
+          type: string
+          description: Indicates whether there was a content match for this rule such as "MATCHED" or "NOT MATCHED"
+        data_pattern_rule2_verdict:
+          type: string
+          description: Indicates whether there was a content match for this rule such as "MATCHED" or "NOT MATCHED"
+
+
+    CustomerAppObject:
+      type: object
+      properties:
+        customer_appId:
+          type: string
+          description: Customer Application ID
+        tsg_id:
+          type: string
+          description: Tenant Service Group ID for Customer App
+        app_name:
+          type: string
+          description: Customer Application Name
+        model_name:
+          type: string
+          description: AI Model Name for Customer App
+        cloud_provider:
+          type: string
+          description: Cloud Provider Name for Customer App
+        environment:
+          type: string
+          description: Cloud Provider Name for Customer App
+        status:
+          type: string
+          description: Indicates Customer App Status whether completed or pending
+        created_by:
+          type: string
+          description: Customer App timestamp
+        updated_by:
+          type: string
+          description: Customer App timestamp
+        ai_agent_framework:
+          type: string
+          description: Framework associated for AI Agent
+      required:
+        - tsg_id
+        - app_name
+        - cloud_provider
+        - environment
+
+
+    PaginatedCustomerAppObject:
+      type: object
+      properties:
+        customer_apps:
+          type: array
+          items:
+            $ref: '#/components/schemas/CustomerAppObjectWithAPIKeyAndDP'
+        next_offset:
+          type: integer
+          format: int32
+
+
+    CustomerAppObjectWithAPIKeyAndDP:
+      type: object
+      properties:
+        customer_appId:
+          type: string
+        tsg_id:
+          type: string
+          description: Tenant Service Group ID
+        app_name:
+          type: string
+        model_name:
+          type: string
+        cloud_provider:
+          type: string
+        environment:
+          type: string
+        ai_agent_framework:
+          type: string
+        api_keys_dp_info:
+          type: array
+          items:
+            $ref: '#/components/schemas/APIKeyDPInfo'
+      required:
+        - tsg_id
+        - customer_appId
+        - app_name
+        - cloud_provider
+        - environment
+
+
+    APIKeyDPInfo:
+      type: object
+      properties:
+        api_key_name:
+          type: string
+        dp_name:
+          type: string
+        auth_code:
+          type: string
+      required:
+        - api_key_name
+        - dp_name
+        - auth_code
+
+
+    PageTokenJsonObject:
+      type: object
+      properties:
+        page_token:
+          type: string
+    ClientIdAndCustomerApp:
+     type: object
+     properties:
+       client_id:
+         type: string
+       customer_app:
+         type: string
+     required:
+       - client_id
+       - customer_app
+    Oauth2TokenObject:
+     type: object
+     properties:
+       token_type:
+         type: string
+       issued_at:
+         type: string
+       client_id:
+         type: string
+       access_token:
+         type: string
+       expires_in:
+         type: string
+       status:
+         type: string
+     required:
+       - access_token
+    Error:
+     type: object
+     properties:
+       status_code:
+         type: integer
+         format: int32
+       error_message:
+         type: string
+     required:
+       - status_code
+       - error_message
+    CustomTopicObject:
+      type: object
+      properties:
+        topic_id:
+          type: string
+          description: Unique identifier for the custom topic
+        topic_name:
+          type: string
+          description: Name of the custom topic
+        revision:
+          type: integer
+          format: int64
+          description: Revision number of the custom topic
+        active:
+          type: boolean
+          description: Indicates whether the custom topic is currently active or disabled
+        description:
+          type: string
+          description: Detailed explanation or purpose of the custom topic
+        examples:
+          type: array
+          description: List of example usages or scenarios for the custom topic
+          items:
+            type: string
+        created_by:
+          type: string
+          description: Email address of the user who created the custom topic
+        updated_by:
+          type: string
+          description: Email address of the user who last modified the custom topic
+        last_modified_ts:
+          type: string
+          format: date-time
+          description: Timestamp of when the custom topic was last modified
+        created_ts:
+          type: string
+          format: date-time
+          description: Timestamp of when the custom topic was created
+      required:
+       - topic_name
+       - revision
+       - description
+       - examples
+    PaginatedCustomTopicObject:
+     type: object
+     properties:
+       custom_topics:
+         type: array
+         items:
+           $ref: '#/components/schemas/CustomTopicObject'
+       next_offset:
+         type: integer
+         format: int32
+    DeleteCustomTopicResponse:
+     type: object
+     properties:
+       message:
+         type: string
+       payload:
+         type: array
+         items:
+           $ref: '#/components/schemas/ProfilePayload'
+         minItems: 0
+    ProfilePayload:
+     type: object
+     properties:
+       profile_id:
+         type: string
+       profile_name:
+         type: string
+       revision:
+         type: integer
+         format: int64
+    DeleteAIProfileResponse:
+     type: object
+     properties:
+       message:
+         type: string
+       payload:
+         type: array
+         items:
+           $ref: '#/components/schemas/PolicyPayload'
+         minItems: 0
+    PolicyPayload:
+     type: object
+     properties:
+       policy_id:
+         type: string
+       policy_name:
+         type: string
+       priority:
+         type: integer
+         format: int64     

--- a/test/preflight/diff-schemas.spec.ts
+++ b/test/preflight/diff-schemas.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { diffSchemas } from '../../scripts/preflight/diff-schemas.js';
+import type { JsonSchema } from '../../scripts/preflight/diff-schemas.js';
+
+const openapi: JsonSchema = {
+  type: 'object',
+  required: ['id', 'name'],
+  properties: {
+    id: { type: 'string' },
+    name: { type: 'string' },
+    count: { type: 'integer' },
+  },
+};
+
+describe('diffSchemas — happy path', () => {
+  it('returns no findings when schemas match', () => {
+    const zod: JsonSchema = {
+      type: 'object',
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        count: { type: 'integer' },
+      },
+    };
+    expect(diffSchemas(zod, openapi, 'Item')).toEqual([]);
+  });
+
+  it('returns no findings when Zod has fewer optional fields than OpenAPI', () => {
+    // Zod is allowed to be a subset for non-required fields (passthrough handles extras)
+    const zod: JsonSchema = {
+      type: 'object',
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+      },
+    };
+    expect(diffSchemas(zod, openapi, 'Item')).toEqual([]);
+  });
+});
+
+describe('diffSchemas — required-field drift', () => {
+  it('flags when Zod is missing a field OpenAPI marks as required', () => {
+    const zod: JsonSchema = {
+      type: 'object',
+      required: ['id'],
+      properties: { id: { type: 'string' } },
+    };
+    const findings = diffSchemas(zod, openapi, 'Item');
+    expect(
+      findings.some((f) => f.kind === 'missing-required-field' && f.path.includes('name')),
+    ).toBe(true);
+  });
+
+  it('flags when Zod has a required field OpenAPI does not require', () => {
+    const zod: JsonSchema = {
+      type: 'object',
+      required: ['id', 'name', 'count'],
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        count: { type: 'integer' },
+      },
+    };
+    const findings = diffSchemas(zod, openapi, 'Item');
+    expect(
+      findings.some((f) => f.kind === 'extra-required-field' && f.path.includes('count')),
+    ).toBe(true);
+  });
+});
+
+describe('diffSchemas — type drift', () => {
+  it('flags primitive type mismatch on a shared field', () => {
+    const zod: JsonSchema = {
+      type: 'object',
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'integer' }, // wrong
+        name: { type: 'string' },
+      },
+    };
+    const findings = diffSchemas(zod, openapi, 'Item');
+    expect(findings.some((f) => f.kind === 'type-mismatch' && f.path.includes('id'))).toBe(true);
+  });
+
+  it('treats integer and number as compatible', () => {
+    const zod: JsonSchema = {
+      type: 'object',
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        count: { type: 'number' }, // OpenAPI says integer
+      },
+    };
+    expect(diffSchemas(zod, openapi, 'Item')).toEqual([]);
+  });
+});
+
+describe('diffSchemas — phantom fields', () => {
+  it('flags a field present in Zod but not in OpenAPI', () => {
+    const zod: JsonSchema = {
+      type: 'object',
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        ghost: { type: 'string' }, // not in OpenAPI
+      },
+    };
+    const findings = diffSchemas(zod, openapi, 'Item');
+    expect(findings.some((f) => f.kind === 'extra-field' && f.path.includes('ghost'))).toBe(true);
+  });
+});
+
+describe('diffSchemas — top-level type mismatch', () => {
+  it('flags when one is object and the other is array', () => {
+    const zod: JsonSchema = { type: 'array', items: { type: 'string' } };
+    const findings = diffSchemas(zod, openapi, 'Item');
+    expect(findings.some((f) => f.kind === 'type-mismatch' && f.path === '$')).toBe(true);
+  });
+});
+
+describe('diffSchemas — output shape', () => {
+  it('every finding includes schemaName', () => {
+    const zod: JsonSchema = { type: 'object', required: [], properties: {} };
+    const findings = diffSchemas(zod, openapi, 'Bag');
+    for (const f of findings) {
+      expect(f.schemaName).toBe('Bag');
+      expect(typeof f.message).toBe('string');
+      expect(f.message.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/test/preflight/load-spec.spec.ts
+++ b/test/preflight/load-spec.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadSpec } from '../../scripts/preflight/load-spec.js';
+
+const fixture = `
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Item:
+      type: object
+      required: [id, name]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        count: { type: integer }
+    Bag:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Item'
+`;
+
+let fixturePath: string;
+let tmpDir: string;
+
+describe('loadSpec', () => {
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'preflight-'));
+    fixturePath = join(tmpDir, 'fixture.yaml');
+    await writeFile(fixturePath, fixture, 'utf-8');
+  });
+
+  it('returns a map of component schema names to JSON Schema', async () => {
+    const map = await loadSpec(fixturePath);
+    expect(map.size).toBeGreaterThanOrEqual(2);
+    expect(map.has('Item')).toBe(true);
+    expect(map.has('Bag')).toBe(true);
+  });
+
+  it('preserves required fields on each schema', async () => {
+    const map = await loadSpec(fixturePath);
+    const item = map.get('Item');
+    expect(item?.required).toEqual(['id', 'name']);
+  });
+
+  it('dereferences $ref so nested schemas are inline', async () => {
+    const map = await loadSpec(fixturePath);
+    const bag = map.get('Bag');
+    const items = (bag as { properties: { items: { items: unknown } } }).properties.items.items;
+    expect(items).toMatchObject({ type: 'object', required: ['id', 'name'] });
+  });
+
+  it('throws on missing spec file', async () => {
+    await expect(loadSpec('/nonexistent/path.yaml')).rejects.toThrow();
+  });
+});
+
+describe('loadSpec — empty components', () => {
+  it('returns empty map for spec with no components', async () => {
+    const empty = `
+openapi: 3.0.3
+info: { title: Empty, version: 1.0.0 }
+paths: {}
+`;
+    const path = join(tmpDir, 'empty.yaml');
+    await writeFile(path, empty, 'utf-8');
+    const map = await loadSpec(path);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('loadSpec cleanup', () => {
+  it('removes tmpDir', async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    expect(true).toBe(true);
+  });
+});

--- a/test/preflight/resolve-name.spec.ts
+++ b/test/preflight/resolve-name.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import type { OpenAPIV3 } from 'openapi-types';
+import { resolveOpenApiName, NAME_SUFFIXES } from '../../scripts/preflight/resolve-name.js';
+
+const obj: OpenAPIV3.SchemaObject = { type: 'object' };
+
+describe('resolveOpenApiName', () => {
+  it('matches by bare name when present', () => {
+    const map = new Map([['Item', obj]]);
+    expect(resolveOpenApiName('Item', map)?.matchedName).toBe('Item');
+  });
+
+  it('falls back to <Name>Object suffix', () => {
+    const map = new Map([['DbsEntryObject', obj]]);
+    expect(resolveOpenApiName('DbsEntry', map)?.matchedName).toBe('DbsEntryObject');
+  });
+
+  it('prefers bare name over a suffixed alternate when both exist', () => {
+    const map = new Map([
+      ['Item', obj],
+      ['ItemObject', obj],
+    ]);
+    expect(resolveOpenApiName('Item', map)?.matchedName).toBe('Item');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(resolveOpenApiName('Nope', new Map())).toBeUndefined();
+  });
+
+  it('returns the schema object on match', () => {
+    const map = new Map([['Item', obj]]);
+    expect(resolveOpenApiName('Item', map)?.schema).toBe(obj);
+  });
+
+  it('NAME_SUFFIXES starts with empty string', () => {
+    expect(NAME_SUFFIXES[0]).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #117. Part of #113. Drift triage tracked in #118.

## Summary

Adds the pre-flight schema check infrastructure:

- `scripts/preflight-schemas.ts` — entry point. Loads every \`specs/*.yaml\` (dereferenced via \`@apidevtools/swagger-parser\`), every \`*Schema\` export from \`src/models/*.ts\`, converts the Zod schemas with \`zod-to-json-schema\`, and diffs them against the matching OpenAPI components.
- `scripts/preflight/{load-spec,diff-schemas,resolve-name}.ts` — testable helpers.
- `test/preflight/*.spec.ts` — 21 unit tests covering each helper.
- \`npm run preflight\` (strict, exit 1 on drift) and \`npm run preflight:warn\` (log only, exit 0).
- CI runs \`preflight:warn\` so drift is visible in logs without blocking. Will flip to strict once drift is fixed (PR 2e in #118).

## Initial drift snapshot

| | count |
|---|---|
| Zod schemas total | 250 |
| OpenAPI components total | 295 |
| Matched (by direct or suffix lookup) | 82 |
| Unmatched (likely local helpers) | 168 |
| Drift findings on matched schemas | 81 |

Top offenders: \`ScanIdResult\` (12), \`ScanResponse\` (12), \`DetectionServiceResultObject\` (9), \`ToolDetected\` (9), \`DSDetailResultObject\` (8). Full triage in #118.

## Test plan

- [x] \`npm run test\` — 1055/1055 (was 1034, +21)
- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npm run build\` — CJS + ESM + types build successfully
- [x] \`npm run preflight:warn\` runs locally and prints the report
- [x] No public API change (\`src/index.ts\` unchanged)
- [x] No new runtime deps (only devDeps: \`@apidevtools/swagger-parser\`, \`zod-to-json-schema\`, \`tsx\`)

## Follow-ups

- #118 — drift triage and fix sequence (PRs 2a–2e)
- After 2e: flip CI gate from \`preflight:warn\` to \`preflight\`

## Out of scope

- OpenAPI → Zod codegen (deferred from grilling)
- Fixing the 81 drift findings or 168 unmatched schemas