### PR TITLE
chore: release v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.7.1';
+export const SDK_VERSION = '0.8.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
Bumps \`package.json\` and \`SDK_VERSION\` to \`0.8.0\` for the unified-request-pipeline campaign release.

## Changes since v0.7.1

10 PRs merged (#115, #116, #119, #121, #123, #125, #127, #130, #131, #132).

### Internal architecture
- Single \`request()\` helper across all four domains
- \`OAuthAuth\` + \`ApiKeyAuth\` adapters
- \`Listing\` module for shared pagination
- Runtime Zod validation on every response
- Pre-flight schema gate (strict) in CI with allowlist for documented divergences

### Public API
- **Breaking type changes** (minor bump): \`ScanResponse.timeout/error/errors\` and \`CustomTopic.revision/description/examples\` now required; \`tool_detected.input_detected\`/\`output_detected\` reshaped to \`{ detection_entries }\`; \`tool_detected.summary\` reshaped to \`{ detections, threats }\`
- **New error type**: \`ErrorType.RESPONSE_VALIDATION\` for backend response shape mismatches
- **New exports**: \`ToolDetectionFlags\`, \`ToolDetectionEntry\`, \`ToolDetectionDetails\`, \`ListingOptions\`

Full release notes at \`~/Documents/ccr/prisma-airs-sdk-v0.8.0-release-notes.md\` (developer machine).

## Test plan

- [x] \`npm run test\` — 1037/1037 (SDK_VERSION-matches-package.json test passes)
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` — clean
- [x] \`npm run build\` — CJS + ESM + types
- [x] \`npm run preflight\` (strict) — 36 acknowledged, 0 unacknowledged drift

## After merge

1. Create GitHub release with tag \`v0.8.0\` → publish workflow fires automatically (OIDC trusted publishing).
2. Verify package on npm.