### PR TITLE
feat: live-tenant audit script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,12 @@ npm run typecheck      # tsc --noEmit
 npm run format         # prettier --write
 npm run format:check   # prettier --check
 npm run clean          # rm -rf dist/
+npm run preflight      # diff Zod schemas vs OpenAPI specs (strict; CI gate)
+npm run preflight:warn # same, exit 0 even on drift
+npm run audit:live     # hit read-only endpoints on a real tenant; reports schema drift
 ```
+
+`audit:live` requires `PANW_*` env vars set for the tenants you want to probe. It catches API-vs-Zod runtime divergence (the kind that surfaced #128, #134, #136 only after CLI smoke tests). Run before tagging a release or after API-side changes.
 
 Run a single test file:
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:coverage": "vitest run --coverage",
     "preflight": "tsx scripts/preflight-schemas.ts",
     "preflight:warn": "tsx scripts/preflight-schemas.ts --warn-only",
+    "audit:live": "tsx scripts/live-audit.ts",
     "prepare": "git config core.hooksPath .githooks && npm run build",
     "prepublishOnly": "npm run lint && npm run test",
     "example:scan": "npx tsx --env-file=.env examples/basic-scan.ts",

--- a/scripts/live-audit.ts
+++ b/scripts/live-audit.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env tsx
+/**
+ * @internal
+ * Live-tenant audit. Hits a representative set of read-only endpoints across the three
+ * OAuth domains, classifies each result, and exits non-zero on any RESPONSE_VALIDATION.
+ *
+ * Usage (requires PANW_* env vars set for the tenants you want to probe):
+ *   npm run audit:live
+ *
+ * Catches the class of bug pre-flight cannot see: real API responses that don't match
+ * the Zod schemas. Pre-flight is Zod-vs-OpenAPI; this is API-vs-Zod.
+ */
+import {
+  AISecSDKException,
+  ErrorType,
+  ManagementClient,
+  ModelSecurityClient,
+  RedTeamClient,
+} from '../src/index.js';
+
+interface Probe {
+  domain: 'mgmt' | 'model-sec' | 'red-team';
+  endpoint: string;
+  call: () => Promise<unknown>;
+}
+
+interface Finding {
+  domain: Probe['domain'];
+  endpoint: string;
+  status: 'ok' | 'schema-drift' | 'auth' | 'other-error';
+  detail?: string;
+}
+
+const probes: Probe[] = [];
+
+function tryBuild(name: string, fn: () => void): void {
+  try {
+    fn();
+  } catch (err) {
+    console.warn(`[live-audit] ${name}: skipped (${(err as Error).message})`);
+  }
+}
+
+function buildManagementProbes(): void {
+  tryBuild('ManagementClient', () => {
+    const c = new ManagementClient();
+    probes.push(
+      { domain: 'mgmt', endpoint: 'profiles.list', call: () => c.profiles.list() },
+      { domain: 'mgmt', endpoint: 'topics.list', call: () => c.topics.list() },
+      { domain: 'mgmt', endpoint: 'apiKeys.list', call: () => c.apiKeys.list() },
+      { domain: 'mgmt', endpoint: 'customerApps.list', call: () => c.customerApps.list() },
+      { domain: 'mgmt', endpoint: 'dlpProfiles.list', call: () => c.dlpProfiles.list() },
+      {
+        domain: 'mgmt',
+        endpoint: 'deploymentProfiles.list',
+        call: () => c.deploymentProfiles.list(),
+      },
+      // The scan-logs query that surfaced #136. Use a small range to keep payloads small.
+      {
+        domain: 'mgmt',
+        endpoint: 'scanLogs.query',
+        call: () =>
+          c.scanLogs.query({
+            time_interval: 1,
+            time_unit: 'hour',
+            pageNumber: 1,
+            pageSize: 10,
+            filter: 'all',
+          }),
+      },
+    );
+  });
+}
+
+function buildModelSecurityProbes(): void {
+  tryBuild('ModelSecurityClient', () => {
+    const c = new ModelSecurityClient();
+    probes.push(
+      {
+        domain: 'model-sec',
+        endpoint: 'securityRules.list',
+        call: () => c.securityRules.list(),
+      },
+      {
+        domain: 'model-sec',
+        endpoint: 'securityGroups.list',
+        call: () => c.securityGroups.list(),
+      },
+      { domain: 'model-sec', endpoint: 'scans.list', call: () => c.scans.list({ limit: 10 }) },
+      {
+        domain: 'model-sec',
+        endpoint: 'scans.getLabelKeys',
+        call: () => c.scans.getLabelKeys({ limit: 10 }),
+      },
+    );
+  });
+}
+
+function buildRedTeamProbes(): void {
+  tryBuild('RedTeamClient', () => {
+    const c = new RedTeamClient();
+    probes.push(
+      { domain: 'red-team', endpoint: 'scans.list', call: () => c.scans.list({ limit: 10 }) },
+      { domain: 'red-team', endpoint: 'scans.getCategories', call: () => c.scans.getCategories() },
+      { domain: 'red-team', endpoint: 'targets.list', call: () => c.targets.list({ limit: 10 }) },
+      {
+        domain: 'red-team',
+        endpoint: 'targets.getTargetMetadata',
+        call: () => c.targets.getTargetMetadata(),
+      },
+      {
+        domain: 'red-team',
+        endpoint: 'targets.getTargetTemplates',
+        call: () => c.targets.getTargetTemplates(),
+      },
+      { domain: 'red-team', endpoint: 'eula.getStatus', call: () => c.eula.getStatus() },
+      {
+        domain: 'red-team',
+        endpoint: 'customAttacks.listPromptSets',
+        call: () => c.customAttacks.listPromptSets({ limit: 10 }),
+      },
+      {
+        domain: 'red-team',
+        endpoint: 'customAttacks.listActivePromptSets',
+        call: () => c.customAttacks.listActivePromptSets(),
+      },
+      {
+        domain: 'red-team',
+        endpoint: 'customAttacks.getPropertyNames',
+        call: () => c.customAttacks.getPropertyNames(),
+      },
+      { domain: 'red-team', endpoint: 'getQuota', call: () => c.getQuota() },
+      {
+        domain: 'red-team',
+        endpoint: 'getDashboardOverview',
+        call: () => c.getDashboardOverview(),
+      },
+    );
+  });
+}
+
+async function runProbe(p: Probe): Promise<Finding> {
+  try {
+    await p.call();
+    return { domain: p.domain, endpoint: p.endpoint, status: 'ok' };
+  } catch (err) {
+    if (err instanceof AISecSDKException) {
+      switch (err.errorType) {
+        case ErrorType.RESPONSE_VALIDATION:
+          return {
+            domain: p.domain,
+            endpoint: p.endpoint,
+            status: 'schema-drift',
+            detail: err.message,
+          };
+        case ErrorType.OAUTH_ERROR:
+        case ErrorType.MISSING_VARIABLE:
+          return {
+            domain: p.domain,
+            endpoint: p.endpoint,
+            status: 'auth',
+            detail: err.message,
+          };
+        default:
+          return {
+            domain: p.domain,
+            endpoint: p.endpoint,
+            status: 'other-error',
+            detail: err.message,
+          };
+      }
+    }
+    return {
+      domain: p.domain,
+      endpoint: p.endpoint,
+      status: 'other-error',
+      detail: (err as Error).message,
+    };
+  }
+}
+
+function printSection(title: string, findings: Finding[]): void {
+  if (findings.length === 0) return;
+  console.log(`\n[live-audit] ${title} (${findings.length}):`);
+  for (const f of findings) {
+    console.log(`  ${f.domain}.${f.endpoint}`);
+    if (f.detail) {
+      // Indent multi-line details for readability
+      for (const line of f.detail.split('\n')) {
+        console.log(`    ${line}`);
+      }
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  buildManagementProbes();
+  buildModelSecurityProbes();
+  buildRedTeamProbes();
+
+  if (probes.length === 0) {
+    console.log(
+      '[live-audit] No clients could be initialized (set PANW_* env vars). Nothing to probe.',
+    );
+    return;
+  }
+
+  console.log(`[live-audit] running ${probes.length} probes against the live tenant...`);
+
+  const findings = await Promise.all(probes.map(runProbe));
+
+  const tally = { ok: 0, 'schema-drift': 0, auth: 0, 'other-error': 0 };
+  for (const f of findings) tally[f.status]++;
+
+  console.log(
+    `[live-audit] OK: ${tally.ok} | schema-drift: ${tally['schema-drift']} | auth: ${tally.auth} | other-error: ${tally['other-error']}`,
+  );
+
+  printSection(
+    'Schema drift (API returned a shape Zod rejected — fix the schema)',
+    findings.filter((f) => f.status === 'schema-drift'),
+  );
+  printSection(
+    'Auth issues (these probes never reached the API)',
+    findings.filter((f) => f.status === 'auth'),
+  );
+  printSection(
+    'Other errors (4xx/5xx — usually empty tenant or permissions, not bugs)',
+    findings.filter((f) => f.status === 'other-error'),
+  );
+
+  if (tally['schema-drift'] > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('[live-audit] Fatal error:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
Closes #138.

## Summary

Adds \`scripts/live-audit.ts\` — a maintainer tool that catches API-vs-Zod runtime divergence proactively. The class of bug pre-flight can't see, surfaced three times in 5 days post-v0.8.0 (#128, #134, #136), each time only after a CLI consumer hit it.

## What it does

\`\`\`
npm run audit:live
\`\`\`

Reads \`PANW_*\` env vars, builds the three OAuth clients, and hits 21 read-only endpoints across all three domains. Each result classified into one of:

- **ok** — schema parsed cleanly
- **schema-drift** — \`AISecSDKException(RESPONSE_VALIDATION)\` thrown; this is the signal we care about
- **auth** — \`OAUTH_ERROR\` or \`MISSING_VARIABLE\`; tenant not configured for that domain
- **other-error** — 4xx/5xx; usually empty tenant or permissions

Exits 1 if any \`schema-drift\` findings; prints full Zod error path so the fix is targeted (same diagnostic quality as #134's report). Exits 0 cleanly with no credentials (CI-safe).

## Probe coverage (read-only)

**Management (7):** profiles, topics, apiKeys, customerApps, dlpProfiles, deploymentProfiles, scanLogs.query (the empty-body case from #136)

**Model security (4):** securityRules, securityGroups, scans.list, scans.getLabelKeys

**Red team (10):** scans.list, scans.getCategories, targets (3 endpoints), eula.getStatus, customAttacks (3 endpoints), getQuota, getDashboardOverview

## Out of scope (deliberately)

- \`Scanner.syncScan\` — sends actual prompts, costs tokens, side-effecty
- Any endpoint requiring a UUID input we don't have generically (\`profiles.get(uuid)\`, etc.)
- Mutating operations (POST/PUT/DELETE)

## Test plan

- [x] \`npm run typecheck\` / \`lint\` / \`format:check\` — clean
- [x] \`npm run audit:live\` with no env vars → exits 0 with "No clients could be initialized" message (verified locally)
- [x] All 1041 existing tests pass

The actual live-tenant verification happens locally with credentials — that's the point of the script. CI runs it as a no-op.

## Doc

CLAUDE.md \`Commands\` section now lists \`audit:live\` and notes when to run it.

## Why this is worth the ~250 LOC

Each of the post-0.8.0 hot patches (0.8.1, 0.8.2) cost: an issue, a PR, a release, a CLI version bump, and brief CLI downtime. A 30-second \`npm run audit:live\` before the next release would have caught both of them locally on the maintainer's machine. The script pays for itself the first time it surfaces a finding.