### PR TITLE
refactor: migrate management domain to unified request() helper

### DIFF
--- a/.changeset/0012-management-migrate-to-request.md
+++ b/.changeset/0012-management-migrate-to-request.md
@@ -1,0 +1,10 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Internal: migrate management domain to unified `request()` helper (no public API change).
+
+- Every method in `src/management/*.ts` now flows through `request()` with a `responseSchema` — runtime Zod validation is on for management responses.
+- `ManagementClient` constructs one `OAuthAuth` adapter and shares it across sub-clients.
+- Local UUID helpers replaced with shared `assertUuid` from `src/validators.ts`.
+- `managementHttpRequest` is unused by management; deletion deferred to PR 5 once `model-security` and `red-team` migrate.

--- a/src/management/api-keys.ts
+++ b/src/management/api-keys.ts
@@ -1,19 +1,22 @@
 import { MGMT_API_KEY_PATH, MGMT_API_KEYS_TSG_PATH } from '../constants.js';
-import { managementHttpRequest } from './management-http-client.js';
-import type { OAuthClient } from './oauth-client.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
 import type { PaginationOptions } from './profiles.js';
-import type {
-  ApiKey,
-  ApiKeyCreateRequest,
-  ApiKeyRegenerateRequest,
-  ApiKeyListResponse,
-  ApiKeyDeleteResponse,
+import {
+  ApiKeySchema,
+  ApiKeyListResponseSchema,
+  ApiKeyDeleteResponseSchema,
+  type ApiKey,
+  type ApiKeyCreateRequest,
+  type ApiKeyRegenerateRequest,
+  type ApiKeyListResponse,
+  type ApiKeyDeleteResponse,
 } from '../models/mgmt-api-key.js';
 
 /** @internal */
 export interface ApiKeysClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   tsgId: string;
   numRetries: number;
 }
@@ -21,32 +24,32 @@ export interface ApiKeysClientOptions {
 /** Client for AIRS API key management operations. */
 export class ApiKeysClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly tsgId: string;
   private readonly numRetries: number;
 
   constructor(opts: ApiKeysClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.tsgId = opts.tsgId;
     this.numRetries = opts.numRetries;
   }
 
   /**
    * Create a new API key.
-   * @param request - API key creation request.
+   * @param body - API key creation request.
    * @returns The created API key.
    */
-  async create(request: ApiKeyCreateRequest): Promise<ApiKey> {
-    const res = await managementHttpRequest<ApiKey>({
+  async create(body: ApiKeyCreateRequest): Promise<ApiKey> {
+    return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: MGMT_API_KEY_PATH,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: ApiKeySchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -60,15 +63,15 @@ export class ApiKeysClient {
       limit: String(opts?.limit ?? 100),
     };
 
-    const res = await managementHttpRequest<ApiKeyListResponse>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MGMT_API_KEYS_TSG_PATH}/${this.tsgId}`,
       params,
-      oauthClient: this.oauthClient,
+      responseSchema: ApiKeyListResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -78,32 +81,32 @@ export class ApiKeysClient {
    * @returns Deletion confirmation.
    */
   async delete(apiKeyName: string, updatedBy: string): Promise<ApiKeyDeleteResponse> {
-    const res = await managementHttpRequest<ApiKeyDeleteResponse>({
+    return request({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: `${MGMT_API_KEY_PATH}/delete/${encodeURIComponent(apiKeyName)}`,
       params: { updated_by: updatedBy },
-      oauthClient: this.oauthClient,
+      responseSchema: ApiKeyDeleteResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
    * Regenerate an API key.
    * @param apiKeyId - UUID of the API key to regenerate.
-   * @param request - Regeneration request with rotation config.
+   * @param body - Regeneration request with rotation config.
    * @returns The regenerated API key.
    */
-  async regenerate(apiKeyId: string, request: ApiKeyRegenerateRequest): Promise<ApiKey> {
-    const res = await managementHttpRequest<ApiKey>({
+  async regenerate(apiKeyId: string, body: ApiKeyRegenerateRequest): Promise<ApiKey> {
+    return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: `${MGMT_API_KEY_PATH}/regenerate/${encodeURIComponent(apiKeyId)}`,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: ApiKeySchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/src/management/client.ts
+++ b/src/management/client.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MGMT_ENDPOINT, MGMT_ENDPOINT } from '../constants.js';
+import { OAuthAuth } from '../http/auth/oauth.js';
 import { resolveOAuthConfig } from '../oauth-config.js';
 import { ProfilesClient } from './profiles.js';
 import { TopicsClient } from './topics.js';
@@ -52,56 +53,15 @@ export class ManagementClient {
       primaryEnvPrefix: 'PANW_MGMT',
     });
 
-    this.profiles = new ProfilesClient({
-      baseUrl,
-      oauthClient,
-      tsgId,
-      numRetries,
-    });
+    const auth = new OAuthAuth(oauthClient);
 
-    this.topics = new TopicsClient({
-      baseUrl,
-      oauthClient,
-      tsgId,
-      numRetries,
-    });
-
-    this.apiKeys = new ApiKeysClient({
-      baseUrl,
-      oauthClient,
-      tsgId,
-      numRetries,
-    });
-
-    this.customerApps = new CustomerAppsClient({
-      baseUrl,
-      oauthClient,
-      tsgId,
-      numRetries,
-    });
-
-    this.dlpProfiles = new DlpProfilesClient({
-      baseUrl,
-      oauthClient,
-      numRetries,
-    });
-
-    this.deploymentProfiles = new DeploymentProfilesClient({
-      baseUrl,
-      oauthClient,
-      numRetries,
-    });
-
-    this.scanLogs = new ScanLogsClient({
-      baseUrl,
-      oauthClient,
-      numRetries,
-    });
-
-    this.oauth = new OAuthManagementClient({
-      baseUrl,
-      oauthClient,
-      numRetries,
-    });
+    this.profiles = new ProfilesClient({ baseUrl, auth, tsgId, numRetries });
+    this.topics = new TopicsClient({ baseUrl, auth, tsgId, numRetries });
+    this.apiKeys = new ApiKeysClient({ baseUrl, auth, tsgId, numRetries });
+    this.customerApps = new CustomerAppsClient({ baseUrl, auth, tsgId, numRetries });
+    this.dlpProfiles = new DlpProfilesClient({ baseUrl, auth, numRetries });
+    this.deploymentProfiles = new DeploymentProfilesClient({ baseUrl, auth, numRetries });
+    this.scanLogs = new ScanLogsClient({ baseUrl, auth, numRetries });
+    this.oauth = new OAuthManagementClient({ baseUrl, auth, numRetries });
   }
 }

--- a/src/management/customer-apps.ts
+++ b/src/management/customer-apps.ts
@@ -1,13 +1,18 @@
 import { MGMT_CUSTOMER_APP_PATH, MGMT_CUSTOMER_APPS_TSG_PATH } from '../constants.js';
-import { managementHttpRequest } from './management-http-client.js';
-import type { OAuthClient } from './oauth-client.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
 import type { PaginationOptions } from './profiles.js';
-import type { CustomerApp, CustomerAppListResponse } from '../models/mgmt-customer-app.js';
+import {
+  CustomerAppSchema,
+  CustomerAppListResponseSchema,
+  type CustomerApp,
+  type CustomerAppListResponse,
+} from '../models/mgmt-customer-app.js';
 
 /** @internal */
 export interface CustomerAppsClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   tsgId: string;
   numRetries: number;
 }
@@ -15,13 +20,13 @@ export interface CustomerAppsClientOptions {
 /** Client for AIRS customer application management operations. */
 export class CustomerAppsClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly tsgId: string;
   private readonly numRetries: number;
 
   constructor(opts: CustomerAppsClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.tsgId = opts.tsgId;
     this.numRetries = opts.numRetries;
   }
@@ -32,15 +37,15 @@ export class CustomerAppsClient {
    * @returns The customer app.
    */
   async get(appName: string): Promise<CustomerApp> {
-    const res = await managementHttpRequest<CustomerApp>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: MGMT_CUSTOMER_APP_PATH,
       params: { app_name: appName },
-      oauthClient: this.oauthClient,
+      responseSchema: CustomerAppSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -54,15 +59,15 @@ export class CustomerAppsClient {
       limit: String(opts?.limit ?? 100),
     };
 
-    const res = await managementHttpRequest<CustomerAppListResponse>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MGMT_CUSTOMER_APPS_TSG_PATH}/${this.tsgId}`,
       params,
-      oauthClient: this.oauthClient,
+      responseSchema: CustomerAppListResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -71,17 +76,17 @@ export class CustomerAppsClient {
    * @param request - Updated customer app data.
    * @returns The updated customer app.
    */
-  async update(customerAppId: string, request: CustomerApp): Promise<CustomerApp> {
-    const res = await managementHttpRequest<CustomerApp>({
+  async update(customerAppId: string, body: CustomerApp): Promise<CustomerApp> {
+    return request({
       method: 'PUT',
       baseUrl: this.baseUrl,
       path: MGMT_CUSTOMER_APP_PATH,
       params: { customer_app_id: customerAppId },
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: CustomerAppSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -91,14 +96,14 @@ export class CustomerAppsClient {
    * @returns The deleted customer app.
    */
   async delete(appName: string, updatedBy: string): Promise<CustomerApp> {
-    const res = await managementHttpRequest<CustomerApp>({
+    return request({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: MGMT_CUSTOMER_APP_PATH,
       params: { app_name: appName, updated_by: updatedBy },
-      oauthClient: this.oauthClient,
+      responseSchema: CustomerAppSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/src/management/deployment-profiles.ts
+++ b/src/management/deployment-profiles.ts
@@ -1,12 +1,15 @@
 import { MGMT_DEPLOYMENT_PROFILES_PATH } from '../constants.js';
-import { managementHttpRequest } from './management-http-client.js';
-import type { OAuthClient } from './oauth-client.js';
-import type { DeploymentProfilesResponse } from '../models/mgmt-deployment-profile.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import {
+  DeploymentProfilesResponseSchema,
+  type DeploymentProfilesResponse,
+} from '../models/mgmt-deployment-profile.js';
 
 /** @internal */
 export interface DeploymentProfilesClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   numRetries: number;
 }
 
@@ -19,12 +22,12 @@ export interface DeploymentProfileListOptions {
 /** Client for listing deployment profiles. */
 export class DeploymentProfilesClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly numRetries: number;
 
   constructor(opts: DeploymentProfilesClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.numRetries = opts.numRetries;
   }
 
@@ -37,14 +40,14 @@ export class DeploymentProfilesClient {
     const params: Record<string, string> = {};
     if (opts?.unactivated !== undefined) params.unactivated = String(opts.unactivated);
 
-    const res = await managementHttpRequest<DeploymentProfilesResponse>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: MGMT_DEPLOYMENT_PROFILES_PATH,
       params: Object.keys(params).length > 0 ? params : undefined,
-      oauthClient: this.oauthClient,
+      responseSchema: DeploymentProfilesResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/src/management/dlp-profiles.ts
+++ b/src/management/dlp-profiles.ts
@@ -1,24 +1,27 @@
 import { MGMT_DLP_PROFILES_PATH } from '../constants.js';
-import { managementHttpRequest } from './management-http-client.js';
-import type { OAuthClient } from './oauth-client.js';
-import type { DlpProfileListResponse } from '../models/mgmt-dlp-profile.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import {
+  DlpProfileListResponseSchema,
+  type DlpProfileListResponse,
+} from '../models/mgmt-dlp-profile.js';
 
 /** @internal */
 export interface DlpProfilesClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   numRetries: number;
 }
 
 /** Client for listing DLP profiles. */
 export class DlpProfilesClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly numRetries: number;
 
   constructor(opts: DlpProfilesClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.numRetries = opts.numRetries;
   }
 
@@ -27,13 +30,13 @@ export class DlpProfilesClient {
    * @returns List of DLP profiles.
    */
   async list(): Promise<DlpProfileListResponse> {
-    const res = await managementHttpRequest<DlpProfileListResponse>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: MGMT_DLP_PROFILES_PATH,
-      oauthClient: this.oauthClient,
+      responseSchema: DlpProfileListResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/src/management/oauth-management.ts
+++ b/src/management/oauth-management.ts
@@ -1,12 +1,17 @@
+import { z } from 'zod';
 import { MGMT_OAUTH_INVALIDATE_PATH, MGMT_OAUTH_TOKEN_PATH } from '../constants.js';
-import { managementHttpRequest } from './management-http-client.js';
-import type { OAuthClient } from './oauth-client.js';
-import type { ClientIdAndCustomerApp, Oauth2Token } from '../models/mgmt-oauth.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import {
+  Oauth2TokenSchema,
+  type ClientIdAndCustomerApp,
+  type Oauth2Token,
+} from '../models/mgmt-oauth.js';
 
 /** @internal */
 export interface OAuthManagementClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   numRetries: number;
 }
 
@@ -23,12 +28,12 @@ export interface GetTokenOptions {
 /** Client for OAuth token management operations. */
 export class OAuthManagementClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly numRetries: number;
 
   constructor(opts: OAuthManagementClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.numRetries = opts.numRetries;
   }
 
@@ -39,16 +44,16 @@ export class OAuthManagementClient {
    * @returns Confirmation string.
    */
   async invalidateToken(token: string, body: ClientIdAndCustomerApp): Promise<string> {
-    const res = await managementHttpRequest<string>({
+    return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: MGMT_OAUTH_INVALIDATE_PATH,
       params: { token },
       body,
-      oauthClient: this.oauthClient,
+      responseSchema: z.string(),
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -62,15 +67,15 @@ export class OAuthManagementClient {
       params.tokenTtlInterval = String(opts.tokenTtlInterval);
     if (opts.tokenTtlUnit !== undefined) params.tokenTtlUnit = opts.tokenTtlUnit;
 
-    const res = await managementHttpRequest<Oauth2Token>({
+    return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: MGMT_OAUTH_TOKEN_PATH,
       params: Object.keys(params).length > 0 ? params : undefined,
       body: opts.body,
-      oauthClient: this.oauthClient,
+      responseSchema: Oauth2TokenSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/src/management/profiles.ts
+++ b/src/management/profiles.ts
@@ -1,13 +1,16 @@
 import { MGMT_PROFILE_PATH, MGMT_PROFILES_TSG_PATH } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
-import { isValidUuid } from '../utils.js';
-import { managementHttpRequest } from './management-http-client.js';
-import type { OAuthClient } from './oauth-client.js';
-import type {
-  SecurityProfile,
-  CreateSecurityProfileRequest,
-  SecurityProfileListResponse,
-  DeleteProfileResponse,
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  SecurityProfileSchema,
+  SecurityProfileListResponseSchema,
+  DeleteProfileResponseSchema,
+  type SecurityProfile,
+  type CreateSecurityProfileRequest,
+  type SecurityProfileListResponse,
+  type DeleteProfileResponse,
 } from '../models/mgmt-security-profile.js';
 
 /** Pagination parameters for list operations. */
@@ -21,7 +24,7 @@ export interface PaginationOptions {
 /** @internal */
 export interface ProfilesClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   tsgId: string;
   numRetries: number;
 }
@@ -29,32 +32,32 @@ export interface ProfilesClientOptions {
 /** Client for AIRS security profile CRUD operations. */
 export class ProfilesClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly tsgId: string;
   private readonly numRetries: number;
 
   constructor(opts: ProfilesClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.tsgId = opts.tsgId;
     this.numRetries = opts.numRetries;
   }
 
   /**
    * Create a new security profile.
-   * @param request - Profile configuration.
+   * @param body - Profile configuration.
    * @returns The created security profile.
    */
-  async create(request: CreateSecurityProfileRequest): Promise<SecurityProfile> {
-    const res = await managementHttpRequest<SecurityProfile>({
+  async create(body: CreateSecurityProfileRequest): Promise<SecurityProfile> {
+    return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: MGMT_PROFILE_PATH,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: SecurityProfileSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -68,15 +71,15 @@ export class ProfilesClient {
       limit: String(opts?.limit ?? 100),
     };
 
-    const res = await managementHttpRequest<SecurityProfileListResponse>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MGMT_PROFILES_TSG_PATH}/${this.tsgId}`,
       params,
-      oauthClient: this.oauthClient,
+      responseSchema: SecurityProfileListResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -118,26 +121,20 @@ export class ProfilesClient {
   /**
    * Update an existing security profile.
    * @param profileId - UUID of the profile to update.
-   * @param request - Updated profile configuration.
+   * @param body - Updated profile configuration.
    * @returns The updated security profile.
    */
-  async update(profileId: string, request: CreateSecurityProfileRequest): Promise<SecurityProfile> {
-    if (!isValidUuid(profileId)) {
-      throw new AISecSDKException(
-        `Invalid profile_id: ${profileId}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<SecurityProfile>({
+  async update(profileId: string, body: CreateSecurityProfileRequest): Promise<SecurityProfile> {
+    assertUuid(profileId, 'profile_id');
+    return request({
       method: 'PUT',
       baseUrl: this.baseUrl,
       path: `${MGMT_PROFILE_PATH}/uuid/${profileId}`,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: SecurityProfileSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -146,21 +143,15 @@ export class ProfilesClient {
    * @returns Deletion confirmation message.
    */
   async delete(profileId: string): Promise<DeleteProfileResponse> {
-    if (!isValidUuid(profileId)) {
-      throw new AISecSDKException(
-        `Invalid profile_id: ${profileId}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<DeleteProfileResponse>({
+    assertUuid(profileId, 'profile_id');
+    return request({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: `${MGMT_PROFILE_PATH}/${profileId}`,
-      oauthClient: this.oauthClient,
+      responseSchema: DeleteProfileResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -170,21 +161,15 @@ export class ProfilesClient {
    * @returns Deletion confirmation message.
    */
   async forceDelete(profileId: string, updatedBy: string): Promise<DeleteProfileResponse> {
-    if (!isValidUuid(profileId)) {
-      throw new AISecSDKException(
-        `Invalid profile_id: ${profileId}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<DeleteProfileResponse>({
+    assertUuid(profileId, 'profile_id');
+    return request({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: `${MGMT_PROFILE_PATH}/${profileId}/force`,
       params: { updated_by: updatedBy },
-      oauthClient: this.oauthClient,
+      responseSchema: DeleteProfileResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/src/management/scan-logs.ts
+++ b/src/management/scan-logs.ts
@@ -1,12 +1,12 @@
 import { MGMT_SCAN_LOGS_PATH } from '../constants.js';
-import { managementHttpRequest } from './management-http-client.js';
-import type { OAuthClient } from './oauth-client.js';
-import type { PaginatedScanResults } from '../models/mgmt-scan-log.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { PaginatedScanResultsSchema, type PaginatedScanResults } from '../models/mgmt-scan-log.js';
 
 /** @internal */
 export interface ScanLogsClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   numRetries: number;
 }
 
@@ -29,12 +29,12 @@ export interface ScanLogQueryOptions {
 /** Client for retrieving scan logs. */
 export class ScanLogsClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly numRetries: number;
 
   constructor(opts: ScanLogsClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.numRetries = opts.numRetries;
   }
 
@@ -54,15 +54,15 @@ export class ScanLogsClient {
 
     const body = opts.page_token ? { page_token: opts.page_token } : undefined;
 
-    const res = await managementHttpRequest<PaginatedScanResults>({
+    return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: MGMT_SCAN_LOGS_PATH,
       params,
       body,
-      oauthClient: this.oauthClient,
+      responseSchema: PaginatedScanResultsSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/src/management/topics.ts
+++ b/src/management/topics.ts
@@ -1,20 +1,22 @@
 import { MGMT_TOPIC_PATH, MGMT_TOPICS_TSG_PATH, MGMT_TOPIC_FORCE_PATH } from '../constants.js';
-import { AISecSDKException, ErrorType } from '../errors.js';
-import { isValidUuid } from '../utils.js';
-import { managementHttpRequest } from './management-http-client.js';
-import type { OAuthClient } from './oauth-client.js';
-import type {
-  CustomTopic,
-  CreateCustomTopicRequest,
-  CustomTopicListResponse,
-  DeleteTopicResponse,
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  CustomTopicSchema,
+  CustomTopicListResponseSchema,
+  DeleteTopicResponseSchema,
+  type CustomTopic,
+  type CreateCustomTopicRequest,
+  type CustomTopicListResponse,
+  type DeleteTopicResponse,
 } from '../models/mgmt-custom-topic.js';
 import type { PaginationOptions } from './profiles.js';
 
 /** @internal */
 export interface TopicsClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   tsgId: string;
   numRetries: number;
 }
@@ -22,32 +24,32 @@ export interface TopicsClientOptions {
 /** Client for AIRS custom topic CRUD operations. */
 export class TopicsClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly tsgId: string;
   private readonly numRetries: number;
 
   constructor(opts: TopicsClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.tsgId = opts.tsgId;
     this.numRetries = opts.numRetries;
   }
 
   /**
    * Create a new custom topic.
-   * @param request - Topic definition with name, description, and examples.
+   * @param body - Topic definition with name, description, and examples.
    * @returns The created custom topic.
    */
-  async create(request: CreateCustomTopicRequest): Promise<CustomTopic> {
-    const res = await managementHttpRequest<CustomTopic>({
+  async create(body: CreateCustomTopicRequest): Promise<CustomTopic> {
+    return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: MGMT_TOPIC_PATH,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: CustomTopicSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -61,40 +63,34 @@ export class TopicsClient {
       limit: String(opts?.limit ?? 100),
     };
 
-    const res = await managementHttpRequest<CustomTopicListResponse>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MGMT_TOPICS_TSG_PATH}/${this.tsgId}`,
       params,
-      oauthClient: this.oauthClient,
+      responseSchema: CustomTopicListResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
    * Update an existing custom topic.
    * @param topicId - UUID of the topic to update.
-   * @param request - Updated topic definition.
+   * @param body - Updated topic definition.
    * @returns The updated custom topic.
    */
-  async update(topicId: string, request: CreateCustomTopicRequest): Promise<CustomTopic> {
-    if (!isValidUuid(topicId)) {
-      throw new AISecSDKException(
-        `Invalid topic_id: ${topicId}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<CustomTopic>({
+  async update(topicId: string, body: CreateCustomTopicRequest): Promise<CustomTopic> {
+    assertUuid(topicId, 'topic_id');
+    return request({
       method: 'PUT',
       baseUrl: this.baseUrl,
       path: `${MGMT_TOPIC_PATH}/uuid/${topicId}`,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: CustomTopicSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -103,21 +99,15 @@ export class TopicsClient {
    * @returns Deletion confirmation message.
    */
   async delete(topicId: string): Promise<DeleteTopicResponse> {
-    if (!isValidUuid(topicId)) {
-      throw new AISecSDKException(
-        `Invalid topic_id: ${topicId}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<DeleteTopicResponse>({
+    assertUuid(topicId, 'topic_id');
+    return request({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: `${MGMT_TOPIC_PATH}/${topicId}`,
-      oauthClient: this.oauthClient,
+      responseSchema: DeleteTopicResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -127,25 +117,19 @@ export class TopicsClient {
    * @returns Deletion confirmation message.
    */
   async forceDelete(topicId: string, updatedBy?: string): Promise<DeleteTopicResponse> {
-    if (!isValidUuid(topicId)) {
-      throw new AISecSDKException(
-        `Invalid topic_id: ${topicId}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
+    assertUuid(topicId, 'topic_id');
     const params: Record<string, string> | undefined = updatedBy
       ? { updated_by: updatedBy }
       : undefined;
 
-    const res = await managementHttpRequest<DeleteTopicResponse>({
+    return request({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: `${MGMT_TOPIC_FORCE_PATH}/${topicId}`,
       params,
-      oauthClient: this.oauthClient,
+      responseSchema: DeleteTopicResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/test/management/api-keys.spec.ts
+++ b/test/management/api-keys.spec.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ApiKeysClient } from '../../src/management/api-keys.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -24,7 +21,7 @@ describe('ApiKeysClient', () => {
   beforeEach(() => {
     client = new ApiKeysClient({
       baseUrl: 'https://api.example.com',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       tsgId: '123',
       numRetries: 0,
     });

--- a/test/management/customer-apps.spec.ts
+++ b/test/management/customer-apps.spec.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CustomerAppsClient } from '../../src/management/customer-apps.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -24,7 +21,7 @@ describe('CustomerAppsClient', () => {
   beforeEach(() => {
     client = new CustomerAppsClient({
       baseUrl: 'https://api.example.com',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       tsgId: '123',
       numRetries: 0,
     });

--- a/test/management/deployment-profiles.spec.ts
+++ b/test/management/deployment-profiles.spec.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { DeploymentProfilesClient } from '../../src/management/deployment-profiles.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -24,7 +21,7 @@ describe('DeploymentProfilesClient', () => {
   beforeEach(() => {
     client = new DeploymentProfilesClient({
       baseUrl: 'https://api.example.com',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       numRetries: 0,
     });
   });

--- a/test/management/dlp-profiles.spec.ts
+++ b/test/management/dlp-profiles.spec.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { DlpProfilesClient } from '../../src/management/dlp-profiles.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -24,7 +21,7 @@ describe('DlpProfilesClient', () => {
   beforeEach(() => {
     client = new DlpProfilesClient({
       baseUrl: 'https://api.example.com',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       numRetries: 0,
     });
   });

--- a/test/management/oauth-management.spec.ts
+++ b/test/management/oauth-management.spec.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { OAuthManagementClient } from '../../src/management/oauth-management.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -24,7 +21,7 @@ describe('OAuthManagementClient', () => {
   beforeEach(() => {
     client = new OAuthManagementClient({
       baseUrl: 'https://api.example.com',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       numRetries: 0,
     });
   });

--- a/test/management/profiles.spec.ts
+++ b/test/management/profiles.spec.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ProfilesClient } from '../../src/management/profiles.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 import { AISecSDKException } from '../../src/errors.js';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -32,7 +29,7 @@ describe('ProfilesClient', () => {
   beforeEach(() => {
     client = new ProfilesClient({
       baseUrl: 'https://api.example.com/aisec',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       tsgId: '123',
       numRetries: 0,
     });

--- a/test/management/scan-logs.spec.ts
+++ b/test/management/scan-logs.spec.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ScanLogsClient } from '../../src/management/scan-logs.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -24,7 +21,7 @@ describe('ScanLogsClient', () => {
   beforeEach(() => {
     client = new ScanLogsClient({
       baseUrl: 'https://api.example.com',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       numRetries: 0,
     });
   });

--- a/test/management/topics.spec.ts
+++ b/test/management/topics.spec.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TopicsClient } from '../../src/management/topics.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 import { AISecSDKException } from '../../src/errors.js';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -32,7 +29,7 @@ describe('TopicsClient', () => {
   beforeEach(() => {
     client = new TopicsClient({
       baseUrl: 'https://api.example.com/aisec',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       tsgId: '456',
       numRetries: 0,
     });


### PR DESCRIPTION
Closes #120. Part of #113. Builds on #114 (PR 1) and #117 (PR 2).

## Summary

Every sub-client in \`src/management/\` now flows through the unified \`request()\` helper with a \`responseSchema\`. **Runtime Zod validation is on for management responses** — the campaign's first domain to flip the parse switch.

- \`src/management/client.ts\` — builds one \`OAuthAuth\` adapter, shared across all 8 sub-clients.
- \`src/management/{api-keys,customer-apps,deployment-profiles,dlp-profiles,oauth-management,profiles,scan-logs,topics}.ts\` — methods rewritten to call \`request()\` with \`responseSchema: <Name>Schema\`.
- Local UUID/length helpers absorbed into \`src/validators.ts:assertUuid\`.
- Constructor signature of every sub-client: \`auth: AuthAdapter\` replaces \`oauthClient: OAuthClient\`.
- Test files updated to pass \`auth\` (passthrough adapter) instead of mocked OAuthClient.

## Scope adjustment

\`src/management/management-http-client.ts\` was originally tagged for deletion in this PR, but it is still used by \`src/red-team/*\` and \`src/model-security/*\`. **Deletion deferred to PR 5** (after PR 4 finishes their migration).

## Test plan

- [x] \`npm run test\` — 1055/1055 (no count change vs main)
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` — clean
- [x] \`npm run build\` — CJS + ESM + types
- [x] \`npm run preflight:warn\` — drift count unchanged at 81 (no new drift introduced; tracked in #118)
- [x] Public API \`src/index.ts\` byte-identical (verified \`git diff\`)
- [x] \`@internal\` audit — all sub-client \`*Options\` interfaces remain internal; sub-client classes themselves stay public

## Follow-ups

- PR 4 — model-security + red-team migration (next in sequence)
- PR 5 — scan migration + delete \`src/management/management-http-client.ts\` and \`src/http-client.ts\`
- #118 — drift triage PRs (interleaved with the migration sequence)