### PR TITLE
fix: hydrate empty 2xx body as {}; release v0.8.2

### DIFF
--- a/.changeset/0021-empty-body-as-object.md
+++ b/.changeset/0021-empty-body-as-object.md
@@ -1,0 +1,11 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Fix: empty 2xx response bodies now hydrate as `{}` (not `undefined`) before schema validation.
+
+The AIRS API returns no body on some endpoints when there are no results — observed on `/v1/mgmt/scanlogs` queries with zero matches in the requested time range. Before this fix, v0.8.0/v0.8.1 threw `AISecSDKException(RESPONSE_VALIDATION)` with the cryptic `"path": [], "expected": "object", "received": "undefined"` message because `JSON.parse('')` produced `undefined`, which no object schema accepts.
+
+Now `request()` treats an empty body as `{}`. Schemas with all-optional fields (e.g. `PaginatedScanResultsSchema`) parse cleanly to `{}`. Schemas with required fields still fail validation, but on the specific missing-field path rather than the root.
+
+Same class of bug as #134 (`TopicArray.topic` accepting `null`) — both are "API leaves it off" patterns surfaced when v0.8.0 turned runtime `.parse()` on.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.8.1';
+export const SDK_VERSION = '0.8.2';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -69,7 +69,12 @@ export async function request<TResponse = void>(spec: RequestSpec<TResponse>): P
 
   let parsed: unknown;
   try {
-    parsed = text ? JSON.parse(text) : undefined;
+    // Hydrate empty 2xx bodies as `{}` so all-optional-fields schemas parse cleanly
+    // (the AIRS API returns no body when an endpoint has zero results, e.g.
+    // /v1/mgmt/scanlogs with no logs in the requested time range). Schemas with
+    // required fields will still fail validation, but on a specific path rather
+    // than the cryptic root-level `expected object, received undefined`.
+    parsed = text ? JSON.parse(text) : {};
   } catch {
     throw new AISecSDKException('Response body is not valid JSON', ErrorType.RESPONSE_VALIDATION);
   }

--- a/test/http/request.spec.ts
+++ b/test/http/request.spec.ts
@@ -255,6 +255,53 @@ describe('request — schema parsing', () => {
 
     expect(result).toBeUndefined();
   });
+
+  // Regression for #136: API returns 200 with an empty body when scan-logs has
+  // zero results. Empty body must hydrate as `{}` so all-optional-fields
+  // schemas parse cleanly instead of failing with "expected object, received undefined".
+  it('hydrates empty 2xx body as {} for schemas with all-optional fields', async () => {
+    const AllOptionalSchema = z
+      .object({
+        total_pages: z.number().optional(),
+        page_number: z.number().optional(),
+      })
+      .passthrough();
+
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(undefined, 200));
+
+    const result = await request({
+      method: 'POST',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/mgmt/scanlogs',
+      responseSchema: AllOptionalSchema,
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('still fails RESPONSE_VALIDATION on empty 2xx body when schema has required fields', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(undefined, 200));
+
+    try {
+      await request<Item>({
+        method: 'GET',
+        baseUrl: 'https://api.example.com',
+        path: '/v1/items/1',
+        responseSchema: ItemSchema, // requires `id` and `name`
+        auth: passthroughAuth,
+        numRetries: 0,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AISecSDKException);
+      expect((err as AISecSDKException).errorType).toBe(ErrorType.RESPONSE_VALIDATION);
+      // Error now points at the specific missing fields, not the cryptic root-level
+      const msg = (err as Error).message;
+      expect(msg).toContain('id');
+    }
+  });
 });
 
 describe('request — error handling', () => {


### PR DESCRIPTION
Closes #136.

## Summary

Found by a CLI consumer running \`airs runtime scan-logs query\` against v0.8.1 with no scan logs in the requested time range. The AIRS API returned 200 OK with an empty body, and the SDK threw \`AISecSDKException\` with cryptic \`expected object, received undefined\` at root path \`[]\`.

## Change

\`src/http/request.ts\`:

\`\`\`ts
// before
parsed = text ? JSON.parse(text) : undefined;
// after
parsed = text ? JSON.parse(text) : {};
\`\`\`

All-optional-fields schemas (\`PaginatedScanResultsSchema\`, etc.) now parse empty bodies cleanly. Schemas with required fields still fail validation, but the error now points at the specific missing field rather than the cryptic root-level \`expected object, received undefined\`.

## Regression tests

Two new cases in \`test/http/request.spec.ts\`:
- Empty 2xx body + all-optional schema → returns \`{}\` (was: throws RESPONSE_VALIDATION)
- Empty 2xx body + required-fields schema → still throws RESPONSE_VALIDATION, but error now mentions the specific missing field

## Test plan

- [x] \`npm run test\` — 1041/1041 (+2 new regression tests)
- [x] \`npm run lint\` / \`typecheck\` / \`format:check\` — clean
- [x] \`npm run preflight\` (strict) — 36 acknowledged, 0 unacknowledged
- [x] \`npm run build\` — clean

## Release

Bumps to **v0.8.2** (\`package.json\` + \`SDK_VERSION\` constant). After merge, tag a GitHub release \`v0.8.2\` to trigger the publish workflow.

## Why this is the right level for the fix

This is the third schema-too-strict bug post-v0.8.0 (after #128 \`tool_detected\` reshape and #134 \`topic-list\` null). All three are "API leaves it off" patterns surfaced when v0.8.0 turned \`.parse()\` on.

The previous two were schema-specific fixes. This one is at the request-helper layer because the underlying behavior (empty body) can affect any endpoint with all-optional fields. Fixing here covers the same class for any future schema, not just scan-logs.