### PR TITLE
fix(scan): reshape IODetected/ScanSummary to match live API shape

### DIFF
--- a/.changeset/0017-tool-detected-reshape.md
+++ b/.changeset/0017-tool-detected-reshape.md
@@ -1,0 +1,45 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+**Breaking type changes** to `ScanResponse.tool_detected` to match the actual AIRS API shape (verified against a live response). Confirms and supersedes the partial fix from #129.
+
+### Changes
+
+`IODetected` shape change. The schema for `tool_detected.input_detected` and `tool_detected.output_detected` is now a wrapper:
+
+Before: `{ url_cats?, dlp?, injection?, toxic_content?, malicious_code? }`
+After: `{ detection_entries?: ToolDetectionEntry[] }`
+
+The flag fields moved into `ToolDetectionEntry.detections`. Code reading `result.tool_detected.input_detected.url_cats` was already getting `undefined` from the API — the type just didn't reflect that. Now correct.
+
+`ScanSummary` shape change. The schema for `tool_detected.summary` changed:
+
+Before: `{ verdict?, action? }`
+After: `{ detections: ToolDetectionFlags, threats: string[] }` (both required)
+
+Top-level `verdict`/`action` remain available on `ScanResponse.category` and `ScanResponse.action`.
+
+`ScanResponse` required fields. `timeout`, `error`, and `errors` are now typed as required (the API always returns them).
+
+### New exports
+
+- `ToolDetectionFlagsSchema` / `ToolDetectionFlags` — boolean flags (8 detection types)
+- `ToolDetectionEntrySchema` / `ToolDetectionEntry` — per-tool detection entry
+- `ToolDetectionDetailsSchema` / `ToolDetectionDetails` — nested per-tool details
+
+### Migration
+
+If you read tool flags from `tool_detected.input_detected.<flag>`, walk `detection_entries` instead:
+
+```ts
+// before
+const hadInjection = response.tool_detected?.input_detected?.injection;
+
+// after
+const hadInjection = response.tool_detected?.input_detected?.detection_entries?.some(
+  (entry) => entry.detections?.injection === true,
+);
+```
+
+Pre-flight drift count: 81 → 39 (-42).

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -31,6 +31,12 @@ export {
 export {
   MaskedDataSchema,
   type MaskedData,
+  ToolDetectionFlagsSchema,
+  type ToolDetectionFlags,
+  ToolDetectionDetailsSchema,
+  type ToolDetectionDetails,
+  ToolDetectionEntrySchema,
+  type ToolDetectionEntry,
   IODetectedSchema,
   type IODetected,
   ScanSummarySchema,

--- a/src/models/scan-id-result.ts
+++ b/src/models/scan-id-result.ts
@@ -1,8 +1,20 @@
 import { z } from 'zod';
-import { ScanResponseSchema } from './scan-response.js';
+import { ScanResponseSchema, type ScanResponse } from './scan-response.js';
+
+/** Result of querying a scan by its scan ID, including status and full scan response. */
+export interface ScanIdResult {
+  source?: string;
+  req_id?: number;
+  status?: string;
+  scan_id?: string;
+  result?: ScanResponse;
+  [key: string]: unknown;
+}
 
 /** Zod schema for a scan ID query result. */
-export const ScanIdResultSchema = z
+// Explicit type annotation: ScanResponseSchema is now structurally too complex
+// for TypeScript to serialize the inferred type. The annotation breaks that cycle.
+export const ScanIdResultSchema: z.ZodType<ScanIdResult> = z
   .object({
     source: z.string().optional(),
     req_id: z.number().optional(),
@@ -11,6 +23,3 @@ export const ScanIdResultSchema = z
     result: ScanResponseSchema.optional(),
   })
   .passthrough();
-
-/** Result of querying a scan by its scan ID, including status and full scan response. */
-export type ScanIdResult = z.infer<typeof ScanIdResultSchema>;

--- a/src/models/scan-response.ts
+++ b/src/models/scan-response.ts
@@ -15,29 +15,84 @@ export const MaskedDataSchema = z
 /** Masked data containing redacted content and pattern detections. */
 export type MaskedData = z.infer<typeof MaskedDataSchema>;
 
-/** Zod schema for I/O detection flags. */
-export const IODetectedSchema = z
+/**
+ * Zod schema for the boolean detection flags returned by per-tool scans.
+ *
+ * Each flag indicates whether a particular detection service triggered on the
+ * tool's input or output. Used inside {@link ToolDetectionEntrySchema} and
+ * {@link ScanSummarySchema}.
+ */
+export const ToolDetectionFlagsSchema = z
   .object({
+    injection: z.boolean().optional(),
     url_cats: z.boolean().optional(),
     dlp: z.boolean().optional(),
-    injection: z.boolean().optional(),
+    db_security: z.boolean().optional(),
     toxic_content: z.boolean().optional(),
     malicious_code: z.boolean().optional(),
+    agent: z.boolean().optional(),
+    topic_violation: z.boolean().optional(),
   })
   .passthrough();
 
-/** Flags indicating which detection types triggered on input or output. */
+/** Boolean detection flags returned by per-tool scans. */
+export type ToolDetectionFlags = z.infer<typeof ToolDetectionFlagsSchema>;
+
+/** Zod schema for nested per-tool detection details (e.g. topic guardrails). */
+export const ToolDetectionDetailsSchema = z
+  .object({
+    topic_guardrails_details: z.unknown().optional(),
+  })
+  .passthrough();
+
+/** Nested per-tool detection details. */
+export type ToolDetectionDetails = z.infer<typeof ToolDetectionDetailsSchema>;
+
+/** Zod schema for a single tool-invocation detection entry. */
+export const ToolDetectionEntrySchema = z
+  .object({
+    tool_invoked: z.string().optional(),
+    detections: ToolDetectionFlagsSchema.optional(),
+    threats: z.array(z.string()).optional(),
+    details: ToolDetectionDetailsSchema.optional(),
+    masked_data: MaskedDataSchema.optional(),
+  })
+  .passthrough();
+
+/** A single tool-invocation detection entry inside `tool_detected.input_detected`. */
+export type ToolDetectionEntry = z.infer<typeof ToolDetectionEntrySchema>;
+
+/**
+ * Zod schema for tool input/output detections.
+ *
+ * **Shape change** vs prior SDK versions: this used to be a flag-style schema
+ * with `url_cats`, `dlp`, etc. directly on it. The flags now live inside
+ * {@link ToolDetectionEntrySchema} entries (one per tool invocation).
+ */
+export const IODetectedSchema = z
+  .object({
+    detection_entries: z.array(ToolDetectionEntrySchema).optional(),
+  })
+  .passthrough();
+
+/** Wrapper for per-tool detection entries on `tool_detected.input_detected` / `output_detected`. */
 export type IODetected = z.infer<typeof IODetectedSchema>;
 
-/** Zod schema for the scan summary (verdict + action). */
+/**
+ * Zod schema for the scan summary inside `tool_detected.summary`.
+ *
+ * **Shape change** vs prior SDK versions: this used to be `{ verdict?, action? }`.
+ * The current API returns aggregated `{ detections, threats }` here. Top-level
+ * verdict/action remain on `ScanResponse.category` / `ScanResponse.action`.
+ */
 export const ScanSummarySchema = z
   .object({
-    verdict: z.string().optional(),
-    action: z.string().optional(),
+    detections: ToolDetectionFlagsSchema,
+    threats: z.array(z.string()),
   })
   .passthrough();
 
-/** Scan summary containing overall verdict and action. */
+/** Aggregated detection summary inside `tool_detected.summary`. */
 export type ScanSummary = z.infer<typeof ScanSummarySchema>;
 
 /** Zod schema for tool/agent detection results. */
@@ -66,9 +121,9 @@ export const ScanResponseSchema = z
     profile_name: z.string().optional(),
     category: z.string(),
     action: z.string(),
-    timeout: z.boolean().optional(),
-    error: z.boolean().optional(),
-    errors: z.array(ContentErrorSchema).optional(),
+    timeout: z.boolean(),
+    error: z.boolean(),
+    errors: z.array(ContentErrorSchema),
     prompt_detected: PromptDetectedSchema.optional(),
     response_detected: ResponseDetectedSchema.optional(),
     prompt_masked_data: MaskedDataSchema.optional(),

--- a/test/models/models.spec.ts
+++ b/test/models/models.spec.ts
@@ -40,6 +40,9 @@ describe('ScanResponseSchema', () => {
       scan_id: 's1',
       category: 'benign',
       action: 'allow',
+      timeout: false,
+      error: false,
+      errors: [],
     });
     expect(result.success).toBe(true);
   });
@@ -52,6 +55,9 @@ describe('ScanResponseSchema', () => {
       category: 'malicious',
       action: 'block',
       session_id: 'sess1',
+      timeout: false,
+      error: false,
+      errors: [],
       prompt_detected: { injection: true, toxic_content: false },
       response_detected: { dlp: true, ungrounded: true },
       tool_detected: { verdict: 'malicious' },
@@ -87,6 +93,9 @@ describe('ScanResponseSchema', () => {
       scan_id: 's1',
       category: 'benign',
       action: 'allow',
+      timeout: false,
+      error: false,
+      errors: [],
       prompt_masked_data: {
         data: "SELECT * FROM users WHERE password='***'",
         pattern_detections: [{ pattern: 'password', locations: [[35, 54]] }],
@@ -121,6 +130,9 @@ describe('ScanIdResultSchema', () => {
         scan_id: 's1',
         category: 'benign',
         action: 'allow',
+        timeout: false,
+        error: false,
+        errors: [],
       },
     });
     expect(result.success).toBe(true);

--- a/test/models/passthrough.spec.ts
+++ b/test/models/passthrough.spec.ts
@@ -156,6 +156,9 @@ describe('passthrough — scan-related schemas preserve unknown fields', () => {
       scan_id: 's1',
       category: 'benign',
       action: 'allow',
+      timeout: false,
+      error: false,
+      errors: [],
       _future: 1,
     });
     expect(r.success).toBe(true);

--- a/test/scan/scanner.spec.ts
+++ b/test/scan/scanner.spec.ts
@@ -35,6 +35,9 @@ describe('Scanner', () => {
         scan_id: 's1',
         category: 'benign',
         action: 'allow',
+        timeout: false,
+        error: false,
+        errors: [],
       };
       mockFetch(response);
 
@@ -47,7 +50,15 @@ describe('Scanner', () => {
     });
 
     it('sends trId and sessionId', async () => {
-      mockFetch({ report_id: 'r', scan_id: 's', category: 'benign', action: 'allow' });
+      mockFetch({
+        report_id: 'r',
+        scan_id: 's',
+        category: 'benign',
+        action: 'allow',
+        timeout: false,
+        error: false,
+        errors: [],
+      });
 
       const scanner = new Scanner();
       const content = new Content({ prompt: 'hi' });
@@ -59,7 +70,15 @@ describe('Scanner', () => {
     });
 
     it('sends metadata', async () => {
-      mockFetch({ report_id: 'r', scan_id: 's', category: 'benign', action: 'allow' });
+      mockFetch({
+        report_id: 'r',
+        scan_id: 's',
+        category: 'benign',
+        action: 'allow',
+        timeout: false,
+        error: false,
+        errors: [],
+      });
 
       const scanner = new Scanner();
       const content = new Content({ prompt: 'hi' });


### PR DESCRIPTION
Closes #128. Supersedes #129 (folds in its timeout/error/errors fix). Part of #118.

## Summary

The Zod schemas for \`ScanResponse.tool_detected.{input_detected,output_detected,summary}\` were stale. Verified against a live API response shared by the maintainer that the API has been reshaped:

- \`tool_detected.input_detected\` and \`output_detected\` now contain \`{ detection_entries: [{ tool_invoked, detections, threats }] }\`. The flag fields (\`url_cats\`, \`dlp\`, \`injection\`, etc.) live inside each entry's \`detections\`.
- \`tool_detected.summary\` now contains \`{ detections, threats }\` instead of \`{ verdict, action }\`. (Top-level \`verdict\`/\`action\` are unchanged on \`ScanResponse\`.)

Consumers reading \`result.tool_detected.input_detected.url_cats\` directly were getting \`undefined\` because the field moved — the type system was lying about it.

## Drift impact

| | drift findings |
|---|---|
| Before campaign | 81 |
| Before this PR (after #129's interim fix) | 75 |
| **After this PR** | **39** |

This PR alone drops drift by **42** findings (vs 6 in #129).

## Breaking type changes

\`IODetected\`:
- Before: \`{ url_cats?, dlp?, injection?, toxic_content?, malicious_code? }\`
- After: \`{ detection_entries?: ToolDetectionEntry[] }\`

\`ScanSummary\`:
- Before: \`{ verdict?, action? }\`
- After: \`{ detections: ToolDetectionFlags, threats: string[] }\` (both required)

\`ScanResponse\`:
- \`timeout\`, \`error\`, \`errors\` are now required (matches what the API always returns).

### Migration

\`\`\`ts
// before
const hadInjection = response.tool_detected?.input_detected?.injection;

// after
const hadInjection = response.tool_detected?.input_detected?.detection_entries?.some(
  (entry) => entry.detections?.injection === true,
);
\`\`\`

## New exports

- \`ToolDetectionFlagsSchema\` / \`ToolDetectionFlags\` — 8-flag boolean detection schema
- \`ToolDetectionEntrySchema\` / \`ToolDetectionEntry\` — per-tool detection entry
- \`ToolDetectionDetailsSchema\` / \`ToolDetectionDetails\` — nested per-tool details

## Test plan

- [x] \`npm run test\` — 1031/1031
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` — clean
- [x] \`npm run preflight:warn\` — drift count 81 → 39
- [x] Verified against the live API response shared in #128

## Next

PR #129 is superseded — should be closed without merging.

After this lands, remaining drift is in `mgmt-security-profile`, `mgmt-custom-topic`, `model-security`, `red-team` schemas (#118 PRs 2b/2c/2d).