### PR TITLE
fix: downloadTemplate returns CSV string; release v0.8.3

### DIFF
--- a/.changeset/0022-download-template-csv.md
+++ b/.changeset/0022-download-template-csv.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Fix `RedTeamCustomAttacksClient.downloadTemplate()` crashing with `Response body is not valid JSON` when the API returns a CSV body. The method now bypasses the shared `request()` helper (which unconditionally `JSON.parse()`s 2xx bodies), reads the response as text, and returns `string` instead of `unknown`. Closes #77.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.8.2';
+export const SDK_VERSION = '0.8.3';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/red-team/custom-attacks-client.ts
+++ b/src/red-team/custom-attacks-client.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import { RED_TEAM_CUSTOM_ATTACK_PATH, USER_AGENT } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { request } from '../http/request.js';
@@ -233,19 +232,40 @@ export class RedTeamCustomAttacksClient {
 
   /**
    * Download CSV template for a prompt set.
+   *
+   * Bypasses `request()` because the response is `text/csv`, not JSON, and
+   * `request()` unconditionally `JSON.parse()`s 2xx bodies.
+   *
    * @param uuid - The prompt set UUID.
-   * @returns The CSV template content (untyped — raw response from the API).
+   * @returns The CSV template content as a raw string.
    */
-  async downloadTemplate(uuid: string): Promise<unknown> {
+  async downloadTemplate(uuid: string): Promise<string> {
     assertUuid(uuid, 'prompt set uuid');
-    return request({
+
+    const url = new URL(
+      `${this.baseUrl.replace(/\/+$/, '')}${RED_TEAM_CUSTOM_ATTACK_PATH}/download-template/${uuid}`,
+    );
+
+    const stub: PreparedRequest = {
       method: 'GET',
-      baseUrl: this.baseUrl,
-      path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/download-template/${uuid}`,
-      responseSchema: z.unknown(),
-      auth: this.auth,
-      numRetries: this.numRetries,
+      url,
+      headers: { 'User-Agent': USER_AGENT },
+    };
+    const prepared = await this.auth.prepare(stub);
+
+    const response = await fetch(prepared.url.toString(), {
+      method: 'GET',
+      headers: prepared.headers,
     });
+
+    const text = await response.text();
+    if (!response.ok) {
+      throw new AISecSDKException(
+        `Download template failed (${response.status}): ${text}`,
+        ErrorType.SERVER_SIDE_ERROR,
+      );
+    }
+    return text;
   }
 
   /**

--- a/test/red-team/custom-attacks-client.spec.ts
+++ b/test/red-team/custom-attacks-client.spec.ts
@@ -197,13 +197,32 @@ describe('RedTeamCustomAttacksClient', () => {
   });
 
   describe('downloadTemplate', () => {
-    it('GETs /v1/custom-attack/download-template/:uuid', async () => {
-      mockFetch('csv-data');
+    it('GETs /v1/custom-attack/download-template/:uuid and returns raw CSV text', async () => {
+      const csv = 'prompt,goal\n"hello","greet"\n"bye","farewell"';
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(csv),
+      });
+
       const result = await client.downloadTemplate(validUuid);
 
-      expect(result).toBe('csv-data');
-      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(result).toBe(csv);
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain(`/v1/custom-attack/download-template/${validUuid}`);
+      expect(init.method).toBe('GET');
+    });
+
+    it('throws AISecSDKException on non-2xx response', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('not found'),
+      });
+
+      await expect(client.downloadTemplate(validUuid)).rejects.toThrow(
+        /Download template failed \(404\)/,
+      );
     });
 
     it('rejects invalid UUID', async () => {


### PR DESCRIPTION
## Summary

Fixes #77.

`request()` unconditionally `JSON.parse()`s 2xx response bodies, but the `download-template` endpoint returns `text/csv`. Against real API responses this throws `Response body is not valid JSON`.

This PR makes `downloadTemplate()` bypass `request()` (mirroring how `uploadPromptsCsv` already bypasses for `FormData`), reads `response.text()` directly, and returns `string` instead of `unknown`.

## Changes

- `src/red-team/custom-attacks-client.ts`: rewrite `downloadTemplate` to use `auth.prepare()` + raw `fetch`, return typed `string`.
- `test/red-team/custom-attacks-client.spec.ts`: existing test passed only because the shared `mockFetch` JSON-stringified the payload, masking the bug. Replaced with a real CSV mock; added a 4xx error-path test.
- Changeset: patch.

## Test plan

- [x] `npm test` (1042 pass)
- [x] `npm run lint`, `npm run typecheck` clean
- [x] New regression test fails on `main`, passes on this branch