### PR TITLE
fix: TopicArraySchema.topic accepts null; release v0.8.1

### DIFF
--- a/.changeset/0020-topic-array-nullable.md
+++ b/.changeset/0020-topic-array-nullable.md
@@ -1,0 +1,11 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Fix: `TopicArraySchema.topic` now accepts `null` (matches live API behavior).
+
+The AIRS API serializes `"topic": null` when an action bucket (allow or block) within a topic guardrail has no topics — common pattern for empty buckets. Before this fix, 0.8.0's runtime Zod validation rejected any profile-list response that included such a bucket, causing `AISecSDKException` with `RESPONSE_VALIDATION` error type instead of returning the parsed profiles.
+
+Type signature change: `TopicArray.topic: TopicObject[]` → `TopicObject[] | null`. Consumers reading this field should handle the null case.
+
+Verified against a live `/v1/mgmt/profiles/tsg` response containing 4 affected profiles.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.8.0';
+export const SDK_VERSION = '0.8.1';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/models/mgmt-security-profile.ts
+++ b/src/models/mgmt-security-profile.ts
@@ -110,10 +110,15 @@ export const TopicObjectSchema = z
 export type TopicObject = z.infer<typeof TopicObjectSchema>;
 
 /** Zod schema for a topic array within model protection. */
+//
+// `topic` accepts `null` to match observed API behavior: when the allow or block
+// bucket has no topics, the API serializes `"topic": null` rather than `[]`.
+// The upstream OpenAPI marks this required and non-nullable; this is a known
+// divergence (verified against a live `/v1/mgmt/profiles/tsg` response).
 export const TopicArraySchema = z
   .object({
     action: z.string(),
-    topic: z.array(TopicObjectSchema),
+    topic: z.array(TopicObjectSchema).nullable(),
   })
   .passthrough();
 

--- a/test/models/mgmt-security-profile.spec.ts
+++ b/test/models/mgmt-security-profile.spec.ts
@@ -231,6 +231,25 @@ describe('TopicArraySchema', () => {
     });
     expect(result.topic).toHaveLength(1);
   });
+
+  // Regression: live API serializes `"topic": null` when an action bucket
+  // (allow or block) has no topics. Without `.nullable()` the whole profile
+  // fails to parse. Verified against /v1/mgmt/profiles/tsg in production.
+  it('accepts topic: null (regression)', () => {
+    const result = TopicArraySchema.parse({
+      action: 'allow',
+      topic: null,
+    });
+    expect(result.topic).toBeNull();
+  });
+
+  it('accepts an empty topic array', () => {
+    const result = TopicArraySchema.parse({
+      action: 'block',
+      topic: [],
+    });
+    expect(result.topic).toEqual([]);
+  });
 });
 
 describe('ModelProtectionItemSchema', () => {


### PR DESCRIPTION
Closes #134.

## Summary

Found by a CLI consumer's smoke test against v0.8.0: a real \`/v1/mgmt/profiles/tsg\` response was rejected because \`TopicArraySchema.topic\` didn't accept \`null\`.

The AIRS API serializes \`"topic": null\` when an action bucket (allow or block) within a topic guardrail has no topics. Single-field fix: add \`.nullable()\`.

## Change

\`\`\`ts
// src/models/mgmt-security-profile.ts
topic: z.array(TopicObjectSchema).nullable(),  // was: z.array(TopicObjectSchema)
\`\`\`

\`TopicArray.topic\` is now typed as \`TopicObject[] | null\`. Consumers reading this field need to handle the null case.

## Regression test

Added two cases to \`test/models/mgmt-security-profile.spec.ts\`:
- \`topic: null\` parses (the new case from the live response)
- \`topic: []\` parses (sanity check)

The pre-existing \`topic: [{ ... }]\` case still passes.

## Audit of similar fields

Quick check of all \`z.array(*Schema)\` in mgmt schemas turned up three other arrays:
- \`SecurityProfileListResponse.ai_profiles\`
- \`CustomTopicListResponse.custom_topics\`
- \`DeploymentProfilesResponse.deployment_profiles\`

All three are top-level list-endpoint payloads where the API returns \`[]\` not \`null\`. Leaving them strict.

## Test plan

- [x] \`npm run test\` — 1039/1039 (+2 new regression tests)
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` — clean
- [x] \`npm run preflight\` (strict) — 36 acknowledged, 0 unacknowledged
- [x] \`npm run build\` — clean

## Release

Bumps to **v0.8.1** (\`package.json\` + \`SDK_VERSION\` constant). After merge, tag a GitHub release \`v0.8.1\` to trigger the publish workflow.