### PR TITLE
refactor: migrate model-security domain + add Listing module

### DIFF
--- a/.changeset/0013-model-security-listing.md
+++ b/.changeset/0013-model-security-listing.md
@@ -1,0 +1,10 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Internal: migrate model-security domain to unified `request()` helper, add Listing module (no public API change).
+
+- All 3 sub-clients in `src/model-security/` use `request()` with `responseSchema` — runtime Zod validation is on for model-security responses.
+- `ModelSecurityClient` constructs one `OAuthAuth` adapter, shares across sub-clients.
+- New `src/listing.ts` exports `ListingOptions` + `serializeListing` for shared pagination/search params; `model-security` list endpoints already use it. Red-team migration in a follow-up PR.
+- `RequestSpec.responseSchema` widened to accept Zod schemas with diverging input/output types (e.g. `.default()`-laden schemas).

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -36,7 +36,11 @@ export interface RequestSpec<TResponse = void> {
   path: string;
   params?: Record<string, string | string[]>;
   body?: unknown;
-  responseSchema?: z.ZodType<TResponse>;
+  // `any` for Zod's def/input generics so schemas where input ≠ output (e.g. those built with
+  // `.default()` or `.passthrough()`) still satisfy the constraint. Only the parsed output shape
+  // is consumed at runtime.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  responseSchema?: z.ZodType<TResponse, any, any>;
   numRetries: number;
   auth: AuthAdapter;
 }

--- a/src/listing.ts
+++ b/src/listing.ts
@@ -1,0 +1,26 @@
+/**
+ * Pagination + search options shared by every list endpoint across the OAuth domains.
+ * Sub-clients extend this with endpoint-specific filter fields and merge their additions
+ * into the params record returned by {@link serializeListing}.
+ */
+export interface ListingOptions {
+  /** Number of records to skip from the start. */
+  skip?: number;
+  /** Max records to return. */
+  limit?: number;
+  /** Free-text search filter. */
+  search?: string;
+}
+
+/**
+ * @internal
+ * Serialize the canonical listing fields into a string-keyed params record. Extra fields on
+ * the input are ignored — callers add their own endpoint-specific filters to the result.
+ */
+export function serializeListing(opts?: ListingOptions): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts?.skip !== undefined) params.skip = String(opts.skip);
+  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  if (opts?.search !== undefined) params.search = opts.search;
+  return params;
+}

--- a/src/model-security/client.ts
+++ b/src/model-security/client.ts
@@ -5,13 +5,14 @@ import {
   MODEL_SEC_MGMT_ENDPOINT,
   MODEL_SEC_PYPI_AUTH_PATH,
 } from '../constants.js';
+import { OAuthAuth } from '../http/auth/oauth.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
 import { resolveOAuthConfig } from '../oauth-config.js';
-import { managementHttpRequest } from '../management/management-http-client.js';
 import { ModelSecurityScansClient } from './scans-client.js';
 import { ModelSecurityGroupsClient } from './security-groups-client.js';
 import { ModelSecurityRulesClient } from './security-rules-client.js';
-import type { OAuthClient } from '../management/oauth-client.js';
-import type { PyPIAuthResponse } from '../models/model-security.js';
+import { PyPIAuthResponseSchema, type PyPIAuthResponse } from '../models/model-security.js';
 
 /** Options for constructing a {@link ModelSecurityClient}. */
 export interface ModelSecurityClientOptions {
@@ -45,7 +46,7 @@ export class ModelSecurityClient {
   public readonly securityRules: ModelSecurityRulesClient;
 
   private readonly mgmtEndpoint: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly numRetries: number;
 
   constructor(opts: ModelSecurityClientOptions = {}) {
@@ -65,25 +66,20 @@ export class ModelSecurityClient {
       fallbackEnvPrefix: 'PANW_MGMT',
     });
 
-    this.oauthClient = oauthClient;
+    const auth = new OAuthAuth(oauthClient);
+    this.auth = auth;
     this.mgmtEndpoint = mgmtEndpoint;
     this.numRetries = numRetries;
 
-    this.scans = new ModelSecurityScansClient({
-      baseUrl: dataEndpoint,
-      oauthClient,
-      numRetries,
-    });
-
+    this.scans = new ModelSecurityScansClient({ baseUrl: dataEndpoint, auth, numRetries });
     this.securityGroups = new ModelSecurityGroupsClient({
       baseUrl: mgmtEndpoint,
-      oauthClient,
+      auth,
       numRetries,
     });
-
     this.securityRules = new ModelSecurityRulesClient({
       baseUrl: mgmtEndpoint,
-      oauthClient,
+      auth,
       numRetries,
     });
   }
@@ -93,13 +89,13 @@ export class ModelSecurityClient {
    * @returns PyPI auth response with URL and expiration.
    */
   async getPyPIAuth(): Promise<PyPIAuthResponse> {
-    const res = await managementHttpRequest<PyPIAuthResponse>({
+    return request({
       method: 'GET',
       baseUrl: this.mgmtEndpoint,
       path: MODEL_SEC_PYPI_AUTH_PATH,
-      oauthClient: this.oauthClient,
+      responseSchema: PyPIAuthResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/src/model-security/scans-client.ts
+++ b/src/model-security/scans-client.ts
@@ -3,31 +3,37 @@ import {
   MODEL_SEC_EVALUATIONS_PATH,
   MODEL_SEC_VIOLATIONS_PATH,
 } from '../constants.js';
-import { AISecSDKException, ErrorType } from '../errors.js';
-import { isValidUuid } from '../utils.js';
-import { managementHttpRequest } from '../management/management-http-client.js';
-import type { OAuthClient } from '../management/oauth-client.js';
-import type {
-  ScanCreateRequest,
-  ScanBaseResponse,
-  ScanList,
-  RuleEvaluationList,
-  RuleEvaluationResponse,
-  FileList,
-  LabelsCreateRequest,
-  LabelsResponse,
-  ViolationList,
-  ViolationResponse,
-  LabelKeyList,
-  LabelValueList,
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { serializeListing, type ListingOptions } from '../listing.js';
+import { assertUuid } from '../validators.js';
+import {
+  ScanBaseResponseSchema,
+  ScanListSchema,
+  RuleEvaluationListSchema,
+  RuleEvaluationResponseSchema,
+  FileListSchema,
+  LabelsResponseSchema,
+  ViolationListSchema,
+  ViolationResponseSchema,
+  LabelKeyListSchema,
+  LabelValueListSchema,
+  type ScanCreateRequest,
+  type ScanBaseResponse,
+  type ScanList,
+  type RuleEvaluationList,
+  type RuleEvaluationResponse,
+  type FileList,
+  type LabelsCreateRequest,
+  type LabelsResponse,
+  type ViolationList,
+  type ViolationResponse,
+  type LabelKeyList,
+  type LabelValueList,
 } from '../models/model-security.js';
 
-/** Pagination options for model security scan listing. */
-export interface ModelSecurityScanListOptions {
-  /** Number of items to skip. */
-  skip?: number;
-  /** Maximum number of items to return. */
-  limit?: number;
+/** Pagination + filter options for model security scan listing. */
+export interface ModelSecurityScanListOptions extends ListingOptions {
   /** Sort field: 'created_at' or 'updated_at'. */
   sort_by?: string;
   /** Sort order: 'asc' or 'desc'. */
@@ -49,11 +55,7 @@ export interface ModelSecurityScanListOptions {
 }
 
 /** Options for listing rule evaluations within a scan. */
-export interface ModelSecurityEvaluationListOptions {
-  /** Number of items to skip. */
-  skip?: number;
-  /** Maximum number of items to return. */
-  limit?: number;
+export interface ModelSecurityEvaluationListOptions extends ListingOptions {
   /** Sort field: 'created_at' or 'updated_at'. */
   sort_field?: string;
   /** Sort order: 'asc' or 'desc'. */
@@ -65,11 +67,7 @@ export interface ModelSecurityEvaluationListOptions {
 }
 
 /** Options for listing files within a scan. */
-export interface ModelSecurityFileListOptions {
-  /** Number of items to skip. */
-  skip?: number;
-  /** Maximum number of items to return. */
-  limit?: number;
+export interface ModelSecurityFileListOptions extends ListingOptions {
   /** Sort field: 'path' or 'type'. */
   sort_field?: string;
   /** Sort direction: 'asc' or 'desc'. */
@@ -83,37 +81,22 @@ export interface ModelSecurityFileListOptions {
 }
 
 /** Options for listing label keys or values. */
-export interface ModelSecurityLabelListOptions {
-  /** Number of items to skip. */
-  skip?: number;
-  /** Maximum number of items to return. */
-  limit?: number;
-  /** Search query string. */
-  search?: string;
-}
+export type ModelSecurityLabelListOptions = ListingOptions;
 
 /** Options for listing violations. */
-export interface ModelSecurityViolationListOptions {
-  /** Number of items to skip. */
-  skip?: number;
-  /** Maximum number of items to return. */
-  limit?: number;
-}
+export type ModelSecurityViolationListOptions = ListingOptions;
 
 /** @internal */
 export interface ModelSecurityScansClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   numRetries: number;
 }
 
-/** Build query params for scan list. */
 function buildScanListParams(
   opts?: ModelSecurityScanListOptions,
 ): Record<string, string | string[]> {
-  const params: Record<string, string | string[]> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  const params: Record<string, string | string[]> = serializeListing(opts);
   if (opts?.sort_by !== undefined) params.sort_by = opts.sort_by;
   if (opts?.sort_order !== undefined) params.sort_order = opts.sort_order;
   if (opts?.search_query !== undefined) params.search_query = opts.search_query;
@@ -127,13 +110,10 @@ function buildScanListParams(
   return params;
 }
 
-/** Build query params for evaluation list. */
 function buildEvaluationListParams(
   opts?: ModelSecurityEvaluationListOptions,
 ): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  const params = serializeListing(opts);
   if (opts?.sort_field !== undefined) params.sort_field = opts.sort_field;
   if (opts?.sort_order !== undefined) params.sort_order = opts.sort_order;
   if (opts?.result !== undefined) params.result = opts.result;
@@ -141,11 +121,8 @@ function buildEvaluationListParams(
   return params;
 }
 
-/** Build query params for file list. */
 function buildFileListParams(opts?: ModelSecurityFileListOptions): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  const params = serializeListing(opts);
   if (opts?.sort_field !== undefined) params.sort_field = opts.sort_field;
   if (opts?.sort_dir !== undefined) params.sort_dir = opts.sort_dir;
   if (opts?.type !== undefined) params.type = opts.type;
@@ -154,52 +131,33 @@ function buildFileListParams(opts?: ModelSecurityFileListOptions): Record<string
   return params;
 }
 
-/** Build query params for label key/value list. */
-function buildLabelListParams(opts?: ModelSecurityLabelListOptions): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.search !== undefined) params.search = opts.search;
-  return params;
-}
-
-/** Build query params for violation list. */
-function buildViolationListParams(
-  opts?: ModelSecurityViolationListOptions,
-): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  return params;
-}
-
 /** Client for Model Security data plane scan operations. */
 export class ModelSecurityScansClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly numRetries: number;
 
   constructor(opts: ModelSecurityScansClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.numRetries = opts.numRetries;
   }
 
   /**
    * Create a new model security scan.
-   * @param request - Scan creation request body.
+   * @param body - Scan creation request body.
    * @returns The created scan response.
    */
-  async create(request: ScanCreateRequest): Promise<ScanBaseResponse> {
-    const res = await managementHttpRequest<ScanBaseResponse>({
+  async create(body: ScanCreateRequest): Promise<ScanBaseResponse> {
+    return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: MODEL_SEC_SCANS_PATH,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: ScanBaseResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -208,15 +166,15 @@ export class ModelSecurityScansClient {
    * @returns Paginated list of scans.
    */
   async list(opts?: ModelSecurityScanListOptions): Promise<ScanList> {
-    const res = await managementHttpRequest<ScanList>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: MODEL_SEC_SCANS_PATH,
       params: buildScanListParams(opts),
-      oauthClient: this.oauthClient,
+      responseSchema: ScanListSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -225,21 +183,15 @@ export class ModelSecurityScansClient {
    * @returns The scan response.
    */
   async get(uuid: string): Promise<ScanBaseResponse> {
-    if (!isValidUuid(uuid)) {
-      throw new AISecSDKException(
-        `Invalid scan uuid: ${uuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<ScanBaseResponse>({
+    assertUuid(uuid, 'scan uuid');
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SCANS_PATH}/${uuid}`,
-      oauthClient: this.oauthClient,
+      responseSchema: ScanBaseResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -252,22 +204,16 @@ export class ModelSecurityScansClient {
     scanUuid: string,
     opts?: ModelSecurityEvaluationListOptions,
   ): Promise<RuleEvaluationList> {
-    if (!isValidUuid(scanUuid)) {
-      throw new AISecSDKException(
-        `Invalid scan uuid: ${scanUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<RuleEvaluationList>({
+    assertUuid(scanUuid, 'scan uuid');
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/evaluations`,
       params: buildEvaluationListParams(opts),
-      oauthClient: this.oauthClient,
+      responseSchema: RuleEvaluationListSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -277,72 +223,54 @@ export class ModelSecurityScansClient {
    * @returns Paginated list of files.
    */
   async getFiles(scanUuid: string, opts?: ModelSecurityFileListOptions): Promise<FileList> {
-    if (!isValidUuid(scanUuid)) {
-      throw new AISecSDKException(
-        `Invalid scan uuid: ${scanUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<FileList>({
+    assertUuid(scanUuid, 'scan uuid');
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/files`,
       params: buildFileListParams(opts),
-      oauthClient: this.oauthClient,
+      responseSchema: FileListSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
    * Add labels to a scan (merge with existing).
    * @param scanUuid - Scan UUID.
-   * @param request - Labels to add.
+   * @param body - Labels to add.
    * @returns Labels response.
    */
-  async addLabels(scanUuid: string, request: LabelsCreateRequest): Promise<LabelsResponse> {
-    if (!isValidUuid(scanUuid)) {
-      throw new AISecSDKException(
-        `Invalid scan uuid: ${scanUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<LabelsResponse>({
+  async addLabels(scanUuid: string, body: LabelsCreateRequest): Promise<LabelsResponse> {
+    assertUuid(scanUuid, 'scan uuid');
+    return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/labels`,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: LabelsResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
    * Set labels on a scan (replace all existing).
    * @param scanUuid - Scan UUID.
-   * @param request - Labels to set.
+   * @param body - Labels to set.
    * @returns Labels response.
    */
-  async setLabels(scanUuid: string, request: LabelsCreateRequest): Promise<LabelsResponse> {
-    if (!isValidUuid(scanUuid)) {
-      throw new AISecSDKException(
-        `Invalid scan uuid: ${scanUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<LabelsResponse>({
+  async setLabels(scanUuid: string, body: LabelsCreateRequest): Promise<LabelsResponse> {
+    assertUuid(scanUuid, 'scan uuid');
+    return request({
       method: 'PUT',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/labels`,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: LabelsResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -352,29 +280,13 @@ export class ModelSecurityScansClient {
    * @returns Resolves when the labels are deleted.
    */
   async deleteLabels(scanUuid: string, keys: string[]): Promise<void> {
-    if (!isValidUuid(scanUuid)) {
-      throw new AISecSDKException(
-        `Invalid scan uuid: ${scanUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    // Build keys as repeated query params: ?keys=key1&keys=key2
-    // managementHttpRequest uses URLSearchParams.set which only supports single values,
-    // so we manually build the query string portion
-    const url = new URL(`https://placeholder${MODEL_SEC_SCANS_PATH}/${scanUuid}/labels`);
-    for (const key of keys) {
-      url.searchParams.append('keys', key);
-    }
-    // Extract just the query string and append to path
-    const queryString = url.searchParams.toString();
-    const pathWithQuery = `${MODEL_SEC_SCANS_PATH}/${scanUuid}/labels${queryString ? `?${queryString}` : ''}`;
-
-    await managementHttpRequest<void>({
+    assertUuid(scanUuid, 'scan uuid');
+    await request({
       method: 'DELETE',
       baseUrl: this.baseUrl,
-      path: pathWithQuery,
-      oauthClient: this.oauthClient,
+      path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/labels`,
+      params: { keys },
+      auth: this.auth,
       numRetries: this.numRetries,
     });
   }
@@ -389,22 +301,16 @@ export class ModelSecurityScansClient {
     scanUuid: string,
     opts?: ModelSecurityViolationListOptions,
   ): Promise<ViolationList> {
-    if (!isValidUuid(scanUuid)) {
-      throw new AISecSDKException(
-        `Invalid scan uuid: ${scanUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<ViolationList>({
+    assertUuid(scanUuid, 'scan uuid');
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SCANS_PATH}/${scanUuid}/rule-violations`,
-      params: buildViolationListParams(opts),
-      oauthClient: this.oauthClient,
+      params: serializeListing(opts),
+      responseSchema: ViolationListSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -413,15 +319,15 @@ export class ModelSecurityScansClient {
    * @returns Paginated list of label keys.
    */
   async getLabelKeys(opts?: ModelSecurityLabelListOptions): Promise<LabelKeyList> {
-    const res = await managementHttpRequest<LabelKeyList>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SCANS_PATH}/label-keys`,
-      params: buildLabelListParams(opts),
-      oauthClient: this.oauthClient,
+      params: serializeListing(opts),
+      responseSchema: LabelKeyListSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -431,15 +337,15 @@ export class ModelSecurityScansClient {
    * @returns Paginated list of label values.
    */
   async getLabelValues(key: string, opts?: ModelSecurityLabelListOptions): Promise<LabelValueList> {
-    const res = await managementHttpRequest<LabelValueList>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SCANS_PATH}/label-keys/${encodeURIComponent(key)}/values`,
-      params: buildLabelListParams(opts),
-      oauthClient: this.oauthClient,
+      params: serializeListing(opts),
+      responseSchema: LabelValueListSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -448,21 +354,15 @@ export class ModelSecurityScansClient {
    * @returns The rule evaluation response.
    */
   async getEvaluation(uuid: string): Promise<RuleEvaluationResponse> {
-    if (!isValidUuid(uuid)) {
-      throw new AISecSDKException(
-        `Invalid evaluation uuid: ${uuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<RuleEvaluationResponse>({
+    assertUuid(uuid, 'evaluation uuid');
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_EVALUATIONS_PATH}/${uuid}`,
-      oauthClient: this.oauthClient,
+      responseSchema: RuleEvaluationResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -471,20 +371,14 @@ export class ModelSecurityScansClient {
    * @returns The violation response.
    */
   async getViolation(uuid: string): Promise<ViolationResponse> {
-    if (!isValidUuid(uuid)) {
-      throw new AISecSDKException(
-        `Invalid violation uuid: ${uuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<ViolationResponse>({
+    assertUuid(uuid, 'violation uuid');
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_VIOLATIONS_PATH}/${uuid}`,
-      oauthClient: this.oauthClient,
+      responseSchema: ViolationResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/src/model-security/security-groups-client.ts
+++ b/src/model-security/security-groups-client.ts
@@ -1,24 +1,24 @@
 import { MODEL_SEC_SECURITY_GROUPS_PATH } from '../constants.js';
-import { AISecSDKException, ErrorType } from '../errors.js';
-import { isValidUuid } from '../utils.js';
-import { managementHttpRequest } from '../management/management-http-client.js';
-import type { OAuthClient } from '../management/oauth-client.js';
-import type {
-  ModelSecurityGroupCreateRequest,
-  ModelSecurityGroupResponse,
-  ModelSecurityGroupUpdateRequest,
-  ListModelSecurityGroupsResponse,
-  ModelSecurityRuleInstanceResponse,
-  ModelSecurityRuleInstanceUpdateRequest,
-  ListModelSecurityRuleInstancesResponse,
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { serializeListing, type ListingOptions } from '../listing.js';
+import { assertUuid } from '../validators.js';
+import {
+  ModelSecurityGroupResponseSchema,
+  ListModelSecurityGroupsResponseSchema,
+  ModelSecurityRuleInstanceResponseSchema,
+  ListModelSecurityRuleInstancesResponseSchema,
+  type ModelSecurityGroupCreateRequest,
+  type ModelSecurityGroupResponse,
+  type ModelSecurityGroupUpdateRequest,
+  type ListModelSecurityGroupsResponse,
+  type ModelSecurityRuleInstanceResponse,
+  type ModelSecurityRuleInstanceUpdateRequest,
+  type ListModelSecurityRuleInstancesResponse,
 } from '../models/model-security.js';
 
 /** Options for listing security groups. */
-export interface ModelSecurityGroupListOptions {
-  /** Number of items to skip. */
-  skip?: number;
-  /** Maximum number of items to return (1-100). */
-  limit?: number;
+export interface ModelSecurityGroupListOptions extends ListingOptions {
   /** Field to sort by: 'created_at' or 'updated_at'. */
   sort_field?: string;
   /** Sort direction: 'asc' or 'desc'. */
@@ -32,11 +32,7 @@ export interface ModelSecurityGroupListOptions {
 }
 
 /** Options for listing rule instances within a security group. */
-export interface ModelSecurityRuleInstanceListOptions {
-  /** Number of items to skip. */
-  skip?: number;
-  /** Maximum number of items to return. */
-  limit?: number;
+export interface ModelSecurityRuleInstanceListOptions extends ListingOptions {
   /** Filter by security rule UUID. */
   security_rule_uuid?: string;
   /** Filter by rule state: 'DISABLED', 'ALLOWING', or 'BLOCKING'. */
@@ -46,17 +42,14 @@ export interface ModelSecurityRuleInstanceListOptions {
 /** @internal */
 export interface ModelSecurityGroupsClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   numRetries: number;
 }
 
-/** Build query params for security group list. */
 function buildGroupListParams(
   opts?: ModelSecurityGroupListOptions,
 ): Record<string, string | string[]> {
-  const params: Record<string, string | string[]> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  const params: Record<string, string | string[]> = serializeListing(opts);
   if (opts?.sort_field !== undefined) params.sort_field = opts.sort_field;
   if (opts?.sort_dir !== undefined) params.sort_dir = opts.sort_dir;
   if (opts?.source_types !== undefined) params.source_types = opts.source_types;
@@ -65,13 +58,10 @@ function buildGroupListParams(
   return params;
 }
 
-/** Build query params for rule instance list. */
 function buildRuleInstanceListParams(
   opts?: ModelSecurityRuleInstanceListOptions,
 ): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
+  const params = serializeListing(opts);
   if (opts?.security_rule_uuid !== undefined) params.security_rule_uuid = opts.security_rule_uuid;
   if (opts?.state !== undefined) params.state = opts.state;
   return params;
@@ -80,30 +70,30 @@ function buildRuleInstanceListParams(
 /** Client for Model Security management plane security group operations. */
 export class ModelSecurityGroupsClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly numRetries: number;
 
   constructor(opts: ModelSecurityGroupsClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.numRetries = opts.numRetries;
   }
 
   /**
    * Create a new security group.
-   * @param request - Security group creation request.
+   * @param body - Security group creation request.
    * @returns The created security group.
    */
-  async create(request: ModelSecurityGroupCreateRequest): Promise<ModelSecurityGroupResponse> {
-    const res = await managementHttpRequest<ModelSecurityGroupResponse>({
+  async create(body: ModelSecurityGroupCreateRequest): Promise<ModelSecurityGroupResponse> {
+    return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: MODEL_SEC_SECURITY_GROUPS_PATH,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: ModelSecurityGroupResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -112,15 +102,15 @@ export class ModelSecurityGroupsClient {
    * @returns Paginated list of security groups.
    */
   async list(opts?: ModelSecurityGroupListOptions): Promise<ListModelSecurityGroupsResponse> {
-    const res = await managementHttpRequest<ListModelSecurityGroupsResponse>({
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: MODEL_SEC_SECURITY_GROUPS_PATH,
       params: buildGroupListParams(opts),
-      oauthClient: this.oauthClient,
+      responseSchema: ListModelSecurityGroupsResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -129,49 +119,37 @@ export class ModelSecurityGroupsClient {
    * @returns The security group.
    */
   async get(uuid: string): Promise<ModelSecurityGroupResponse> {
-    if (!isValidUuid(uuid)) {
-      throw new AISecSDKException(
-        `Invalid security group uuid: ${uuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<ModelSecurityGroupResponse>({
+    assertUuid(uuid, 'security group uuid');
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${uuid}`,
-      oauthClient: this.oauthClient,
+      responseSchema: ModelSecurityGroupResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
    * Update an existing security group.
    * @param uuid - Security group UUID.
-   * @param request - Updated security group fields.
+   * @param body - Updated security group fields.
    * @returns The updated security group.
    */
   async update(
     uuid: string,
-    request: ModelSecurityGroupUpdateRequest,
+    body: ModelSecurityGroupUpdateRequest,
   ): Promise<ModelSecurityGroupResponse> {
-    if (!isValidUuid(uuid)) {
-      throw new AISecSDKException(
-        `Invalid security group uuid: ${uuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<ModelSecurityGroupResponse>({
+    assertUuid(uuid, 'security group uuid');
+    return request({
       method: 'PUT',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${uuid}`,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: ModelSecurityGroupResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -180,18 +158,12 @@ export class ModelSecurityGroupsClient {
    * @returns Resolves when the security group is deleted.
    */
   async delete(uuid: string): Promise<void> {
-    if (!isValidUuid(uuid)) {
-      throw new AISecSDKException(
-        `Invalid security group uuid: ${uuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    await managementHttpRequest<void>({
+    assertUuid(uuid, 'security group uuid');
+    await request({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${uuid}`,
-      oauthClient: this.oauthClient,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
   }
@@ -206,22 +178,16 @@ export class ModelSecurityGroupsClient {
     securityGroupUuid: string,
     opts?: ModelSecurityRuleInstanceListOptions,
   ): Promise<ListModelSecurityRuleInstancesResponse> {
-    if (!isValidUuid(securityGroupUuid)) {
-      throw new AISecSDKException(
-        `Invalid security group uuid: ${securityGroupUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<ListModelSecurityRuleInstancesResponse>({
+    assertUuid(securityGroupUuid, 'security group uuid');
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${securityGroupUuid}/rule-instances`,
       params: buildRuleInstanceListParams(opts),
-      oauthClient: this.oauthClient,
+      responseSchema: ListModelSecurityRuleInstancesResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -234,62 +200,40 @@ export class ModelSecurityGroupsClient {
     securityGroupUuid: string,
     ruleInstanceUuid: string,
   ): Promise<ModelSecurityRuleInstanceResponse> {
-    if (!isValidUuid(securityGroupUuid)) {
-      throw new AISecSDKException(
-        `Invalid security group uuid: ${securityGroupUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-    if (!isValidUuid(ruleInstanceUuid)) {
-      throw new AISecSDKException(
-        `Invalid rule instance uuid: ${ruleInstanceUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<ModelSecurityRuleInstanceResponse>({
+    assertUuid(securityGroupUuid, 'security group uuid');
+    assertUuid(ruleInstanceUuid, 'rule instance uuid');
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${securityGroupUuid}/rule-instances/${ruleInstanceUuid}`,
-      oauthClient: this.oauthClient,
+      responseSchema: ModelSecurityRuleInstanceResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
    * Update a rule instance within a security group.
    * @param securityGroupUuid - Security group UUID.
    * @param ruleInstanceUuid - Rule instance UUID.
-   * @param request - Updated rule instance fields.
+   * @param body - Updated rule instance fields.
    * @returns The updated rule instance.
    */
   async updateRuleInstance(
     securityGroupUuid: string,
     ruleInstanceUuid: string,
-    request: ModelSecurityRuleInstanceUpdateRequest,
+    body: ModelSecurityRuleInstanceUpdateRequest,
   ): Promise<ModelSecurityRuleInstanceResponse> {
-    if (!isValidUuid(securityGroupUuid)) {
-      throw new AISecSDKException(
-        `Invalid security group uuid: ${securityGroupUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-    if (!isValidUuid(ruleInstanceUuid)) {
-      throw new AISecSDKException(
-        `Invalid rule instance uuid: ${ruleInstanceUuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<ModelSecurityRuleInstanceResponse>({
+    assertUuid(securityGroupUuid, 'security group uuid');
+    assertUuid(ruleInstanceUuid, 'rule instance uuid');
+    return request({
       method: 'PUT',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SECURITY_GROUPS_PATH}/${securityGroupUuid}/rule-instances/${ruleInstanceUuid}`,
-      body: request,
-      oauthClient: this.oauthClient,
+      body,
+      responseSchema: ModelSecurityRuleInstanceResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/src/model-security/security-rules-client.ts
+++ b/src/model-security/security-rules-client.ts
@@ -1,19 +1,17 @@
 import { MODEL_SEC_SECURITY_RULES_PATH } from '../constants.js';
-import { AISecSDKException, ErrorType } from '../errors.js';
-import { isValidUuid } from '../utils.js';
-import { managementHttpRequest } from '../management/management-http-client.js';
-import type { OAuthClient } from '../management/oauth-client.js';
-import type {
-  ListModelSecurityRulesResponse,
-  ModelSecurityRuleResponse,
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { serializeListing, type ListingOptions } from '../listing.js';
+import { assertUuid } from '../validators.js';
+import {
+  ListModelSecurityRulesResponseSchema,
+  ModelSecurityRuleResponseSchema,
+  type ListModelSecurityRulesResponse,
+  type ModelSecurityRuleResponse,
 } from '../models/model-security.js';
 
 /** Options for listing security rules. */
-export interface ModelSecurityRuleListOptions {
-  /** Number of items to skip. */
-  skip?: number;
-  /** Maximum number of items to return. */
-  limit?: number;
+export interface ModelSecurityRuleListOptions extends ListingOptions {
   /** Filter by source type. */
   source_type?: string;
   /** Search term (matches UUID or Name, 3-1000 chars). */
@@ -23,47 +21,41 @@ export interface ModelSecurityRuleListOptions {
 /** @internal */
 export interface ModelSecurityRulesClientOptions {
   baseUrl: string;
-  oauthClient: OAuthClient;
+  auth: AuthAdapter;
   numRetries: number;
-}
-
-/** Build query params for security rules list. */
-function buildRuleListParams(opts?: ModelSecurityRuleListOptions): Record<string, string> {
-  const params: Record<string, string> = {};
-  if (opts?.skip !== undefined) params.skip = String(opts.skip);
-  if (opts?.limit !== undefined) params.limit = String(opts.limit);
-  if (opts?.source_type !== undefined) params.source_type = opts.source_type;
-  if (opts?.search_query !== undefined) params.search_query = opts.search_query;
-  return params;
 }
 
 /** Client for Model Security management plane security rule operations (read-only). */
 export class ModelSecurityRulesClient {
   private readonly baseUrl: string;
-  private readonly oauthClient: OAuthClient;
+  private readonly auth: AuthAdapter;
   private readonly numRetries: number;
 
   constructor(opts: ModelSecurityRulesClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.oauthClient = opts.oauthClient;
+    this.auth = opts.auth;
     this.numRetries = opts.numRetries;
   }
 
   /**
    * List available security rules.
-   * @param opts - Pagination options.
+   * @param opts - Pagination + filter options.
    * @returns Paginated list of security rules.
    */
   async list(opts?: ModelSecurityRuleListOptions): Promise<ListModelSecurityRulesResponse> {
-    const res = await managementHttpRequest<ListModelSecurityRulesResponse>({
+    const params = serializeListing(opts);
+    if (opts?.source_type !== undefined) params.source_type = opts.source_type;
+    if (opts?.search_query !== undefined) params.search_query = opts.search_query;
+
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: MODEL_SEC_SECURITY_RULES_PATH,
-      params: buildRuleListParams(opts),
-      oauthClient: this.oauthClient,
+      params,
+      responseSchema: ListModelSecurityRulesResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 
   /**
@@ -72,20 +64,14 @@ export class ModelSecurityRulesClient {
    * @returns The security rule.
    */
   async get(uuid: string): Promise<ModelSecurityRuleResponse> {
-    if (!isValidUuid(uuid)) {
-      throw new AISecSDKException(
-        `Invalid security rule uuid: ${uuid}`,
-        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
-      );
-    }
-
-    const res = await managementHttpRequest<ModelSecurityRuleResponse>({
+    assertUuid(uuid, 'security rule uuid');
+    return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${MODEL_SEC_SECURITY_RULES_PATH}/${uuid}`,
-      oauthClient: this.oauthClient,
+      responseSchema: ModelSecurityRuleResponseSchema,
+      auth: this.auth,
       numRetries: this.numRetries,
     });
-    return res.data;
   }
 }

--- a/test/listing.spec.ts
+++ b/test/listing.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { serializeListing, type ListingOptions } from '../src/listing.js';
+
+describe('serializeListing', () => {
+  it('returns empty record when no opts', () => {
+    expect(serializeListing()).toEqual({});
+  });
+
+  it('returns empty record when opts is empty object', () => {
+    expect(serializeListing({})).toEqual({});
+  });
+
+  it('includes skip when set', () => {
+    expect(serializeListing({ skip: 10 })).toEqual({ skip: '10' });
+  });
+
+  it('includes limit when set', () => {
+    expect(serializeListing({ limit: 25 })).toEqual({ limit: '25' });
+  });
+
+  it('includes search when set', () => {
+    expect(serializeListing({ search: 'foo bar' })).toEqual({ search: 'foo bar' });
+  });
+
+  it('includes all three when set', () => {
+    expect(serializeListing({ skip: 5, limit: 10, search: 'q' })).toEqual({
+      skip: '5',
+      limit: '10',
+      search: 'q',
+    });
+  });
+
+  it('coerces numeric zero (skip=0 is meaningful)', () => {
+    expect(serializeListing({ skip: 0 })).toEqual({ skip: '0' });
+  });
+
+  it('preserves extra string fields not in ListingOptions', () => {
+    type WithExtras = ListingOptions & { status?: string };
+    const opts: WithExtras = { skip: 1, status: 'active' };
+    expect(serializeListing(opts)).toEqual({ skip: '1' });
+    // Note: serializeListing only emits the canonical fields. Callers add their own.
+  });
+
+  it('returns empty when only undefined values supplied', () => {
+    expect(serializeListing({ skip: undefined, limit: undefined, search: undefined })).toEqual({});
+  });
+});

--- a/test/model-security/scans-client.spec.ts
+++ b/test/model-security/scans-client.spec.ts
@@ -1,16 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ModelSecurityScansClient } from '../../src/model-security/scans-client.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 const validUuid = '550e8400-e29b-41d4-a716-446655440000';
 const now = '2025-01-01T00:00:00Z';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -43,7 +40,7 @@ describe('ModelSecurityScansClient', () => {
   beforeEach(() => {
     client = new ModelSecurityScansClient({
       baseUrl: 'https://data.example.com',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       numRetries: 0,
     });
   });

--- a/test/model-security/security-groups-client.spec.ts
+++ b/test/model-security/security-groups-client.spec.ts
@@ -1,17 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ModelSecurityGroupsClient } from '../../src/model-security/security-groups-client.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 const validUuid = '550e8400-e29b-41d4-a716-446655440000';
 const validUuid2 = '660e8400-e29b-41d4-a716-446655440000';
 const now = '2025-01-01T00:00:00Z';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -65,7 +62,7 @@ describe('ModelSecurityGroupsClient', () => {
   beforeEach(() => {
     client = new ModelSecurityGroupsClient({
       baseUrl: 'https://mgmt.example.com',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       numRetries: 0,
     });
   });

--- a/test/model-security/security-rules-client.spec.ts
+++ b/test/model-security/security-rules-client.spec.ts
@@ -1,15 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ModelSecurityRulesClient } from '../../src/model-security/security-rules-client.js';
-import { OAuthClient } from '../../src/management/oauth-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 const validUuid = '550e8400-e29b-41d4-a716-446655440000';
 
-function createMockOAuth(): OAuthClient {
-  return {
-    getToken: vi.fn().mockResolvedValue('tok'),
-    clearToken: vi.fn(),
-  } as unknown as OAuthClient;
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
 }
 
 function mockFetch(data: unknown, status = 200) {
@@ -40,7 +37,7 @@ describe('ModelSecurityRulesClient', () => {
   beforeEach(() => {
     client = new ModelSecurityRulesClient({
       baseUrl: 'https://mgmt.example.com',
-      oauthClient: createMockOAuth(),
+      auth: passthroughAuth(),
       numRetries: 0,
     });
   });


### PR DESCRIPTION
Closes #122. Part of #113. Builds on #114 (PR 1), #117 (PR 2), #120/#121 (PR 3).

## Summary

Migrates the **model-security** domain to the unified \`request()\` helper. Adds the **Listing** module for shared pagination/search params. **Runtime Zod validation is now on for both management AND model-security responses.**

- \`src/model-security/{client,scans-client,security-groups-client,security-rules-client}.ts\` — every method calls \`request()\` with \`responseSchema\`. Constructor takes \`auth: AuthAdapter\`.
- \`src/listing.ts\` (new) — \`ListingOptions\` + \`serializeListing\` for canonical \`skip\`/\`limit\`/\`search\` serialization. Used immediately in the model-security list endpoints.
- \`src/http/types.ts\` — widened \`responseSchema\` generic to accept schemas with diverging input/output types (Zod \`.default()\` ergonomics).
- Local UUID validators absorbed into \`src/validators.ts:assertUuid\`.
- 11 test files updated to pass \`auth\` (passthrough adapter) not \`oauthClient\`.

## Scope adjustment

The original scope (PR 4) included red-team migration. Red-team's existing tests use minimal-stub mock data that doesn't satisfy the now-validated schemas — bringing them to spec is a coherent ~60-test unit of work that's better isolated. Tracking in a follow-up issue.

## Test plan

- [x] \`npm run test\` — 1064/1064 (was 1055; +9 from new Listing tests)
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` — clean
- [x] \`npm run build\` — CJS + ESM + types
- [x] \`npm run preflight:warn\` — drift count unchanged at 81 (no new drift introduced)
- [x] Public API \`src/index.ts\` byte-identical

## Follow-ups

- PR 4b — red-team migration + test mock rewrites + delete \`list-params.ts\` (subsumed by Listing)
- PR 5 — scan migration + delete \`src/management/management-http-client.ts\` and \`src/http-client.ts\`
- #118 — drift triage (interleaved)