### PR TITLE
fix(mgmt): tighten CustomTopic required fields; document DataProtection drift

### DIFF
--- a/.changeset/0018-mgmt-schema-drift.md
+++ b/.changeset/0018-mgmt-schema-drift.md
@@ -1,0 +1,17 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Type fix: `CustomTopic.revision`, `CustomTopic.description`, and `CustomTopic.examples` are now typed as required (the API always returns them per the OpenAPI contract).
+
+Before: `revision?: number; description?: string; examples?: string[]`
+After: `revision: number; description: string; examples: string[]`
+
+The request body type (`CreateCustomTopicRequest`) is unchanged — these fields remain optional on input.
+
+Also documents two known schema divergences in `DataProtectionSchema` that the pre-flight will continue to flag:
+
+- `data-leak-detection.member` is marked nullable/optional in Zod even though the OpenAPI marks it required, because the API returns `null` for it on some profiles.
+- `database-security` is on Zod but not in the OpenAPI; the API does return it.
+
+Pre-flight drift: 39 → 36 (-3).

--- a/src/models/mgmt-custom-topic.ts
+++ b/src/models/mgmt-custom-topic.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 
-/** Zod schema for an AIRS custom topic. */
+/** Zod schema for an AIRS custom topic (response). */
 export const CustomTopicSchema = z
   .object({
     topic_id: z.string().optional(),
     topic_name: z.string(),
-    revision: z.number().optional(),
+    revision: z.number(),
     active: z.boolean().optional(),
-    description: z.string().optional(),
-    examples: z.array(z.string()).optional(),
+    description: z.string(),
+    examples: z.array(z.string()),
     created_by: z.string().optional(),
     updated_by: z.string().optional(),
     last_modified_ts: z.string().optional(),

--- a/src/models/mgmt-security-profile.ts
+++ b/src/models/mgmt-security-profile.ts
@@ -37,6 +37,13 @@ export const DatabaseSecurityItemSchema = z
 export type DatabaseSecurityItem = z.infer<typeof DatabaseSecurityItemSchema>;
 
 /** Zod schema for the data-protection section of a model configuration. */
+//
+// Two known divergences from the OpenAPI flagged by `npm run preflight`:
+// - `data-leak-detection.member`: spec marks required, but the API returns
+//   `null` on some profiles (see test/models/mgmt-security-profile.spec.ts).
+//   We allow `null`/missing to match observed behavior.
+// - `database-security`: not in the OpenAPI but the API does return it.
+//   Kept until upstream OpenAPI documents it.
 export const DataProtectionSchema = z
   .object({
     'data-leak-detection': z

--- a/test/management/topics.spec.ts
+++ b/test/management/topics.spec.ts
@@ -20,6 +20,8 @@ const sampleTopic = {
   topic_name: 'credit-cards',
   revision: 1,
   active: true,
+  description: 'detect credit card numbers',
+  examples: ['4111-1111-1111-1111'],
 };
 
 describe('TopicsClient', () => {


### PR DESCRIPTION
Drift triage PR for management domain. Part of #118.

## Summary

| | drift findings |
|---|---|
| Before | 39 |
| After | 36 |

Net **-3** by making \`CustomTopic.revision\` / \`description\` / \`examples\` required (the OpenAPI contract says the API always returns them).

## Type changes

\`CustomTopic\` (response):
- Before: \`revision?: number; description?: string; examples?: string[]\`
- After: \`revision: number; description: string; examples: string[]\`

\`CreateCustomTopicRequest\` (input) is **unchanged** — fields remain optional on the request side.

## Documented (not fixed) drift

Two findings in \`DataProtectionSchema\` are now annotated in code as known divergences:

- \`data-leak-detection.member\` — OpenAPI marks required, but the test suite (and code comment) confirms the API actually returns \`null\` on some profiles. Kept as \`nullable().optional()\` in Zod to match observed reality.
- \`database-security\` — present in Zod, not in OpenAPI. The API does return it; OpenAPI is incomplete.

These two will keep appearing in pre-flight output until the upstream OpenAPI is updated.

## Test plan

- [x] \`npm run test\` — 1031/1031
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` — clean
- [x] \`npm run preflight:warn\` — drift 39 → 36

## Remaining drift (next)

| Schema | findings |
|---|---|
| DetectionServiceResultObject | 9 |
| DSDetailResultObject | 8 |
| DSResultMetadata | 2 |
| AiSecurityProfileObject | 5 (4 \`app-protection\` extras + 1 nested \`data-leak-detection.member\`) |
| ScanResponse | 6 (nested verdict/action/flags on tool_detected — investigate next) |
| Other report objects | smaller buckets |

The 4 \`AiSecurityProfileObject\` extra-field findings under \`app-protection\` (\`default-url-category\`, \`url-detected-action\`, \`malicious-code-protection\`) are likely the same pattern as \`database-security\` (real API fields not in upstream OpenAPI). Worth a follow-up to verify against a live profile response.