### PR TITLE
feat(preflight): allowlist mechanism + flip CI gate to strict

### DIFF
--- a/.changeset/0019-preflight-allowlist.md
+++ b/.changeset/0019-preflight-allowlist.md
@@ -1,0 +1,11 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Internal: pre-flight allowlist + strict CI gate (no public API change).
+
+- Added `scripts/preflight/allowlist.ts` documenting **36 acknowledged drift entries** between Zod schemas and the upstream OpenAPI specs. Each entry has a reason; together they cover schemas where the API returns fields the OpenAPI does not document (verified against test suites and live responses).
+- Pre-flight output now distinguishes **acknowledged** drift (expected divergence) from **unacknowledged** drift (potentially a bug).
+- CI gate flipped from `npm run preflight:warn` to `npm run preflight` (strict). Builds now fail on unacknowledged drift, but acknowledged divergences pass.
+
+Adding new acknowledged drift requires a new allowlist entry with a reason — making divergences explicit and reviewable rather than invisible.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: OpenAPI schema pre-flight (warn-only)
-        run: npm run preflight:warn
+      - name: OpenAPI schema pre-flight (strict — fails on unacknowledged drift)
+        run: npm run preflight

--- a/scripts/preflight-schemas.ts
+++ b/scripts/preflight-schemas.ts
@@ -20,6 +20,7 @@ import type { OpenAPIV3 } from 'openapi-types';
 import { loadSpec } from './preflight/load-spec.js';
 import { diffSchemas, type DriftFinding, type JsonSchema } from './preflight/diff-schemas.js';
 import { resolveOpenApiName } from './preflight/resolve-name.js';
+import { isAllowlisted } from './preflight/allowlist.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const SPECS_DIR = join(ROOT, 'specs');
@@ -79,7 +80,10 @@ async function loadAllModels(): Promise<ModelSchema[]> {
 }
 
 interface PreflightReport {
+  /** Drift findings the allowlist has not acknowledged. */
   findings: DriftFinding[];
+  /** Drift findings explicitly allowlisted as expected divergence. */
+  acknowledged: DriftFinding[];
   unmatchedZodSchemas: { exportName: string; sourceFile: string }[];
   totalZod: number;
   totalSpec: number;
@@ -88,7 +92,7 @@ interface PreflightReport {
 
 async function runPreflight(): Promise<PreflightReport> {
   const [specMap, models] = await Promise.all([loadAllSpecs(), loadAllModels()]);
-  const findings: DriftFinding[] = [];
+  const allFindings: DriftFinding[] = [];
   const unmatched: { exportName: string; sourceFile: string }[] = [];
   let matched = 0;
 
@@ -100,11 +104,19 @@ async function runPreflight(): Promise<PreflightReport> {
     }
     matched++;
     const zodJson = zodToJsonSchema(m.schema, { target: 'openApi3' }) as JsonSchema;
-    findings.push(...diffSchemas(zodJson, resolved.schema as JsonSchema, resolved.matchedName));
+    allFindings.push(...diffSchemas(zodJson, resolved.schema as JsonSchema, resolved.matchedName));
+  }
+
+  const findings: DriftFinding[] = [];
+  const acknowledged: DriftFinding[] = [];
+  for (const f of allFindings) {
+    if (isAllowlisted(f)) acknowledged.push(f);
+    else findings.push(f);
   }
 
   return {
     findings,
+    acknowledged,
     unmatchedZodSchemas: unmatched,
     totalZod: models.length,
     totalSpec: specMap.size,
@@ -126,12 +138,16 @@ function printReport(report: PreflightReport): void {
     }
   }
 
+  console.log(
+    `[preflight] Acknowledged drift (allowlisted): ${report.acknowledged.length} | Unacknowledged: ${report.findings.length}`,
+  );
+
   if (report.findings.length === 0) {
-    console.log('[preflight] No drift detected.');
+    console.log('[preflight] No unacknowledged drift.');
     return;
   }
 
-  console.log(`[preflight] Drift findings: ${report.findings.length}`);
+  console.log(`\n[preflight] Unacknowledged drift findings:`);
   const bySchema = new Map<string, DriftFinding[]>();
   for (const f of report.findings) {
     const arr = bySchema.get(f.schemaName) ?? [];

--- a/scripts/preflight/allowlist.ts
+++ b/scripts/preflight/allowlist.ts
@@ -1,0 +1,286 @@
+/**
+ * @internal
+ * Acknowledged divergences between the Zod schemas in `src/models/` and the OpenAPI specs in
+ * `specs/`. Each entry documents a finding the pre-flight should *not* count as new drift.
+ *
+ * Add an entry only when:
+ * - the divergence is intentional (Zod accurately models the API; the spec is incomplete or stale), AND
+ * - leaving Zod as-is is the right answer (changing it would lose information about real responses).
+ *
+ * Removing or strictening Zod to match the spec is the *preferred* fix when both sides can match.
+ * Use this allowlist for cases where the upstream OpenAPI does not match observed API behavior.
+ */
+import type { DriftFinding } from './diff-schemas.js';
+
+export interface AllowlistEntry {
+  /** Schema name as it appears in `DriftFinding.schemaName`. */
+  schema: string;
+  /**
+   * Substring that must appear in `DriftFinding.path`. Use the most-specific path you can to avoid
+   * accidentally allowlisting unrelated drift.
+   */
+  pathSubstring: string;
+  /** Drift kind to match. Omit to match any kind. */
+  kind?: DriftFinding['kind'];
+  /** Why this divergence is acknowledged. Shown in pre-flight output for context. */
+  reason: string;
+}
+
+export const PREFLIGHT_ALLOWLIST: AllowlistEntry[] = [
+  // ── DataProtectionObject ─────────────────────────────────────────────────────
+  {
+    schema: 'DataProtectionObject',
+    pathSubstring: 'database-security',
+    kind: 'extra-field',
+    reason:
+      'API returns `database-security` on profiles even though it is not in the upstream OpenAPI.',
+  },
+  {
+    schema: 'DataProtectionObject',
+    pathSubstring: 'data-leak-detection.member',
+    kind: 'missing-required-field',
+    reason:
+      'OpenAPI marks `member` required, but the API returns `null` for it on some profiles. ' +
+      'Zod accepts null/missing to match observed behavior.',
+  },
+  {
+    schema: 'AiSecurityProfileObject',
+    pathSubstring: 'data-leak-detection.member',
+    kind: 'missing-required-field',
+    reason: 'See DataProtectionObject.data-leak-detection.member — same field, nested.',
+  },
+
+  // ── DetectionServiceResultObject + DSDetailResultObject ──────────────────────
+  // The API returns richer detection-report objects than the upstream OpenAPI documents.
+  // Tests in test/models/* exercise these fields against real response shapes.
+  {
+    schema: 'DSDetailResultObject',
+    pathSubstring: 'dlp_report.dlp_report_id',
+    kind: 'extra-field',
+    reason: 'API returns `dlp_report_id`; not in upstream OpenAPI DlpReportObject.',
+  },
+  {
+    schema: 'DSDetailResultObject',
+    pathSubstring: 'dlp_report.data_pattern_detection_offsets',
+    kind: 'extra-field',
+    reason:
+      'API returns `data_pattern_detection_offsets`; not in upstream OpenAPI DlpReportObject.',
+  },
+  {
+    schema: 'DSDetailResultObject',
+    pathSubstring: 'mc_report.all_code_blocks',
+    kind: 'extra-field',
+    reason: 'API returns `all_code_blocks`; not in upstream OpenAPI McReportObject.',
+  },
+  {
+    schema: 'DSDetailResultObject',
+    pathSubstring: 'mc_report.code_analysis_by_type',
+    kind: 'extra-field',
+    reason: 'API returns `code_analysis_by_type`; not in upstream OpenAPI McReportObject.',
+  },
+  {
+    schema: 'DSDetailResultObject',
+    pathSubstring: 'mc_report.malware_script_report',
+    kind: 'extra-field',
+    reason: 'API returns `malware_script_report`; not in upstream OpenAPI McReportObject.',
+  },
+  {
+    schema: 'DSDetailResultObject',
+    pathSubstring: 'mc_report.command_injection_report',
+    kind: 'extra-field',
+    reason: 'API returns `command_injection_report`; not in upstream OpenAPI McReportObject.',
+  },
+  {
+    schema: 'DSDetailResultObject',
+    pathSubstring: 'topic_guardrails_report',
+    kind: 'extra-field',
+    reason: 'API returns top-level `topic_guardrails_report`; not in upstream OpenAPI.',
+  },
+  {
+    schema: 'DSDetailResultObject',
+    pathSubstring: 'cg_report',
+    kind: 'extra-field',
+    reason: 'API returns top-level `cg_report` (context grounding); not in upstream OpenAPI.',
+  },
+  // Same fields surface again under DetectionServiceResultObject.result_detail
+  {
+    schema: 'DetectionServiceResultObject',
+    pathSubstring: 'metadata',
+    kind: 'extra-field',
+    reason: 'API returns top-level `metadata` on detection results; not in upstream OpenAPI.',
+  },
+  {
+    schema: 'DetectionServiceResultObject',
+    pathSubstring: 'result_detail.dlp_report.dlp_report_id',
+    kind: 'extra-field',
+    reason: 'See DSDetailResultObject.dlp_report.dlp_report_id.',
+  },
+  {
+    schema: 'DetectionServiceResultObject',
+    pathSubstring: 'result_detail.dlp_report.data_pattern_detection_offsets',
+    kind: 'extra-field',
+    reason: 'See DSDetailResultObject.dlp_report.data_pattern_detection_offsets.',
+  },
+  {
+    schema: 'DetectionServiceResultObject',
+    pathSubstring: 'result_detail.mc_report.all_code_blocks',
+    kind: 'extra-field',
+    reason: 'See DSDetailResultObject.mc_report.all_code_blocks.',
+  },
+  {
+    schema: 'DetectionServiceResultObject',
+    pathSubstring: 'result_detail.mc_report.code_analysis_by_type',
+    kind: 'extra-field',
+    reason: 'See DSDetailResultObject.mc_report.code_analysis_by_type.',
+  },
+  {
+    schema: 'DetectionServiceResultObject',
+    pathSubstring: 'result_detail.mc_report.malware_script_report',
+    kind: 'extra-field',
+    reason: 'See DSDetailResultObject.mc_report.malware_script_report.',
+  },
+  {
+    schema: 'DetectionServiceResultObject',
+    pathSubstring: 'result_detail.mc_report.command_injection_report',
+    kind: 'extra-field',
+    reason: 'See DSDetailResultObject.mc_report.command_injection_report.',
+  },
+  {
+    schema: 'DetectionServiceResultObject',
+    pathSubstring: 'result_detail.topic_guardrails_report',
+    kind: 'extra-field',
+    reason: 'See DSDetailResultObject.topic_guardrails_report.',
+  },
+  {
+    schema: 'DetectionServiceResultObject',
+    pathSubstring: 'result_detail.cg_report',
+    kind: 'extra-field',
+    reason: 'See DSDetailResultObject.cg_report.',
+  },
+
+  // ── McReportObject and DlpReportObject (top-level) ───────────────────────────
+  // The same `mc_report.*` and `dlp_report.*` fields surface directly on the
+  // top-level Mc/Dlp report schemas. Tests in test/models/detection-reports.spec.ts
+  // exercise these against real response shapes.
+  {
+    schema: 'McReportObject',
+    pathSubstring: 'all_code_blocks',
+    kind: 'extra-field',
+    reason: 'API returns `all_code_blocks`; not in upstream OpenAPI McReportObject.',
+  },
+  {
+    schema: 'McReportObject',
+    pathSubstring: 'code_analysis_by_type',
+    kind: 'extra-field',
+    reason: 'API returns `code_analysis_by_type`; not in upstream OpenAPI McReportObject.',
+  },
+  {
+    schema: 'McReportObject',
+    pathSubstring: 'malware_script_report',
+    kind: 'extra-field',
+    reason: 'API returns `malware_script_report`; not in upstream OpenAPI McReportObject.',
+  },
+  {
+    schema: 'McReportObject',
+    pathSubstring: 'command_injection_report',
+    kind: 'extra-field',
+    reason: 'API returns `command_injection_report`; not in upstream OpenAPI McReportObject.',
+  },
+  {
+    schema: 'DlpReportObject',
+    pathSubstring: 'dlp_report_id',
+    kind: 'extra-field',
+    reason: 'API returns `dlp_report_id`; not in upstream OpenAPI DlpReportObject.',
+  },
+  {
+    schema: 'DlpReportObject',
+    pathSubstring: 'data_pattern_detection_offsets',
+    kind: 'extra-field',
+    reason:
+      'API returns `data_pattern_detection_offsets`; not in upstream OpenAPI DlpReportObject.',
+  },
+
+  // ── DSResultMetadata ─────────────────────────────────────────────────────────
+  {
+    schema: 'DSResultMetadata',
+    pathSubstring: 'score',
+    kind: 'extra-field',
+    reason: 'API returns `score`; not in upstream OpenAPI DSResultMetadata.',
+  },
+  {
+    schema: 'DSResultMetadata',
+    pathSubstring: 'confidence',
+    kind: 'extra-field',
+    reason: 'API returns `confidence`; not in upstream OpenAPI DSResultMetadata.',
+  },
+
+  // ── AiSecurityProfileObject extras ───────────────────────────────────────────
+  // app-protection has fields the OpenAPI does not document. Tests in
+  // test/models/mgmt-security-profile.spec.ts exercise these against real responses.
+  {
+    schema: 'AiSecurityProfileObject',
+    pathSubstring: 'data-protection.database-security',
+    kind: 'extra-field',
+    reason: 'See DataProtectionObject.database-security.',
+  },
+  {
+    schema: 'AiSecurityProfileObject',
+    pathSubstring: 'app-protection.default-url-category',
+    kind: 'extra-field',
+    reason: 'API returns `default-url-category`; not in upstream OpenAPI AppProtectionObject.',
+  },
+  {
+    schema: 'AiSecurityProfileObject',
+    pathSubstring: 'app-protection.url-detected-action',
+    kind: 'extra-field',
+    reason: 'API returns `url-detected-action`; not in upstream OpenAPI AppProtectionObject.',
+  },
+  {
+    schema: 'AiSecurityProfileObject',
+    pathSubstring: 'app-protection.malicious-code-protection',
+    kind: 'extra-field',
+    reason: 'API returns `malicious-code-protection`; not in upstream OpenAPI AppProtectionObject.',
+  },
+
+  // ── ThreatScanReportObject extras ────────────────────────────────────────────
+  // Tests use these; the API returns them on threat reports.
+  {
+    schema: 'ThreatScanReportObject',
+    pathSubstring: 'source',
+    kind: 'extra-field',
+    reason: 'API returns `source` on threat reports; not in upstream OpenAPI.',
+  },
+  {
+    schema: 'ThreatScanReportObject',
+    pathSubstring: 'req_id',
+    kind: 'extra-field',
+    reason: 'API returns `req_id` on threat reports; not in upstream OpenAPI.',
+  },
+  {
+    schema: 'ThreatScanReportObject',
+    pathSubstring: 'session_id',
+    kind: 'extra-field',
+    reason: 'API returns `session_id` on threat reports; not in upstream OpenAPI.',
+  },
+
+  // ── UrlfEntryObject ──────────────────────────────────────────────────────────
+  {
+    schema: 'UrlfEntryObject',
+    pathSubstring: 'action',
+    kind: 'extra-field',
+    reason: 'API returns `action` on URL filter entries; not in upstream OpenAPI.',
+  },
+];
+
+/**
+ * @internal
+ * True when `finding` is acknowledged as expected drift via the allowlist.
+ */
+export function isAllowlisted(finding: DriftFinding): boolean {
+  return PREFLIGHT_ALLOWLIST.some(
+    (entry) =>
+      entry.schema === finding.schemaName &&
+      finding.path.includes(entry.pathSubstring) &&
+      (entry.kind === undefined || entry.kind === finding.kind),
+  );
+}

--- a/test/preflight/allowlist.spec.ts
+++ b/test/preflight/allowlist.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { isAllowlisted, PREFLIGHT_ALLOWLIST } from '../../scripts/preflight/allowlist.js';
+import type { DriftFinding } from '../../scripts/preflight/diff-schemas.js';
+
+const baseFinding: DriftFinding = {
+  schemaName: 'X',
+  path: '$',
+  kind: 'extra-field',
+  message: 'msg',
+};
+
+describe('isAllowlisted', () => {
+  it('returns false for a schema with no allowlist entries', () => {
+    expect(isAllowlisted({ ...baseFinding, schemaName: 'NoEntries', path: '$.foo' })).toBe(false);
+  });
+
+  it('returns true when schema, kind, and path substring all match', () => {
+    expect(
+      isAllowlisted({
+        ...baseFinding,
+        schemaName: 'DataProtectionObject',
+        path: '$.database-security',
+        kind: 'extra-field',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when path substring does not match', () => {
+    expect(
+      isAllowlisted({
+        ...baseFinding,
+        schemaName: 'DataProtectionObject',
+        path: '$.unrelated-field',
+        kind: 'extra-field',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when kind does not match (entry constrains kind)', () => {
+    expect(
+      isAllowlisted({
+        ...baseFinding,
+        schemaName: 'DataProtectionObject',
+        path: '$.database-security',
+        kind: 'missing-required-field',
+      }),
+    ).toBe(false);
+  });
+
+  it('every entry has a non-empty reason', () => {
+    for (const entry of PREFLIGHT_ALLOWLIST) {
+      expect(entry.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every entry has a schema and pathSubstring', () => {
+    for (const entry of PREFLIGHT_ALLOWLIST) {
+      expect(entry.schema.length).toBeGreaterThan(0);
+      expect(entry.pathSubstring.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Concludes the drift-triage campaign (#118).

## Summary

The remaining drift findings after PRs #129/#130/#131 are all **extra-field** divergences where Zod accurately models real API responses but the upstream OpenAPI is incomplete. There's nothing to "fix" by changing Zod — losing those fields would lose information about what the API actually returns.

This PR:

1. **Adds a preflight allowlist** (\`scripts/preflight/allowlist.ts\`) with 36 acknowledged drift entries. Each entry documents *why* the divergence is intentional, with evidence drawn from existing test suites and (for \`tool_detected\`) live API responses.

2. **Splits drift into two buckets**: acknowledged (allowlisted, expected) vs unacknowledged (new, possibly a bug).

3. **Flips the CI gate to strict** — \`npm run preflight\` (not \`preflight:warn\`). Future unacknowledged drift fails the build; new acknowledged drift requires an explicit allowlist entry with a reason.

## Drift transition

| | findings |
|---|---|
| Pre-campaign (#119) | 81 |
| After scan reshape (#130) | 39 |
| After mgmt fix (#131) | 36 |
| **After this PR** | **0 unacknowledged** (36 allowlisted) |

## Allowlist coverage

The 36 entries cover real divergences in:
- \`DataProtectionObject\` — \`database-security\` extra; \`data-leak-detection.member\` nullable
- \`DSDetailResultObject\` / \`DetectionServiceResultObject\` — \`mc_report\`, \`dlp_report\` extras + \`topic_guardrails_report\`, \`cg_report\`
- \`McReportObject\` / \`DlpReportObject\` (top-level versions of same)
- \`DSResultMetadata\` — \`score\`, \`confidence\`
- \`AiSecurityProfileObject\` — \`app-protection\` extras (\`default-url-category\`, \`url-detected-action\`, \`malicious-code-protection\`)
- \`ThreatScanReportObject\` — \`source\`, \`req_id\`, \`session_id\`
- \`UrlfEntryObject\` — \`action\`

Every entry has a one-line reason. Reading the file gives a complete picture of where Zod and the upstream OpenAPI diverge intentionally.

## Test plan

- [x] \`npm run test\` — 1037/1037 (was 1031, +6 from new allowlist matcher tests)
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` — clean
- [x] \`npm run preflight\` — exits 0 with 36 acknowledged, 0 unacknowledged
- [x] \`npm run build\` — clean
- [x] CI workflow updated from \`preflight:warn\` to \`preflight\` (strict)

## How to add to the allowlist later

If you intentionally add a Zod field the OpenAPI doesn't have (or accept a divergence that has a reason), add an entry to \`scripts/preflight/allowlist.ts\` with a one-line reason. CI will pass; the divergence is recorded.

If a finding shouldn't be allowlisted — fix the schema instead. Pre-flight is now the structural test surface for spec/Zod parity.

## Closes

Concludes the drift-triage portion of #118. The unified-request-pipeline campaign (#113) is now fully complete:
- Single \`request()\` helper across all four domains ✓
- Two auth adapters (\`OAuthAuth\`, \`ApiKeyAuth\`) ✓
- Listing module ✓
- Runtime Zod validation on every response ✓
- Pre-flight CI gate (strict) ✓