### PR TITLE
chore(specs): add DLP OpenAPI specs

### DIFF
--- a/specs/dlp/DataFilteringProfiles.yaml
+++ b/specs/dlp/DataFilteringProfiles.yaml
@@ -1,0 +1,506 @@
+components:
+  schemas:
+    AppExclusion:
+      properties:
+        app_id:
+          type: string
+        app_name:
+          type: string
+        type:
+          type: string
+      type: object
+    AuditResponse:
+      description: Audit metadata tracking creation and last-update information
+      properties:
+        created_at:
+          description: Timestamp when the resource was created
+          format: date-time
+          type: string
+        created_by:
+          description: Username or service that created the resource
+          type: string
+        updated_at:
+          description: Timestamp when the resource was last updated
+          format: date-time
+          type: string
+        updated_by:
+          description: Username or service that last updated the resource
+          type: string
+      type: object
+    DataFilteringDetails:
+      description: Granular criteria details
+      properties:
+        action:
+          type: string
+        dataProfileId:
+          format: int64
+          type: integer
+        direction:
+          type: string
+        euc_template_id:
+          type: string
+        fileBased:
+          type: string
+        fileTypes:
+          items:
+            type: string
+          type: array
+          uniqueItems: true
+        is_end_user_coaching_enabled:
+          type: boolean
+        logSeverity:
+          type: string
+        nonFileBased:
+          type: string
+        scanType:
+          type: string
+      type: object
+    DataFilteringProfileRequest:
+      description: Request payload for updating a data filtering profile
+      properties:
+        criteria_details:
+          description: Granular criteria details for filtering
+          items:
+            $ref: '#/components/schemas/DataFilteringDetails'
+          type: array
+        data_profile_id:
+          description: ID of the linked data profile
+          format: int64
+          type: integer
+        description:
+          description: Optional human-readable description
+          type: string
+        direction:
+          description: 'Traffic direction: both, c2s, or s2c'
+          enum:
+          - BOTH
+          - UPLOAD
+          - DOWNLOAD
+          type: string
+        euc_template_id:
+          description: ID of the end-user coaching template to use
+          type: string
+        exception_rules:
+          description: Exception rules that bypass filtering
+          items:
+            $ref: '#/components/schemas/ExceptionRuleDTO'
+          type: array
+        exclusions:
+          $ref: '#/components/schemas/Exclusions'
+        file_based:
+          description: Whether file-based scanning is enabled
+          type: boolean
+        file_type:
+          description: List of file types to include in scanning
+          items:
+            description: List of file types to include in scanning
+            type: string
+          type: array
+        is_end_user_coaching_enabled:
+          description: Whether end-user coaching is enabled for this profile
+          type: boolean
+        is_granular_profile:
+          description: Whether this is a granular filtering profile
+          type: boolean
+        log_severity:
+          description: Log severity level
+          enum:
+          - CRITICAL
+          - HIGH
+          - MEDIUM
+          - LOW
+          - INFORMATIONAL
+          type: string
+        non_file_based:
+          description: Whether non-file-based scanning is enabled
+          type: boolean
+        rule1:
+          $ref: '#/components/schemas/DataFilteringRuleDTO'
+        rule2:
+          $ref: '#/components/schemas/DataFilteringRuleDTO'
+        scan_type:
+          description: Scan type (e.g. DLP, ATP)
+          enum:
+          - include
+          - exclude
+          type: string
+      required:
+      - file_based
+      - non_file_based
+      type: object
+    DataFilteringProfileResponse:
+      description: Data filtering profile resource returned by the API
+      properties:
+        audit_metadata:
+          $ref: '#/components/schemas/AuditResponse'
+        criteria_details:
+          description: Granular criteria details
+          items:
+            $ref: '#/components/schemas/DataFilteringDetails'
+          type: array
+        data_profile_id:
+          description: ID of the linked data profile
+          format: int64
+          type: integer
+        description:
+          description: Optional human-readable description
+          type: string
+        direction:
+          description: 'Traffic direction: both, c2s, or s2c'
+          type: string
+        euc_template_id:
+          description: ID of the end-user coaching template
+          type: string
+        exception_rules:
+          description: Exception rules
+          items:
+            $ref: '#/components/schemas/ExceptionRuleDTO'
+          type: array
+        exclusions:
+          $ref: '#/components/schemas/Exclusions'
+        file_based:
+          description: Whether file-based scanning is enabled
+          type: boolean
+        file_type:
+          description: List of file types included in scanning
+          items:
+            description: List of file types included in scanning
+            type: string
+          type: array
+        id:
+          description: Unique identifier of the filtering profile
+          type: string
+        is_end_user_coaching_enabled:
+          description: Whether end-user coaching is enabled
+          type: boolean
+        is_granular_profile:
+          description: Whether this is a granular profile
+          type: boolean
+        is_parent_managed:
+          description: Whether the profile is managed by a parent tenant
+          type: boolean
+        log_severity:
+          description: Log severity level
+          type: string
+        name:
+          description: Display name of the filtering profile
+          type: string
+        non_file_based:
+          description: Whether non-file-based scanning is enabled
+          type: boolean
+        rule1:
+          $ref: '#/components/schemas/DataFilteringRuleDTO'
+        rule2:
+          $ref: '#/components/schemas/DataFilteringRuleDTO'
+        scan_type:
+          description: Scan type
+          enum:
+          - include
+          - exclude
+          type: string
+        tenant_id:
+          description: Tenant identifier that owns this profile
+          type: string
+        type:
+          description: Profile type classification
+          type: string
+        version:
+          description: Version number, incremented on each update
+          format: int32
+          type: integer
+      type: object
+    DataFilteringRuleDTO:
+      description: Secondary filtering rule
+      properties:
+        action:
+          type: string
+        response_page:
+          type: string
+        show_rsp_page:
+          type: string
+      type: object
+    DestinationAttributes:
+      properties:
+        app_ids:
+          items:
+            type: string
+          type: array
+        match_any:
+          type: boolean
+        url_patterns:
+          items:
+            type: string
+          type: array
+      type: object
+    ExceptionRuleDTO:
+      description: Exception rules
+      properties:
+        action:
+          enum:
+          - ALLOW
+          - ALERT
+          - BLOCK
+          type: string
+        data_profile_ids:
+          items:
+            format: int64
+            type: integer
+          type: array
+        destination_attributes:
+          $ref: '#/components/schemas/DestinationAttributes'
+        id:
+          type: string
+        log_severity:
+          enum:
+          - INFORMATIONAL
+          - LOW
+          - MEDIUM
+          - HIGH
+          - CRITICAL
+          type: string
+        source_attributes:
+          $ref: '#/components/schemas/SourceAttributes'
+      type: object
+    Exclusions:
+      description: Exclusion rules
+      properties:
+        app_exclusion_list:
+          items:
+            $ref: '#/components/schemas/AppExclusion'
+          type: array
+        exclusion_list:
+          additionalProperties:
+            items:
+              type: string
+            type: array
+          type: object
+        url_exclusion_list:
+          items:
+            $ref: '#/components/schemas/URLExclusion'
+          type: array
+      type: object
+    PageDataFilteringProfileResponse:
+      properties:
+        content:
+          items:
+            $ref: '#/components/schemas/DataFilteringProfileResponse'
+          type: array
+        empty:
+          type: boolean
+        first:
+          type: boolean
+        last:
+          type: boolean
+        number:
+          format: int32
+          type: integer
+        numberOfElements:
+          format: int32
+          type: integer
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        size:
+          format: int32
+          type: integer
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        totalElements:
+          format: int64
+          type: integer
+        totalPages:
+          format: int32
+          type: integer
+      type: object
+    PageableObject:
+      properties:
+        offset:
+          format: int64
+          type: integer
+        pageNumber:
+          format: int32
+          type: integer
+        pageSize:
+          format: int32
+          type: integer
+        paged:
+          type: boolean
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+      type: object
+    SortObject:
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+      type: object
+    SourceAttributes:
+      properties:
+        match_any:
+          type: boolean
+        user_group_ids:
+          items:
+            type: string
+          type: array
+        user_ids:
+          items:
+            type: string
+          type: array
+      type: object
+    URLExclusion:
+      properties:
+        type:
+          type: string
+        url_id:
+          type: string
+        url_name:
+          type: string
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Create and manage data filtering profiles for categorizing and protecting\
+    \ sensitive data. Define custom \nfiltering rules to identify and classify sensitive\
+    \ information based on organizational requirements.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: Data Filtering Profiles API v2
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v2/api/data-filtering-profiles:
+    get:
+      description: Returns a paginated list of data filtering profiles for the authenticated
+        tenant.
+      operationId: get-v2-api-data-filtering-profiles
+      parameters:
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default
+          sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      - description: Filter by profile status
+        in: query
+        name: status
+        schema:
+          enum:
+          - enabled
+          - disabled
+          type: string
+      - description: Filter by profile name (partial match)
+        in: query
+        name: name
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDataFilteringProfileResponse'
+          description: Paginated list of data filtering profiles
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: List Data Filtering Profiles
+      tags:
+      - Data Filtering Profiles
+  /v2/api/data-filtering-profiles/{resourceId}:
+    get:
+      description: Retrieves a single data filtering profile by its Id
+      operationId: get-v2-api-data-filtering-profiles-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataFilteringProfileResponse'
+          description: Data filtering profile found
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Data filtering profile not found
+      security:
+      - Bearer: []
+      summary: Get Data Filtering Profile
+      tags:
+      - Data Filtering Profiles
+    put:
+      description: Fully replaces an existing data filtering profile with the provided
+        payload.
+      operationId: put-v2-api-data-filtering-profiles-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataFilteringProfileRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataFilteringProfileResponse'
+          description: Data filtering profile updated
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Data filtering profile not found
+      security:
+      - Bearer: []
+      summary: Update Data Filtering Profile
+      tags:
+      - Data Filtering Profiles
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: Data Filtering Profiles

--- a/specs/dlp/DataPatterns.yaml
+++ b/specs/dlp/DataPatterns.yaml
@@ -1,0 +1,553 @@
+components:
+  schemas:
+    AuditResponse:
+      description: Audit metadata tracking creation and last-update information
+      properties:
+        created_at:
+          description: Timestamp when the resource was created
+          format: date-time
+          type: string
+        created_by:
+          description: Username or service that created the resource
+          type: string
+        updated_at:
+          description: Timestamp when the resource was last updated
+          format: date-time
+          type: string
+        updated_by:
+          description: Username or service that last updated the resource
+          type: string
+      type: object
+    DataPatternDetectionConfig:
+      description: Detection configuration specifying the technique and supported
+        confidence levels
+      properties:
+        supported_confidence_levels:
+          description: List of confidence levels supported by this pattern
+          items:
+            description: List of confidence levels supported by this pattern
+            enum:
+            - low
+            - medium
+            - high
+            type: string
+          type: array
+        technique:
+          description: Detection technique (e.g. regex, ml)
+          enum:
+          - edm
+          - document_fingerprint
+          - trainable_classifier
+          - ml_document
+          - regex
+          - weighted_regex
+          - ml
+          - titus_tag
+          - wildfire
+          - file_property
+          - dictionary
+          - pab
+          - document_classifier
+          type: string
+      required:
+      - technique
+      type: object
+    DataPatternMatchingRules:
+      description: Optional matching rules controlling how the data pattern detects
+        sensitive content
+      properties:
+        delimiter:
+          description: Delimiter character used to separate tokens
+          type: string
+        metadata_criteria:
+          description: Metadata criteria for additional filtering
+          items:
+            $ref: '#/components/schemas/MetadataCriterion'
+          type: array
+        proximity_distance:
+          description: Proximity distance for keyword matching (2-1000)
+          format: int32
+          maximum: 1000
+          minimum: 2
+          type: integer
+        proximity_keywords:
+          description: List of keywords that must appear within the proximity distance
+          items:
+            description: List of keywords that must appear within the proximity distance
+            type: string
+          type: array
+        regexes:
+          description: Weighted regular expressions used for detection
+          items:
+            $ref: '#/components/schemas/WeightedRegex'
+          type: array
+      type: object
+    DataPatternPatchRequest:
+      description: Request payload for partially updating a data pattern (JSON Merge
+        Patch)
+      properties:
+        description:
+          $ref: '#/components/schemas/JsonNullableString'
+        detection_config:
+          $ref: '#/components/schemas/JsonNullableDataPatternDetectionConfig'
+        matching_rules:
+          $ref: '#/components/schemas/JsonNullableDataPatternMatchingRules'
+        name:
+          $ref: '#/components/schemas/JsonNullableString'
+        tags:
+          $ref: '#/components/schemas/JsonNullableDataPatternTags'
+        type:
+          $ref: '#/components/schemas/JsonNullableDataPatternType'
+      required:
+      - detection_config
+      - name
+      - type
+      type: object
+    DataPatternRequest:
+      description: Request payload for creating or updating a data pattern
+      properties:
+        description:
+          description: Optional human-readable description
+          type: string
+        detection_config:
+          $ref: '#/components/schemas/DataPatternDetectionConfig'
+        matching_rules:
+          $ref: '#/components/schemas/DataPatternMatchingRules'
+        name:
+          description: Display name of the data pattern
+          example: SSN Pattern
+          maxLength: 64
+          minLength: 1
+          type: string
+        tags:
+          $ref: '#/components/schemas/DataPatternTags'
+        type:
+          description: Pattern type (e.g. regex, ml_based)
+          enum:
+          - predefined
+          - custom
+          - file_property
+          type: string
+      required:
+      - detection_config
+      - name
+      - type
+      type: object
+    DataPatternResponse:
+      description: Data pattern resource returned by the API
+      properties:
+        audit_metadata:
+          $ref: '#/components/schemas/AuditResponse'
+        description:
+          description: Optional human-readable description
+          type: string
+        detection_config:
+          $ref: '#/components/schemas/DataPatternDetectionConfig'
+        id:
+          description: Unique identifier of the data pattern
+          type: string
+        is_parent_managed:
+          description: Whether the pattern is managed by a parent tenant
+          type: boolean
+        license_type:
+          description: License type associated with the pattern
+          enum:
+          - standard
+          - enterprise
+          - essentials
+          type: string
+        matching_rules:
+          $ref: '#/components/schemas/DataPatternMatchingRules'
+        name:
+          description: Display name of the data pattern
+          type: string
+        status:
+          description: Current lifecycle status of the pattern
+          enum:
+          - active
+          - disabled
+          - deleted
+          - deprecated
+          - silent
+          type: string
+        tags:
+          $ref: '#/components/schemas/DataPatternTags'
+        tenant_id:
+          description: Tenant identifier that owns this pattern
+          type: string
+        type:
+          description: Pattern type
+          enum:
+          - predefined
+          - custom
+          - file_property
+          type: string
+        version:
+          description: Version number, incremented on each update
+          format: int32
+          type: integer
+      type: object
+    DataPatternTags:
+      description: Metadata tags
+      properties:
+        classification:
+          items:
+            type: string
+          type: array
+        compliance:
+          items:
+            type: string
+          type: array
+        geography:
+          items:
+            type: string
+          type: array
+      type: object
+    JsonNullableDataPatternDetectionConfig:
+      description: New detection configuration
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableDataPatternMatchingRules:
+      description: New matching rules
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableDataPatternTags:
+      description: New metadata tags
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableDataPatternType:
+      description: New pattern type
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableString:
+      description: New description (set to null to clear)
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    MetadataCriterion:
+      description: Metadata criteria for additional filtering
+      properties:
+        comparisonOperatorType:
+          enum:
+          - less_than
+          - less_than_or_equal_to
+          - greater_than_or_equal_to
+          - greater_than
+          - equal_to
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+        value:
+          type: string
+      type: object
+    PageDataPatternResponse:
+      properties:
+        content:
+          items:
+            $ref: '#/components/schemas/DataPatternResponse'
+          type: array
+        empty:
+          type: boolean
+        first:
+          type: boolean
+        last:
+          type: boolean
+        number:
+          format: int32
+          type: integer
+        numberOfElements:
+          format: int32
+          type: integer
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        size:
+          format: int32
+          type: integer
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        totalElements:
+          format: int64
+          type: integer
+        totalPages:
+          format: int32
+          type: integer
+      type: object
+    PageableObject:
+      properties:
+        offset:
+          format: int64
+          type: integer
+        pageNumber:
+          format: int32
+          type: integer
+        pageSize:
+          format: int32
+          type: integer
+        paged:
+          type: boolean
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+      type: object
+    SortObject:
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+      type: object
+    WeightedRegex:
+      description: Weighted regular expressions used for detection
+      properties:
+        regex:
+          maxLength: 2147483647
+          minLength: 1
+          type: string
+        weight:
+          format: int32
+          type: integer
+      required:
+      - regex
+      - weight
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Manage data patterns used for detecting sensitive information such\
+    \ as PII, financial data, healthcare \ninformation, and custom patterns. Create,\
+    \ update, and configure detection patterns with various techniques \nincluding\
+    \ regex, machine learning, and exact data matching.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: Data Patterns API v2
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v2/api/data-patterns:
+    get:
+      description: Returns a paginated list of data patterns for the authenticated
+        tenant.
+      operationId: get-v2-api-data-patterns
+      parameters:
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default
+          sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDataPatternResponse'
+          description: Paginated list of data patterns
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: List Data Patterns
+      tags:
+      - Data Patterns
+    post:
+      description: Creates a new custom data pattern for the authenticated tenant.
+      operationId: post-v2-api-data-patterns
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataPatternRequest'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPatternResponse'
+          description: Data pattern created
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: Create Data Pattern
+      tags:
+      - Data Patterns
+  /v2/api/data-patterns/{resourceId}:
+    delete:
+      description: Soft-deletes (archives) a data pattern by its ID.
+      operationId: delete-v2-api-data-patterns-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Data pattern deleted
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Data pattern not found
+      security:
+      - Bearer: []
+      summary: Delete Data Pattern
+      tags:
+      - Data Patterns
+    get:
+      description: Retrieves a single data pattern by its ID.
+      operationId: get-v2-api-data-patterns-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPatternResponse'
+          description: Data pattern found
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Data pattern not found
+      security:
+      - Bearer: []
+      summary: Get Data Pattern
+      tags:
+      - Data Patterns
+    patch:
+      description: Partially updates an existing data pattern using JSON Merge Patch
+        semantics.
+      operationId: patch-v2-api-data-patterns-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/DataPatternPatchRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPatternResponse'
+          description: Data pattern updated
+        '400':
+          description: Invalid patch payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Data pattern not found
+      security:
+      - Bearer: []
+      summary: Patch Data Pattern
+      tags:
+      - Data Patterns
+    put:
+      description: Fully replaces an existing data pattern with the provided payload.
+      operationId: put-v2-api-data-patterns-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataPatternRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPatternResponse'
+          description: Data pattern updated
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Data pattern not found
+      security:
+      - Bearer: []
+      summary: Update Data Pattern
+      tags:
+      - Data Patterns
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: Data Patterns

--- a/specs/dlp/DataProfiles.yaml
+++ b/specs/dlp/DataProfiles.yaml
@@ -1,0 +1,822 @@
+components:
+  schemas:
+    AdvancedDataProfileRequest:
+      description: Advanced data profile request. Use profile_type='advanced'.
+      properties:
+        description:
+          description: Optional human-readable description
+          type: string
+        detection_rules:
+          description: Detection rules (at least one required)
+          items:
+            oneOf:
+            - $ref: '#/components/schemas/DefaultTreeDetectionRule'
+            - $ref: '#/components/schemas/MultiProfileDetectionRule'
+          type: array
+        is_granular_data_profile:
+          description: Whether this is a granular data profile
+          type: boolean
+        name:
+          description: Display name
+          maxLength: 64
+          minLength: 1
+          type: string
+      required:
+      - detection_rules
+      - name
+      type: object
+    AuditResponse:
+      description: Audit metadata tracking creation and last-update information
+      properties:
+        created_at:
+          description: Timestamp when the resource was created
+          format: date-time
+          type: string
+        created_by:
+          description: Username or service that created the resource
+          type: string
+        updated_at:
+          description: Timestamp when the resource was last updated
+          format: date-time
+          type: string
+        updated_by:
+          description: Username or service that last updated the resource
+          type: string
+      type: object
+    DataPatternRuleItem:
+      allOf:
+      - $ref: '#/components/schemas/DetectionRuleItem'
+      - properties:
+          by_unique_count:
+            type: boolean
+          confidence_level:
+            enum:
+            - low
+            - medium
+            - high
+            type: string
+          description:
+            type: string
+          detection_technique:
+            enum:
+            - edm
+            - document_fingerprint
+            - trainable_classifier
+            - ml_document
+            - regex
+            - weighted_regex
+            - ml
+            - titus_tag
+            - wildfire
+            - file_property
+            - dictionary
+            - pab
+            - document_classifier
+            type: string
+          match_type:
+            enum:
+            - include
+            - exclude
+            type: string
+          occurrence_count:
+            format: int32
+            type: integer
+          occurrence_high:
+            format: int32
+            type: integer
+          occurrence_low:
+            format: int32
+            type: integer
+          occurrence_operator_type:
+            enum:
+            - any
+            - less_than_equal_to
+            - more_than_equal_to
+            - between
+            type: string
+          supported_confidence_levels:
+            items:
+              enum:
+              - low
+              - medium
+              - high
+              type: string
+            type: array
+        type: object
+      discriminator:
+        propertyName: detection_technique
+      required:
+      - match_type
+      type: object
+    DataProfilePatchRequest:
+      description: Request payload for partially updating a data profile (JSON Merge
+        Patch)
+      properties:
+        description:
+          $ref: '#/components/schemas/JsonNullableString'
+        detection_rules:
+          $ref: '#/components/schemas/JsonNullableListDetectionRule'
+        name:
+          $ref: '#/components/schemas/JsonNullableString'
+        profile_type:
+          $ref: '#/components/schemas/JsonNullableDataProfileType'
+      required:
+      - name
+      - profile_type
+      type: object
+    DataProfileResponse:
+      description: Data profile resource returned by the API
+      properties:
+        advance_data_patterns_rule_request:
+          description: List of advanced data pattern rule identifiers
+          items:
+            description: List of advanced data pattern rule identifiers
+            type: string
+          type: array
+        audit_metadata:
+          $ref: '#/components/schemas/AuditResponse'
+        description:
+          description: Optional human-readable description
+          type: string
+        detection_rules:
+          description: Detection rules that define sensitive data criteria
+          items:
+            oneOf:
+            - $ref: '#/components/schemas/DefaultTreeDetectionRule'
+            - $ref: '#/components/schemas/MultiProfileDetectionRule'
+          type: array
+        id:
+          description: Unique identifier of the data profile
+          type: string
+        is_granular_data_profile:
+          description: Whether this is a granular profile
+          type: boolean
+        is_parent_managed:
+          description: Whether the profile is managed by a parent tenant
+          type: boolean
+        name:
+          description: Display name of the data profile
+          type: string
+        profile_status:
+          description: Current lifecycle status
+          enum:
+          - active
+          - disabled
+          - deleted
+          type: string
+        profile_type:
+          description: Profile type
+          enum:
+          - basic
+          - advanced
+          type: string
+        tenant_id:
+          description: Tenant identifier that owns this profile
+          type: string
+        type:
+          description: Profile subtype classification
+          enum:
+          - custom
+          - predefined
+          type: string
+        version:
+          description: Version number, incremented on each update
+          format: int32
+          type: integer
+      type: object
+    DefaultTreeDetectionRule:
+      allOf:
+      - $ref: '#/components/schemas/DetectionRule'
+      - properties:
+          expression_tree:
+            $ref: '#/components/schemas/ExpressionTreeNode'
+          rule_type:
+            enum:
+            - expression_tree
+            - multi_profile
+            type: string
+        type: object
+      type: object
+    DetectionRule:
+      description: Detection rules that define sensitive data criteria
+      discriminator:
+        propertyName: rule_type
+      properties:
+        detectionRuleType:
+          enum:
+          - expression_tree
+          - multi_profile
+          type: string
+        rule_type:
+          type: string
+      required:
+      - rule_type
+      type: object
+    DetectionRuleItem:
+      discriminator:
+        propertyName: detection_technique
+      properties:
+        byUniqueCount:
+          type: boolean
+        confidenceLevel:
+          enum:
+          - low
+          - medium
+          - high
+          type: string
+        detectionTechnique:
+          enum:
+          - edm
+          - document_fingerprint
+          - trainable_classifier
+          - ml_document
+          - regex
+          - weighted_regex
+          - ml
+          - titus_tag
+          - wildfire
+          - file_property
+          - dictionary
+          - pab
+          - document_classifier
+          type: string
+        detection_technique:
+          type: string
+        id:
+          type: string
+        matchType:
+          enum:
+          - include
+          - exclude
+          type: string
+        name:
+          type: string
+        occurrenceCount:
+          format: int32
+          type: integer
+        occurrenceHigh:
+          format: int32
+          type: integer
+        occurrenceLow:
+          format: int32
+          type: integer
+        occurrenceOperatorType:
+          enum:
+          - any
+          - less_than_equal_to
+          - more_than_equal_to
+          - between
+          type: string
+        version:
+          format: int32
+          type: integer
+      required:
+      - detection_technique
+      type: object
+    DictionaryRuleItem:
+      allOf:
+      - $ref: '#/components/schemas/DetectionRuleItem'
+      - properties:
+          by_unique_count:
+            type: boolean
+          confidence_level:
+            enum:
+            - low
+            - medium
+            - high
+            type: string
+          description:
+            type: string
+          detection_technique:
+            enum:
+            - edm
+            - document_fingerprint
+            - trainable_classifier
+            - ml_document
+            - regex
+            - weighted_regex
+            - ml
+            - titus_tag
+            - wildfire
+            - file_property
+            - dictionary
+            - pab
+            - document_classifier
+            type: string
+          match_type:
+            enum:
+            - include
+            - exclude
+            type: string
+          occurrence_count:
+            format: int32
+            type: integer
+          occurrence_high:
+            format: int32
+            type: integer
+          occurrence_low:
+            format: int32
+            type: integer
+          occurrence_operator_type:
+            enum:
+            - any
+            - less_than_equal_to
+            - more_than_equal_to
+            - between
+            type: string
+          score:
+            format: int32
+            type: integer
+          score_high:
+            format: int32
+            type: integer
+          score_low:
+            format: int32
+            type: integer
+          supported_confidence_levels:
+            items:
+              enum:
+              - low
+              - medium
+              - high
+              type: string
+            type: array
+        type: object
+      discriminator:
+        propertyName: detection_technique
+      required:
+      - match_type
+      type: object
+    DocumentTypeRuleItem:
+      allOf:
+      - $ref: '#/components/schemas/DetectionRuleItem'
+      - properties:
+          confidence_level:
+            enum:
+            - low
+            - medium
+            - high
+            type: string
+          description:
+            type: string
+          detection_technique:
+            enum:
+            - edm
+            - document_fingerprint
+            - trainable_classifier
+            - ml_document
+            - regex
+            - weighted_regex
+            - ml
+            - titus_tag
+            - wildfire
+            - file_property
+            - dictionary
+            - pab
+            - document_classifier
+            type: string
+          match_type:
+            enum:
+            - include
+            - exclude
+            type: string
+          occurrence_count:
+            format: int32
+            type: integer
+          occurrence_high:
+            format: int32
+            type: integer
+          occurrence_low:
+            format: int32
+            type: integer
+          occurrence_operator_type:
+            enum:
+            - any
+            - less_than_equal_to
+            - more_than_equal_to
+            - between
+            type: string
+          score:
+            format: int32
+            type: integer
+          score_high:
+            format: int32
+            type: integer
+          score_low:
+            format: int32
+            type: integer
+          supported_confidence_levels:
+            items:
+              enum:
+              - low
+              - medium
+              - high
+              type: string
+            type: array
+        type: object
+      discriminator:
+        propertyName: detection_technique
+      required:
+      - match_type
+      type: object
+    EdmRuleItem:
+      allOf:
+      - $ref: '#/components/schemas/DetectionRuleItem'
+      - properties:
+          confidence_level:
+            enum:
+            - low
+            - medium
+            - high
+            type: string
+          detection_technique:
+            enum:
+            - edm
+            - document_fingerprint
+            - trainable_classifier
+            - ml_document
+            - regex
+            - weighted_regex
+            - ml
+            - titus_tag
+            - wildfire
+            - file_property
+            - dictionary
+            - pab
+            - document_classifier
+            type: string
+          edm_dataset_id:
+            type: string
+          occurrence_count:
+            format: int32
+            type: integer
+          occurrence_high:
+            format: int32
+            type: integer
+          occurrence_low:
+            format: int32
+            type: integer
+          occurrence_operator_type:
+            enum:
+            - any
+            - less_than_equal_to
+            - more_than_equal_to
+            - between
+            type: string
+          primary_fields:
+            items:
+              type: string
+            type: array
+            uniqueItems: true
+          primary_match_any_count:
+            format: int32
+            type: integer
+          primary_match_criteria:
+            enum:
+            - any
+            - all
+            type: string
+          secondary_fields:
+            items:
+              type: string
+            type: array
+            uniqueItems: true
+          secondary_match_any_count:
+            format: int32
+            type: integer
+          secondary_match_criteria:
+            enum:
+            - any
+            - all
+            type: string
+        type: object
+      required:
+      - edm_dataset_id
+      - primary_fields
+      type: object
+    ExpressionTreeNode:
+      properties:
+        operator_type:
+          enum:
+          - and
+          - or
+          - not
+          - and_not
+          - or_not
+          type: string
+        rule_item:
+          oneOf:
+          - $ref: '#/components/schemas/DataPatternRuleItem'
+          - $ref: '#/components/schemas/DictionaryRuleItem'
+          - $ref: '#/components/schemas/DocumentTypeRuleItem'
+          - $ref: '#/components/schemas/EdmRuleItem'
+        sub_expressions:
+          items:
+            $ref: '#/components/schemas/ExpressionTreeNode'
+          type: array
+      type: object
+    JsonNullableDataProfileType:
+      description: New profile type
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableListDetectionRule:
+      description: New detection rules
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableString:
+      description: New description (set to null to clear)
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    MultiProfileDataNode:
+      properties:
+        data_profile_ids:
+          items:
+            format: int64
+            type: integer
+          type: array
+        operator_type:
+          enum:
+          - and
+          - or
+          - not
+          - and_not
+          - or_not
+          type: string
+      type: object
+    MultiProfileDetectionRule:
+      allOf:
+      - $ref: '#/components/schemas/DetectionRule'
+      - properties:
+          multi_profile:
+            $ref: '#/components/schemas/MultiProfileDataNode'
+          rule_type:
+            enum:
+            - expression_tree
+            - multi_profile
+            type: string
+        type: object
+      type: object
+    PageDataProfileResponse:
+      properties:
+        content:
+          items:
+            $ref: '#/components/schemas/DataProfileResponse'
+          type: array
+        empty:
+          type: boolean
+        first:
+          type: boolean
+        last:
+          type: boolean
+        number:
+          format: int32
+          type: integer
+        numberOfElements:
+          format: int32
+          type: integer
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        size:
+          format: int32
+          type: integer
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        totalElements:
+          format: int64
+          type: integer
+        totalPages:
+          format: int32
+          type: integer
+      type: object
+    PageableObject:
+      properties:
+        offset:
+          format: int64
+          type: integer
+        pageNumber:
+          format: int32
+          type: integer
+        pageSize:
+          format: int32
+          type: integer
+        paged:
+          type: boolean
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+      type: object
+    SortObject:
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Create and manage data profiles that define collections of data patterns\
+    \ for incident detection. Organize \nmultiple data patterns into logical profiles\
+    \ for comprehensive data protection strategies.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: Data Profiles API v2
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v2/api/data-profiles:
+    get:
+      description: Returns a paginated list of data profiles for the authenticated
+        tenant.
+      operationId: get-v2-api-data-profiles
+      parameters:
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default
+          sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDataProfileResponse'
+          description: Paginated list of data profiles
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: List Data Profiles
+      tags:
+      - Data Profiles
+    post:
+      description: Creates a new data profile for the authenticated tenant.
+      operationId: post-v2-api-data-profiles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdvancedDataProfileRequest'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataProfileResponse'
+          description: Data profile created
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: Create Data Profile
+      tags:
+      - Data Profiles
+  /v2/api/data-profiles/{resourceId}:
+    get:
+      description: Retrieves a single data profile by its ID.
+      operationId: get-v2-api-data-profiles-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataProfileResponse'
+          description: Data profile found
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Data profile not found
+      security:
+      - Bearer: []
+      summary: Get Data Profile
+      tags:
+      - Data Profiles
+    patch:
+      description: Partially updates an existing data profile using JSON Merge Patch
+        semantics.
+      operationId: patch-v2-api-data-profiles-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/DataProfilePatchRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataProfileResponse'
+          description: Data profile updated
+        '400':
+          description: Invalid patch payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Data profile not found
+      security:
+      - Bearer: []
+      summary: Patch Data Profile
+      tags:
+      - Data Profiles
+    put:
+      description: Fully replaces an existing data profile with the provided payload.
+      operationId: put-v2-api-data-profiles-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdvancedDataProfileRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataProfileResponse'
+          description: Data profile updated
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Data profile not found
+      security:
+      - Bearer: []
+      summary: Update Data Profile
+      tags:
+      - Data Profiles
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: Data Profiles

--- a/specs/dlp/Dictionaries.yaml
+++ b/specs/dlp/Dictionaries.yaml
@@ -1,0 +1,530 @@
+components:
+  schemas:
+    AuditResponse:
+      description: Audit metadata tracking creation and last-update information
+      properties:
+        created_at:
+          description: Timestamp when the resource was created
+          format: date-time
+          type: string
+        created_by:
+          description: Username or service that created the resource
+          type: string
+        updated_at:
+          description: Timestamp when the resource was last updated
+          format: date-time
+          type: string
+        updated_by:
+          description: Username or service that last updated the resource
+          type: string
+      type: object
+    DictionaryMetaDataDTO:
+      description: Dictionary metadata including keyword count and file info
+      properties:
+        number_of_keywords:
+          format: int32
+          type: integer
+        original_file_name:
+          type: string
+        original_file_size_in_byte:
+          format: int64
+          type: integer
+      type: object
+    DictionaryPatchRequest:
+      description: Request payload for partially updating a dictionary (JSON Merge
+        Patch)
+      properties:
+        category:
+          $ref: '#/components/schemas/JsonNullableString'
+        description:
+          $ref: '#/components/schemas/JsonNullableString'
+        is_case_sensitive:
+          $ref: '#/components/schemas/JsonNullableBoolean'
+        name:
+          $ref: '#/components/schemas/JsonNullableString'
+        original_file_name:
+          $ref: '#/components/schemas/JsonNullableString'
+        region_name:
+          $ref: '#/components/schemas/JsonNullableString'
+      required:
+      - category
+      - name
+      - original_file_name
+      type: object
+    DictionaryRequest:
+      description: Request payload for creating or updating a dictionary (use as the
+        'json' part in multipart/form-data)
+      properties:
+        category:
+          description: Category for grouping (e.g. PII, Finance)
+          enum:
+          - Academic
+          - Confidential
+          - Employment
+          - Financial
+          - Government
+          - Healthcare
+          - Legal
+          - Marketing
+          - Source Code
+          type: string
+        description:
+          description: Optional human-readable description
+          type: string
+        is_case_sensitive:
+          description: Whether keyword matching is case-sensitive
+          type: boolean
+        name:
+          description: Display name of the dictionary
+          type: string
+        original_file_name:
+          description: Original file name of the uploaded keyword file
+          type: string
+        region_name:
+          description: Optional region name for region-specific dictionaries
+          type: string
+        type:
+          enum:
+          - predefined
+          - custom
+          type: string
+      required:
+      - category
+      - name
+      - original_file_name
+      - region_name
+      type: object
+    DictionaryResponse:
+      description: Dictionary resource returned by the API
+      properties:
+        attributes:
+          description: Additional resource attributes
+          items:
+            $ref: '#/components/schemas/ResourceModelExtension'
+          type: array
+        audit_metadata:
+          $ref: '#/components/schemas/AuditResponse'
+        category:
+          description: Category for grouping
+          type: string
+        description:
+          description: Optional human-readable description
+          type: string
+        detection_sub_technique:
+          description: Detection sub-technique
+          enum:
+          - dnn
+          - gamma
+          - ml_gateway
+          - encoding
+          - password_protected
+          - encryption
+          - compression
+          - threshold
+          type: string
+        detection_technique:
+          description: Detection technique used
+          enum:
+          - edm
+          - document_fingerprint
+          - trainable_classifier
+          - ml_document
+          - regex
+          - weighted_regex
+          - ml
+          - titus_tag
+          - wildfire
+          - file_property
+          - dictionary
+          - pab
+          - document_classifier
+          type: string
+        dictionary_metadata:
+          $ref: '#/components/schemas/DictionaryMetaDataDTO'
+        id:
+          description: Unique identifier of the dictionary
+          type: string
+        is_case_sensitive:
+          description: Whether keyword matching is case-sensitive
+          type: boolean
+        is_parent_managed:
+          description: Whether the dictionary is managed by a parent tenant
+          type: boolean
+        keywords:
+          description: List of keywords (included when keywords=true query param is
+            set)
+          items:
+            description: List of keywords (included when keywords=true query param
+              is set)
+            type: string
+          type: array
+        name:
+          description: Display name of the dictionary
+          type: string
+        region_name:
+          description: Optional region name
+          type: string
+        tags:
+          $ref: '#/components/schemas/DictionaryTags'
+        type:
+          description: Dictionary type (always custom for user-created dictionaries)
+          enum:
+          - predefined
+          - custom
+          type: string
+      type: object
+    DictionaryTags:
+      description: Metadata tags
+      properties:
+        classification:
+          items:
+            enum:
+            - pab
+            - endpoint
+            type: string
+          type: array
+      type: object
+    JsonNullableBoolean:
+      description: New enabled state
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableString:
+      description: New description (set to null to clear)
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    PageDictionaryResponse:
+      properties:
+        content:
+          items:
+            $ref: '#/components/schemas/DictionaryResponse'
+          type: array
+        empty:
+          type: boolean
+        first:
+          type: boolean
+        last:
+          type: boolean
+        number:
+          format: int32
+          type: integer
+        numberOfElements:
+          format: int32
+          type: integer
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        size:
+          format: int32
+          type: integer
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        totalElements:
+          format: int64
+          type: integer
+        totalPages:
+          format: int32
+          type: integer
+      type: object
+    PageableObject:
+      properties:
+        offset:
+          format: int64
+          type: integer
+        pageNumber:
+          format: int32
+          type: integer
+        pageSize:
+          format: int32
+          type: integer
+        paged:
+          type: boolean
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+      type: object
+    ResourceModelExtension:
+      description: Additional resource attributes
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+      type: object
+    SortObject:
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Create and manage custom dictionaries for data pattern matching and\
+    \ detection. Build domain-specific \ndictionaries to enhance detection accuracy\
+    \ for industry-specific sensitive information.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: Dictionaries API v2
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v2/api/dictionaries:
+    get:
+      description: Returns a paginated list of dictionaries for the authenticated
+        tenant.
+      operationId: get-v2-api-dictionaries
+      parameters:
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default
+          sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      - description: If true, include keywords list in response
+        in: query
+        name: keywords
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDictionaryResponse'
+          description: Paginated list of dictionaries
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: List Dictionaries
+      tags:
+      - Dictionaries
+    post:
+      description: Creates a dictionary by uploading a file (multipart/form-data).
+      operationId: post-v2-api-dictionaries
+      parameters:
+      - in: query
+        name: keywords
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                file:
+                  format: binary
+                  type: string
+                json:
+                  $ref: '#/components/schemas/DictionaryRequest'
+              required:
+              - file
+              - json
+              type: object
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryResponse'
+          description: Dictionary created
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: Create Dictionary
+      tags:
+      - Dictionaries
+  /v2/api/dictionaries/{resourceId}:
+    delete:
+      description: Deletes a dictionary by its ID.
+      operationId: delete-v2-api-dictionaries-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Dictionary deleted
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Dictionary not found
+      security:
+      - Bearer: []
+      summary: Delete Dictionary
+      tags:
+      - Dictionaries
+    get:
+      description: Retrieves a single dictionary by its ID.
+      operationId: get-v2-api-dictionaries-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      - description: If true, include keywords list in response
+        in: query
+        name: keywords
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryResponse'
+          description: Dictionary found
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Dictionary not found
+      security:
+      - Bearer: []
+      summary: Get Dictionary
+      tags:
+      - Dictionaries
+    patch:
+      description: Partially updates an existing dictionary using JSON Merge Patch
+        semantics.
+      operationId: patch-v2-api-dictionaries-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/DictionaryPatchRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryResponse'
+          description: Dictionary updated
+        '400':
+          description: Invalid patch payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Dictionary not found
+      security:
+      - Bearer: []
+      summary: Patch Dictionary
+      tags:
+      - Dictionaries
+    put:
+      description: Replaces an existing dictionary by uploading a new file (multipart/form-data).
+      operationId: put-v2-api-dictionaries-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: keywords
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                file:
+                  format: binary
+                  type: string
+                json:
+                  $ref: '#/components/schemas/DictionaryRequest'
+              required:
+              - file
+              - json
+              type: object
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryResponse'
+          description: Dictionary updated
+        '204':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryResponse'
+          description: No Content
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Dictionary not found
+      security:
+      - Bearer: []
+      summary: Update Dictionary
+      tags:
+      - Dictionaries
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: Dictionaries

--- a/specs/dlp/DocumentTypes.yaml
+++ b/specs/dlp/DocumentTypes.yaml
@@ -1,0 +1,500 @@
+components:
+  schemas:
+    AuditResponse:
+      description: Audit metadata tracking creation and last-update information
+      properties:
+        created_at:
+          description: Timestamp when the resource was created
+          format: date-time
+          type: string
+        created_by:
+          description: Username or service that created the resource
+          type: string
+        updated_at:
+          description: Timestamp when the resource was last updated
+          format: date-time
+          type: string
+        updated_by:
+          description: Username or service that last updated the resource
+          type: string
+      type: object
+    DocMetadataDTO:
+      description: Technique-specific metadata (fingerprint or classifier details)
+      type: object
+    DocumentTypePatchRequest:
+      description: Request payload for partially updating a document type (JSON Merge
+        Patch)
+      properties:
+        category:
+          $ref: '#/components/schemas/JsonNullableString'
+        description:
+          $ref: '#/components/schemas/JsonNullableString'
+        detection_technique:
+          $ref: '#/components/schemas/JsonNullableDetectionTechnique'
+        l1_category_id:
+          $ref: '#/components/schemas/JsonNullableInteger'
+        l2_category_id:
+          $ref: '#/components/schemas/JsonNullableInteger'
+        name:
+          $ref: '#/components/schemas/JsonNullableString'
+        original_file_name:
+          $ref: '#/components/schemas/JsonNullableString'
+      required:
+      - category
+      - detection_technique
+      - name
+      - original_file_name
+      type: object
+    DocumentTypeRequest:
+      description: Request payload for creating or updating a document type (use as
+        the 'json' part in multipart/form-data)
+      properties:
+        category:
+          description: Category for grouping
+          enum:
+          - Academic
+          - Confidential
+          - Employment
+          - Financial
+          - Government
+          - Healthcare
+          - Legal
+          - Marketing
+          - Source Code
+          type: string
+        description:
+          description: Optional human-readable description
+          type: string
+        detection_technique:
+          description: 'Detection technique: document_fingerprint or trainable_classifier'
+          enum:
+          - edm
+          - document_fingerprint
+          - trainable_classifier
+          - ml_document
+          - regex
+          - weighted_regex
+          - ml
+          - titus_tag
+          - wildfire
+          - file_property
+          - dictionary
+          - pab
+          - document_classifier
+          type: string
+        l1_category_id:
+          description: L1 category ID for hierarchical classification
+          format: int32
+          type: integer
+        l2_category_id:
+          description: L2 category ID for hierarchical classification
+          format: int32
+          type: integer
+        name:
+          description: Display name of the document type
+          type: string
+        original_file_name:
+          description: Original file name of the uploaded training file
+          type: string
+      required:
+      - category
+      - detection_technique
+      - name
+      - original_file_name
+      type: object
+    DocumentTypeResponse:
+      description: Document type resource returned by the API
+      properties:
+        audit_metadata:
+          $ref: '#/components/schemas/AuditResponse'
+        category:
+          description: Category for grouping
+          type: string
+        description:
+          description: Optional human-readable description
+          type: string
+        detection_sub_technique:
+          description: Detection sub-technique
+          enum:
+          - dnn
+          - gamma
+          - ml_gateway
+          - encoding
+          - password_protected
+          - encryption
+          - compression
+          - threshold
+          type: string
+        detection_technique:
+          description: Detection technique used
+          enum:
+          - edm
+          - document_fingerprint
+          - trainable_classifier
+          - ml_document
+          - regex
+          - weighted_regex
+          - ml
+          - titus_tag
+          - wildfire
+          - file_property
+          - dictionary
+          - pab
+          - document_classifier
+          type: string
+        id:
+          description: Unique identifier of the document type
+          type: string
+        license_type:
+          description: License type associated with this document type
+          enum:
+          - standard
+          - enterprise
+          - essentials
+          type: string
+        metadata:
+          $ref: '#/components/schemas/DocMetadataDTO'
+        name:
+          description: Display name of the document type
+          type: string
+        status:
+          description: Configuration and training status
+          enum:
+          - completed
+          - failed
+          - inProgress
+          - available
+          type: string
+        supported_confidence_levels:
+          description: List of confidence levels supported
+          items:
+            description: List of confidence levels supported
+            enum:
+            - low
+            - medium
+            - high
+            type: string
+          type: array
+        type:
+          description: Document type classification
+          enum:
+          - custom
+          - predefined
+          type: string
+        version:
+          description: Version number, incremented on each update
+          format: int32
+          type: integer
+      type: object
+    JsonNullableDetectionTechnique:
+      description: New detection technique
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableInteger:
+      description: New priority order
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableString:
+      description: New description (set to null to clear)
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    PageDocumentTypeResponse:
+      properties:
+        content:
+          items:
+            $ref: '#/components/schemas/DocumentTypeResponse'
+          type: array
+        empty:
+          type: boolean
+        first:
+          type: boolean
+        last:
+          type: boolean
+        number:
+          format: int32
+          type: integer
+        numberOfElements:
+          format: int32
+          type: integer
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        size:
+          format: int32
+          type: integer
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        totalElements:
+          format: int64
+          type: integer
+        totalPages:
+          format: int32
+          type: integer
+      type: object
+    PageableObject:
+      properties:
+        offset:
+          format: int64
+          type: integer
+        pageNumber:
+          format: int32
+          type: integer
+        pageSize:
+          format: int32
+          type: integer
+        paged:
+          type: boolean
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+      type: object
+    SortObject:
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Manage document type classifications for enhanced document scanning\
+    \ and categorization. Define custom \ndocument types to improve detection accuracy\
+    \ and enable type-specific DLP policies.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: Document Types API v2
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v2/api/document-types:
+    get:
+      description: Returns a paginated list of document types for the authenticated
+        tenant.
+      operationId: get-v2-api-document-types
+      parameters:
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default
+          sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDocumentTypeResponse'
+          description: Paginated list of document types
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: List Document Types
+      tags:
+      - Document Types
+    post:
+      description: Creates a document type by uploading training files (multipart/form-data).
+      operationId: post-v2-api-document-types
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                file:
+                  format: binary
+                  type: string
+                json:
+                  $ref: '#/components/schemas/DocumentTypeRequest'
+                negative:
+                  format: binary
+                  type: string
+                positive:
+                  format: binary
+                  type: string
+              required:
+              - json
+              type: object
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentTypeResponse'
+          description: Document type created
+        '400':
+          description: Invalid request payload or missing required files
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: Create Document Type
+      tags:
+      - Document Types
+  /v2/api/document-types/{resourceId}:
+    delete:
+      description: Deletes a document type by its ID.
+      operationId: delete-v2-api-document-types-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Document type deleted
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Document type not found
+      security:
+      - Bearer: []
+      summary: Delete Document Type
+      tags:
+      - Document Types
+    get:
+      description: Retrieves a single document type by its ID.
+      operationId: get-v2-api-document-types-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentTypeResponse'
+          description: Document type found
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Document type not found
+      security:
+      - Bearer: []
+      summary: Get Document Type
+      tags:
+      - Document Types
+    patch:
+      description: Partially updates an existing document type using JSON Merge Patch
+        semantics.
+      operationId: patch-v2-api-document-types-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/DocumentTypePatchRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentTypeResponse'
+          description: Document type updated
+        '400':
+          description: Invalid patch payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Document type not found
+      security:
+      - Bearer: []
+      summary: Patch Document Type
+      tags:
+      - Document Types
+    put:
+      description: Fully replaces an existing document type with the provided payload.
+      operationId: put-v2-api-document-types-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DocumentTypeRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentTypeResponse'
+          description: Document type updated
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Document type not found
+      security:
+      - Bearer: []
+      summary: Update Document Type
+      tags:
+      - Document Types
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: Document Types

--- a/specs/dlp/EDMDatasets.yaml
+++ b/specs/dlp/EDMDatasets.yaml
@@ -1,0 +1,247 @@
+components:
+  schemas:
+    AuditResponse:
+      description: Audit metadata tracking creation and last-update information
+      properties:
+        created_at:
+          description: Timestamp when the resource was created
+          format: date-time
+          type: string
+        created_by:
+          description: Username or service that created the resource
+          type: string
+        updated_at:
+          description: Timestamp when the resource was last updated
+          format: date-time
+          type: string
+        updated_by:
+          description: Username or service that last updated the resource
+          type: string
+      type: object
+    EdmDatasetResponse:
+      description: EDM dataset resource returned by the API
+      properties:
+        active_fields:
+          description: Set of currently active fields in the dataset
+          items:
+            $ref: '#/components/schemas/EdmField'
+          type: array
+          uniqueItems: true
+        all_fields:
+          description: Set of all fields defined in the dataset
+          items:
+            $ref: '#/components/schemas/EdmField'
+          type: array
+          uniqueItems: true
+        audit_metadata:
+          $ref: '#/components/schemas/AuditResponse'
+        id:
+          description: Unique identifier of the EDM dataset
+          type: string
+        index_status:
+          description: Current indexing status of the dataset
+          enum:
+          - failed
+          - queued
+          - success
+          type: string
+        name:
+          description: Display name of the EDM dataset
+          type: string
+        region_name:
+          description: Region where the dataset is stored
+          type: string
+        tenant_id:
+          description: Tenant identifier that owns this dataset
+          type: string
+      type: object
+    EdmField:
+      description: A field definition within an EDM dataset
+      properties:
+        id:
+          description: Unique identifier of the field
+          type: string
+        name:
+          description: Field name as defined in the dataset
+          type: string
+        type:
+          description: Data type of the field (e.g. string, number)
+          type: string
+      type: object
+    PageEdmDatasetResponse:
+      properties:
+        content:
+          items:
+            $ref: '#/components/schemas/EdmDatasetResponse'
+          type: array
+        empty:
+          type: boolean
+        first:
+          type: boolean
+        last:
+          type: boolean
+        number:
+          format: int32
+          type: integer
+        numberOfElements:
+          format: int32
+          type: integer
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        size:
+          format: int32
+          type: integer
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        totalElements:
+          format: int64
+          type: integer
+        totalPages:
+          format: int32
+          type: integer
+      type: object
+    PageableObject:
+      properties:
+        offset:
+          format: int64
+          type: integer
+        pageNumber:
+          format: int32
+          type: integer
+        pageSize:
+          format: int32
+          type: integer
+        paged:
+          type: boolean
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+      type: object
+    SortObject:
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Manage Exact Data Matching (EDM) datasets for precise detection of\
+    \ sensitive content. Upload and maintain \nEDM datasets containing specific sensitive\
+    \ data such as customer lists, employee records, or financial data.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: EDM Datasets API v2
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v2/api/edm-datasets:
+    get:
+      description: Returns a paginated list of EDM datasets for the authenticated
+        tenant.
+      operationId: get-v2-api-edm-datasets
+      parameters:
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default
+          sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageEdmDatasetResponse'
+          description: Paginated list of EDM datasets
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: List EDM Datasets
+      tags:
+      - EDM Datasets
+  /v2/api/edm-datasets/{resourceId}:
+    delete:
+      description: Deletes an EDM dataset by its ID.
+      operationId: delete-v2-api-edm-datasets-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: EDM dataset deleted
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: EDM dataset not found
+      security:
+      - Bearer: []
+      summary: Delete EDM Dataset
+      tags:
+      - EDM Datasets
+    get:
+      description: Retrieves a single EDM dataset by its ID.
+      operationId: get-v2-api-edm-datasets-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdmDatasetResponse'
+          description: EDM dataset found
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: EDM dataset not found
+      security:
+      - Bearer: []
+      summary: Get EDM Dataset
+      tags:
+      - EDM Datasets
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: EDM Datasets

--- a/specs/dlp/EndpointPolicies.yaml
+++ b/specs/dlp/EndpointPolicies.yaml
@@ -1,0 +1,608 @@
+components:
+  schemas:
+    AuditResponse:
+      description: Audit metadata tracking creation and last-update information
+      properties:
+        created_at:
+          description: Timestamp when the resource was created
+          format: date-time
+          type: string
+        created_by:
+          description: Username or service that created the resource
+          type: string
+        updated_at:
+          description: Timestamp when the resource was last updated
+          format: date-time
+          type: string
+        updated_by:
+          description: Username or service that last updated the resource
+          type: string
+      type: object
+    ClassifiersDTO:
+      description: Classifiers that define what content this policy matches
+      properties:
+        data_profile_id:
+          format: int32
+          type: integer
+        file_types:
+          $ref: '#/components/schemas/FileTypesDTO'
+      type: object
+    EndpointPolicyPatchRequest:
+      description: Request payload for partially updating an endpoint policy (JSON
+        Merge Patch)
+      properties:
+        classifiers:
+          $ref: '#/components/schemas/JsonNullableClassifiersDTO'
+        description:
+          $ref: '#/components/schemas/JsonNullableString'
+        enabled:
+          $ref: '#/components/schemas/JsonNullableBoolean'
+        name:
+          $ref: '#/components/schemas/JsonNullableString'
+        priority:
+          $ref: '#/components/schemas/JsonNullableInteger'
+        response:
+          $ref: '#/components/schemas/JsonNullableResponseDTO'
+        scope:
+          $ref: '#/components/schemas/JsonNullableScopeDTO'
+        severity:
+          $ref: '#/components/schemas/JsonNullableSeverity'
+        type:
+          $ref: '#/components/schemas/JsonNullablePolicyType'
+      required:
+      - enabled
+      - name
+      - response
+      - scope
+      - severity
+      - type
+      type: object
+    EndpointPolicyRequest:
+      description: Request payload for creating or updating an endpoint policy
+      properties:
+        classifiers:
+          $ref: '#/components/schemas/ClassifiersDTO'
+        description:
+          description: Optional human-readable description
+          type: string
+        enabled:
+          description: Whether the policy is active
+          type: boolean
+        name:
+          description: Display name of the policy
+          maxLength: 64
+          minLength: 1
+          type: string
+        priority:
+          description: Evaluation priority order (lower number = higher priority)
+          format: int32
+          type: integer
+        response:
+          $ref: '#/components/schemas/ResponseDTO'
+        scope:
+          $ref: '#/components/schemas/ScopeDTO'
+        severity:
+          description: Severity level of policy violations
+          enum:
+          - informational
+          - low
+          - medium
+          - high
+          - critical
+          type: string
+        type:
+          description: Policy type
+          enum:
+          - endpoint_peripheral_control
+          - endpoint_data_in_motion
+          - network
+          type: string
+      required:
+      - enabled
+      - name
+      - response
+      - scope
+      - severity
+      - type
+      type: object
+    EndpointPolicyResponse:
+      description: Endpoint policy resource returned by the API
+      properties:
+        audit_metadata:
+          $ref: '#/components/schemas/AuditResponse'
+        classifiers:
+          $ref: '#/components/schemas/ClassifiersDTO'
+        description:
+          description: Optional human-readable description
+          type: string
+        enabled:
+          description: Whether the policy is active
+          type: boolean
+        id:
+          description: Unique identifier of the endpoint policy
+          type: string
+        name:
+          description: Display name of the policy
+          type: string
+        priority:
+          description: Evaluation priority order (lower number = higher priority)
+          format: int32
+          type: integer
+        response:
+          $ref: '#/components/schemas/ResponseDTO'
+        scope:
+          $ref: '#/components/schemas/ScopeDTO'
+        severity:
+          description: Severity level of policy violations
+          enum:
+          - informational
+          - low
+          - medium
+          - high
+          - critical
+          type: string
+        type:
+          description: Policy type
+          enum:
+          - endpoint_peripheral_control
+          - endpoint_data_in_motion
+          - network
+          type: string
+      type: object
+    FileTypesDTO:
+      properties:
+        any:
+          type: boolean
+        in:
+          items:
+            type: string
+          type: array
+      type: object
+    IncludedUsersDTO:
+      properties:
+        groups:
+          items:
+            $ref: '#/components/schemas/UserGroupDTO'
+          type: array
+        ids:
+          items:
+            $ref: '#/components/schemas/UserInfoDTO'
+          type: array
+      type: object
+    JsonNullableBoolean:
+      description: New enabled state
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableClassifiersDTO:
+      description: New classifiers
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableInteger:
+      description: New priority order
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullablePolicyType:
+      description: New policy type
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableResponseDTO:
+      description: New response action
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableScopeDTO:
+      description: New scope
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableSeverity:
+      description: New severity level
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    JsonNullableString:
+      description: New description (set to null to clear)
+      properties:
+        present:
+          type: boolean
+        undefined:
+          type: boolean
+      type: object
+    NotIncludedUsersDTO:
+      properties:
+        groups:
+          items:
+            $ref: '#/components/schemas/UserGroupDTO'
+          type: array
+        ids:
+          items:
+            $ref: '#/components/schemas/UserInfoDTO'
+          type: array
+      type: object
+    PageEndpointPolicyResponse:
+      properties:
+        content:
+          items:
+            $ref: '#/components/schemas/EndpointPolicyResponse'
+          type: array
+        empty:
+          type: boolean
+        first:
+          type: boolean
+        last:
+          type: boolean
+        number:
+          format: int32
+          type: integer
+        numberOfElements:
+          format: int32
+          type: integer
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        size:
+          format: int32
+          type: integer
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        totalElements:
+          format: int64
+          type: integer
+        totalPages:
+          format: int32
+          type: integer
+      type: object
+    PageableObject:
+      properties:
+        offset:
+          format: int64
+          type: integer
+        pageNumber:
+          format: int32
+          type: integer
+        pageSize:
+          format: int32
+          type: integer
+        paged:
+          type: boolean
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+      type: object
+    PeripheralDetailsDTO:
+      properties:
+        any:
+          type: boolean
+        in:
+          $ref: '#/components/schemas/PolicyPeripheralGroupDTO'
+        nin:
+          $ref: '#/components/schemas/PolicyPeripheralGroupDTO'
+        none:
+          type: boolean
+      type: object
+    PolicyPeripheralGroupDTO:
+      properties:
+        groups:
+          items:
+            type: string
+          type: array
+      type: object
+    PolicyPeripheralsDTO:
+      properties:
+        network_shares:
+          $ref: '#/components/schemas/PeripheralDetailsDTO'
+        printers:
+          $ref: '#/components/schemas/PeripheralDetailsDTO'
+        usbs:
+          $ref: '#/components/schemas/PeripheralDetailsDTO'
+      type: object
+    ResponseDTO:
+      description: Response action taken when the policy triggers
+      properties:
+        action:
+          type: string
+        euc_template_id:
+          type: string
+        incident_assignee:
+          type: string
+        is_end_user_coaching_enabled:
+          type: boolean
+        notification:
+          items:
+            type: string
+          type: array
+      type: object
+    ScopeDTO:
+      description: Scope defining which users/devices/apps this policy applies to
+      properties:
+        peripherals:
+          $ref: '#/components/schemas/PolicyPeripheralsDTO'
+        users:
+          $ref: '#/components/schemas/UsersDTO'
+      type: object
+    SortObject:
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+      type: object
+    UserGroupDTO:
+      properties:
+        distinguished_name:
+          type: string
+        domain:
+          type: string
+        group_name:
+          type: string
+        unique_id:
+          type: string
+      type: object
+    UserInfoDTO:
+      properties:
+        common_name:
+          type: string
+        domain:
+          type: string
+        principal_name:
+          type: string
+        unique_id:
+          type: string
+      type: object
+    UsersDTO:
+      properties:
+        any:
+          type: boolean
+        in:
+          $ref: '#/components/schemas/IncludedUsersDTO'
+        nin:
+          $ref: '#/components/schemas/NotIncludedUsersDTO'
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Manage endpoint DLP policies for controlling data loss prevention\
+    \ on endpoint devices. Create, update, \nretrieve, and delete policies that define\
+    \ DLP rules and actions for endpoint protection.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: Endpoint Policies API v2
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v2/api/endpoint-policies:
+    get:
+      description: Returns a paginated list of endpoint policies for the authenticated
+        tenant.
+      operationId: get-v2-api-endpoint-policies
+      parameters:
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default
+          sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      - description: Filter by enabled state
+        in: query
+        name: enabled
+        schema:
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageEndpointPolicyResponse'
+          description: Paginated list of endpoint policies
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: List Endpoint Policies
+      tags:
+      - Endpoint Policies
+    post:
+      description: Creates a new endpoint policy for the authenticated tenant.
+      operationId: post-v2-api-endpoint-policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EndpointPolicyRequest'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EndpointPolicyResponse'
+          description: Endpoint policy created
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: Create Endpoint Policy
+      tags:
+      - Endpoint Policies
+  /v2/api/endpoint-policies/{resourceId}:
+    delete:
+      description: Deletes an endpoint policy by its ID.
+      operationId: delete-v2-api-endpoint-policies-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Endpoint policy deleted
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Endpoint policy not found
+      security:
+      - Bearer: []
+      summary: Delete Endpoint Policy
+      tags:
+      - Endpoint Policies
+    get:
+      description: Retrieves a single endpoint policy by its ID.
+      operationId: get-v2-api-endpoint-policies-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EndpointPolicyResponse'
+          description: Endpoint policy found
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Endpoint policy not found
+      security:
+      - Bearer: []
+      summary: Get Endpoint Policy
+      tags:
+      - Endpoint Policies
+    patch:
+      description: Partially updates an existing endpoint policy using JSON Merge
+        Patch semantics.
+      operationId: patch-v2-api-endpoint-policies-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/EndpointPolicyPatchRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EndpointPolicyResponse'
+          description: Endpoint policy updated
+        '400':
+          description: Invalid patch payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Endpoint policy not found
+      security:
+      - Bearer: []
+      summary: Patch Endpoint Policy
+      tags:
+      - Endpoint Policies
+    put:
+      description: Fully replaces an existing endpoint policy with the provided payload.
+      operationId: put-v2-api-endpoint-policies-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EndpointPolicyRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EndpointPolicyResponse'
+          description: Endpoint policy updated
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Endpoint policy not found
+      security:
+      - Bearer: []
+      summary: Update Endpoint Policy
+      tags:
+      - Endpoint Policies
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: Endpoint Policies

--- a/specs/dlp/IncidentsAPI(Beta).yaml
+++ b/specs/dlp/IncidentsAPI(Beta).yaml
@@ -1,0 +1,942 @@
+components:
+  schemas:
+    DataPattern:
+      properties:
+        category_score:
+          format: int32
+          type: integer
+        detection_frequency:
+          format: int32
+          type: integer
+        high_confidence_frequency:
+          format: int32
+          type: integer
+        id:
+          type: string
+        language:
+          type: string
+        low_confidence_frequency:
+          format: int32
+          type: integer
+        medium_confidence_frequency:
+          format: int32
+          type: integer
+        name:
+          type: string
+        strict_detection_frequency:
+          format: int32
+          type: integer
+        sub_category_score:
+          format: int32
+          type: integer
+        technique:
+          type: string
+        total_detection_frequency:
+          format: int32
+          type: integer
+        total_strict_detection_frequency:
+          format: int32
+          type: integer
+        type:
+          type: string
+        version:
+          format: int32
+          type: integer
+        weighted_frequency:
+          format: int32
+          type: integer
+      type: object
+    DataProfile:
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+      type: object
+    DeviceInfo:
+      properties:
+        id:
+          type: string
+        ip:
+          type: string
+        loggedin_users:
+          items:
+            type: string
+          type: array
+        name:
+          type: string
+        serial_number:
+          type: string
+      type: object
+    EndpointOsInfo:
+      properties:
+        dlp_client_version:
+          type: string
+        gp_version:
+          type: string
+        os_type:
+          type: string
+        os_version:
+          type: string
+      type: object
+    ErrorInfo:
+      properties:
+        error_code:
+          minLength: 1
+          type: string
+        error_message:
+          minLength: 1
+          type: string
+        id:
+          minLength: 1
+          type: string
+      type: object
+    ExceptionRuleEntity:
+      properties:
+        action:
+          type: string
+        data_profile_id:
+          type: string
+        destination_app:
+          type: string
+        destination_url:
+          type: string
+        id:
+          type: string
+        log_severity:
+          type: string
+        source_group:
+          type: string
+        source_user:
+          type: string
+        version:
+          format: int64
+          type: integer
+      type: object
+    ExposureDetails:
+      properties:
+        cloud_url:
+          type: string
+        is_exposed_by_parent_folder:
+          type: boolean
+        is_public_url:
+          type: boolean
+        is_shared_url:
+          type: boolean
+        is_sign_in_required:
+          type: boolean
+        public_url:
+          type: string
+      type: object
+    IncidentDetailEntity:
+      properties:
+        action:
+          type: string
+        app_id:
+          type: string
+        app_instance_id:
+          type: string
+        app_name:
+          type: string
+        app_tags:
+          items:
+            type: string
+          type: array
+        app_type:
+          type: string
+        asset_hash:
+          type: string
+        asset_id:
+          type: string
+        asset_name:
+          type: string
+        asset_risk:
+          format: double
+          type: number
+        asset_size:
+          type: string
+        assigned_to:
+          type: string
+        assignee_email:
+          type: string
+        assignee_name:
+          type: string
+        category:
+          type: string
+        control_point:
+          type: string
+        created_date:
+          format: int64
+          type: integer
+        data_patterns:
+          items:
+            $ref: '#/components/schemas/DataPattern'
+          type: array
+        data_profiles:
+          items:
+            $ref: '#/components/schemas/DataProfile'
+          type: array
+        destination:
+          type: string
+        device_info:
+          items:
+            $ref: '#/components/schemas/DeviceInfo'
+          type: array
+        direction:
+          type: string
+        endpoint_os_info:
+          $ref: '#/components/schemas/EndpointOsInfo'
+        exception_rule_results:
+          items:
+            $ref: '#/components/schemas/ExceptionRuleEntity'
+          type: array
+        exposure:
+          type: string
+        exposure_details:
+          $ref: '#/components/schemas/ExposureDetails'
+        id:
+          type: string
+        modified_date:
+          format: int64
+          type: integer
+        notes:
+          type: string
+        peripheral_info:
+          $ref: '#/components/schemas/PeripheralInfo'
+        policy:
+          $ref: '#/components/schemas/Policy'
+        priority:
+          format: int32
+          type: integer
+        reason_for_action:
+          type: string
+        report_date:
+          format: int64
+          type: integer
+        report_id:
+          type: string
+        resolved_by:
+          type: string
+        severity:
+          type: string
+        source:
+          type: string
+        status:
+          type: string
+        tag:
+          type: string
+        tsg_id:
+          type: string
+        url:
+          type: string
+        user_department:
+          type: string
+        user_email:
+          type: string
+        user_id:
+          type: string
+        user_location:
+          type: string
+        user_manager:
+          type: string
+        user_name:
+          type: string
+      type: object
+    IncidentDetailResponse:
+      properties:
+        query_token:
+          type: string
+        rows:
+          items:
+            $ref: '#/components/schemas/IncidentDetailEntity'
+          type: array
+        status:
+          enum:
+          - READY
+          - PENDING
+          type: string
+        status_description:
+          type: string
+      type: object
+    IncidentInventoryEntity:
+      properties:
+        action:
+          type: string
+        asset_name:
+          type: string
+        assignee_email:
+          type: string
+        assignee_id:
+          type: string
+        assignee_name:
+          type: string
+        control_point:
+          type: string
+        created_date:
+          format: int64
+          type: integer
+        data_profile_id:
+          type: string
+        destination:
+          type: string
+        incident_id:
+          type: string
+        modified_date:
+          format: int64
+          type: integer
+        notes:
+          type: string
+        peripheral_name:
+          type: string
+        peripheral_type:
+          type: string
+        policy_type:
+          type: string
+        priority:
+          format: int32
+          type: integer
+        report_id:
+          type: string
+        resolved_by:
+          type: string
+        severity:
+          type: string
+        source:
+          type: string
+        source_region:
+          type: string
+        status:
+          type: string
+        sub_policy_type:
+          type: string
+        tag:
+          type: string
+        url_domain:
+          type: string
+      type: object
+    IncidentInventoryRequest:
+      properties:
+        columns:
+          description: Optional columns to include in the response
+          items:
+            type: string
+          type: array
+          writeOnly: true
+        end_time:
+          description: Required when time_range is CUSTOM. Start time as Unix timestamp
+            in milliseconds(ms).
+          format: int64
+          type: integer
+          writeOnly: true
+        filter:
+          description: "Filter expression string\n<br>Operators supported: =, in and\
+            \ AND\n<br>Pattern: {FilterName} = {value} or {FilterName} in ({value1},\
+            \ {value2}, ...)\n<br>Supported FilterName values:\n- Action: Filter by\
+            \ action taken (e.g., 'block', 'allow')\n- ApplicationName: Filter by\
+            \ application name\n- Asset: Filter by asset name\n- AssigneeId: Filter\
+            \ by assignee user ID\n- AssigneeName: Filter by assignee display name\n\
+            - Channel: Filter by channel (e.g., 'PRISMA_ACCESS', 'NGFW')\n- DataPattern:\
+            \ Filter by detection types/data patterns (e.g., 'SSN', 'Credit Card')\n\
+            - DataProfile: Filter by data profile ID\n- Destination: Filter by destination\n\
+            - IncidentId: Filter by specific incident ID\n- Priority: Filter by priority\
+            \ level (numeric values 1-5)\n- ReportId: Filter by report ID\n- Severity:\
+            \ Filter by severity level\n        - 5 = Critical\n        - 4 = High\n\
+            \        - 3 = Medium\n        - 2 = Low\n        - 1 = Informational\n\
+            - Source: Filter by source\n- Region: Filter by region (e.g., 'US', 'EU',\
+            \ 'UK', 'SG', 'IN', 'AU', 'CA', 'JP')\n- Status: Filter by incident status\
+            \ (e.g., 'New', 'open', 'under_investigation', 'closed')\n- UrlDomain:\
+            \ Filter by URL domain\n- Tag: Filter by incident tags\n\nExamples:\n\
+            - \"Tag = 'Needs Escalation'\"\n- \"Status in ('New','open','under_investigation')\"\
+            \n- \"UrlDomain = 'dlptest.com'\"\n- \"Channel = 'PRISMA_ACCESS' AND DataProfile\
+            \ in ('11995030','11995033')\"\n"
+          example: Tag = 'Needs Escalation'
+          minLength: 1
+          type: string
+        max_rows:
+          description: Maximum number of rows to return (optional, e.g., 1000)
+          example: 10000
+          format: int32
+          type: integer
+          writeOnly: true
+        page_size:
+          description: Size for pagination
+          format: int32
+          type: integer
+          writeOnly: true
+        sort_by:
+          description: Optional field to sort by
+          type: string
+          writeOnly: true
+        sort_order:
+          description: Optional sort order (asc/desc)
+          type: string
+          writeOnly: true
+        start_time:
+          description: Required when time_range is CUSTOM. Start time as Unix timestamp
+            in milliseconds(ms).
+          format: int64
+          type: integer
+          writeOnly: true
+        time_range:
+          enum:
+          - HOUR_1
+          - HOUR_3
+          - HOUR_24
+          - DAY_7
+          - DAY_30
+          - DAY_90
+          - CUSTOM
+          type: string
+      required:
+      - time_range
+      type: object
+    IncidentInventoryResponse:
+      properties:
+        query_token:
+          type: string
+        rows:
+          items:
+            $ref: '#/components/schemas/IncidentInventoryEntity'
+          type: array
+        status:
+          enum:
+          - READY
+          - PENDING
+          type: string
+        status_description:
+          type: string
+        total_rows:
+          format: int64
+          type: integer
+      type: object
+    IncidentUpdateDetails:
+      properties:
+        assignee_display_name:
+          type: string
+        assignee_email:
+          type: string
+        assignee_id:
+          type: string
+        notes:
+          type: string
+        priority:
+          format: int32
+          type: integer
+        resolution_status:
+          type: string
+        resolved_by:
+          type: string
+        tag:
+          type: string
+      type: object
+    IncidentUpdateRequest:
+      properties:
+        incident_ids:
+          items:
+            format: uuid
+            type: string
+          minItems: 1
+          type: array
+        update_details:
+          $ref: '#/components/schemas/IncidentUpdateDetails'
+      required:
+      - incident_ids
+      - update_details
+      type: object
+    IncidentUpdateResults:
+      properties:
+        error:
+          $ref: '#/components/schemas/ErrorInfo'
+        success:
+          format: int32
+          type: integer
+      type: object
+    PeripheralInfo:
+      properties:
+        group_id:
+          type: string
+        group_name:
+          type: string
+        id:
+          type: string
+        is_known:
+          type: boolean
+        manufacturer_name:
+          type: string
+        name:
+          type: string
+        product_id:
+          type: string
+        product_name:
+          type: string
+        serial_number:
+          type: string
+        type:
+          type: string
+        vendor_id:
+          type: string
+      type: object
+    Policy:
+      properties:
+        policy_id:
+          type: string
+        policy_type:
+          type: string
+        policy_version:
+          type: string
+      type: object
+    ResultsDownloadRequest:
+      properties:
+        columns:
+          description: Optional columns to include in the response
+          items:
+            type: string
+          type: array
+          writeOnly: true
+        end_time:
+          description: Required when time_range is CUSTOM. End time as Unix timestamp
+            in milliseconds(ms).
+          format: int64
+          type: integer
+          writeOnly: true
+        filter:
+          description: "Filter expression string\n<br>Operators supported: =, in and\
+            \ AND\n<br>Pattern: {FilterName} = {value} or {FilterName} in ({value1},\
+            \ {value2}, ...)\n<br>Supported FilterName values:\n- Action: Filter by\
+            \ action taken (e.g., 'block', 'allow')\n- ApplicationName: Filter by\
+            \ application name\n- Asset: Filter by asset name\n- AssigneeId: Filter\
+            \ by assignee user ID\n- AssigneeName: Filter by assignee display name\n\
+            - Channel: Filter by channel (e.g., 'PRISMA_ACCESS', 'NGFW')\n- DataPattern:\
+            \ Filter by detection types/data patterns (e.g., 'SSN', 'Credit Card')\n\
+            - DataProfile: Filter by data profile ID\n- Destination: Filter by destination\n\
+            - IncidentId: Filter by specific incident ID\n- Priority: Filter by priority\
+            \ level (numeric values 1-5)\n- ReportId: Filter by report ID\n- Severity:\
+            \ Filter by severity level\n        - 5 = Critical\n        - 4 = High\n\
+            \        - 3 = Medium\n        - 2 = Low\n        - 1 = Informational\n\
+            - Source: Filter by source\n- Region: Filter by region (e.g., 'US', 'EU',\
+            \ 'UK', 'SG', 'IN', 'AU', 'CA', 'JP')\n- Status: Filter by incident status\
+            \ (e.g., 'New', 'open', 'under_investigation', 'closed')\n- UrlDomain:\
+            \ Filter by URL domain\n- Tag: Filter by incident tags\n\nExamples:\n\
+            - \"Tag = 'Needs Escalation'\"\n- \"Status in ('New','open','under_investigation')\"\
+            \n- \"UrlDomain = 'dlptest.com'\"\n- \"Channel = 'PRISMA_ACCESS' AND DataProfile\
+            \ in ('11995030','11995033')\"\n"
+          example: Tag = 'Needs Escalation'
+          type: string
+        max_rows:
+          description: Maximum number of rows to return (optional, e.g., 1000)
+          example: 10000
+          format: int32
+          type: integer
+          writeOnly: true
+        sort_by:
+          description: Optional field to sort by
+          type: string
+          writeOnly: true
+        sort_order:
+          description: Optional sort order (asc/desc)
+          type: string
+          writeOnly: true
+        start_time:
+          description: Required when time_range is CUSTOM. Start time as Unix timestamp
+            in milliseconds(ms).
+          format: int64
+          type: integer
+          writeOnly: true
+        time_range:
+          enum:
+          - HOUR_1
+          - HOUR_3
+          - HOUR_24
+          - DAY_7
+          - DAY_30
+          - DAY_90
+          - CUSTOM
+          type: string
+        token:
+          type: string
+      required:
+      - time_range
+      type: object
+    ResultsDownloadResponse:
+      properties:
+        download_url:
+          type: string
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Beta Incidents API providing advanced incident management features\
+    \ including paginated retrieval, \ncomprehensive filtering and sorting, batch\
+    \ incident updates, and signed URL generation for secure \nincident data downloads.\
+    \ These endpoints offer enhanced functionality for large-scale incident analysis.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: Incidents API (Beta)
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v4/api/incidents:
+    get:
+      description: "Retrieve a paginated list of DLP incidents with optional filtering\
+        \ and sorting capabilities. \nThis endpoint provides efficient access to large\
+        \ incident datasets through token-based pagination.\n"
+      operationId: get-v4-api-incidents
+      parameters:
+      - description: The pagination token received from the initial POST /incidents
+          API call. This token identifies the specific query for which results are
+          being paginated.
+        in: query
+        name: token
+        required: true
+        schema:
+          type: string
+      - description: The row offset from which to start fetching incident records.
+          For the first paginated request, this would typically be page_size. For
+          subsequent requests, it would be previous_offset + page_size
+        in: query
+        name: offset
+        required: true
+        schema:
+          type: string
+      - description: The maximum number of incident records to return in this paginated
+          response. This value should be between 1 and 1000
+        in: query
+        name: pageSize
+        required: true
+        schema:
+          type: string
+      - description: Optional flag to include data profile information in the response.
+        in: query
+        name: include_data_profiles
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                query_token: test_token
+                rows:
+                - action: block
+                  asset_name: test asset name
+                  control_point: PRISMA_ACCESS
+                  created_date: 1753121720515000
+                  data_profile_id: '11995064'
+                  destination: web-browsing
+                  incident_id: 58feac56-e49d-43b3-ade3-c2d8e34ecd68
+                  modified_date: 1753121720515739
+                  policy_type: Network
+                  report_id: '3082846756'
+                  severity: '2'
+                  source: palodlp11
+                  source_region: US_STG
+                  status: New
+                  sub_policy_type: Data in Motion
+                  url_domain: test url domain
+                status: READY
+                status_description: Query results are ready.
+                total_rows: 1
+              schema:
+                $ref: '#/components/schemas/IncidentInventoryResponse'
+          description: Successful!
+        '400':
+          description: Bad Request
+        '500':
+          description: Internal Server Error
+      security:
+      - Bearer: []
+      summary: Retrieve Paginated DLP Incidents
+      tags:
+      - Incidents API (Beta)
+    post:
+      description: "Query the DLP incident inventory with customizable parameters\
+        \ for comprehensive incident analysis. \nSubmit a POST request with filter\
+        \ criteria to retrieve matching incidents with advanced filtering and sorting.\n"
+      operationId: post-v4-api-incidents
+      parameters:
+      - description: Optional flag to include data profile information in the response.
+        in: query
+        name: include_data_profiles
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            example:
+              time_range: HOUR_24
+            schema:
+              $ref: '#/components/schemas/IncidentInventoryRequest'
+        description: Request body containing filter criteria, time range, pagination
+          parameters, and sorting options for incident inventory queries.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                query_token: test_token
+                rows:
+                - action: block
+                  asset_name: test asset name
+                  control_point: PRISMA_ACCESS
+                  created_date: 1753121720515000
+                  data_profile_id: '11995064'
+                  destination: web-browsing
+                  incident_id: 58feac56-e49d-43b3-ade3-c2d8e34ecd68
+                  modified_date: 1753121720515739
+                  policy_type: Network
+                  report_id: '3082846756'
+                  severity: '2'
+                  source: palodlp11
+                  source_region: US_STG
+                  status: New
+                  sub_policy_type: Data in Motion
+                  url_domain: test url domain
+                status: READY
+                status_description: Query results are ready.
+                total_rows: 1
+              schema:
+                $ref: '#/components/schemas/IncidentInventoryResponse'
+          description: Successful!
+        '400':
+          description: Bad Request
+        '500':
+          description: Internal Server Error
+      security:
+      - Bearer: []
+      summary: Query DLP Incident Inventory
+      tags:
+      - Incidents API (Beta)
+  /v4/api/incidents/download:
+    post:
+      description: "Generate a signed URL for downloading DLP incident data based\
+        \ on specified criteria. The signed URL \ncan be used to securely download\
+        \ incident information for external processing or archival. The URL is \n\
+        valid for a limited time period.\n"
+      operationId: post-v4-api-incidents-download
+      requestBody:
+        content:
+          application/json:
+            example:
+              time_range: HOUR_24
+            schema:
+              $ref: '#/components/schemas/ResultsDownloadRequest'
+        description: Request body containing filter criteria and download parameters
+          for generating the signed URL.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                download_url: https://storage.googleapis.com/casb-data-platform-prod-uim-inc-export/1494634703/incidents_20250721_205140_e3f288124dec432c8f94ed4f5b49b19b.csv.gz?test_signed_url
+              schema:
+                $ref: '#/components/schemas/ResultsDownloadResponse'
+          description: Successful!
+        '400':
+          description: Bad Request
+        '500':
+          description: Internal Server Error
+      security:
+      - Bearer: []
+      summary: Generate Signed URL for Incident Download
+      tags:
+      - Incidents API (Beta)
+  /v4/api/incidents/management:
+    post:
+      description: "Update incident properties including status, assignees, notes,\
+        \ and priority for comprehensive incident \nlifecycle management. This endpoint\
+        \ allows batch updates to multiple incidents simultaneously, improving \n\
+        operational efficiency.\n"
+      operationId: post-v4-api-incidents-management
+      requestBody:
+        content:
+          application/json:
+            example:
+              incident_ids:
+              - 5ba587fd-4b83-416d-998f-16d79c7da889
+              - 58feac56-e49d-43b3-ade3-c2d8e34ecd68
+              update_details:
+                assignee_display_name: John Doe
+                assignee_email: john.doe@example.com
+                assignee_id: user123
+                notes: Escalated for further investigation
+                priority: 2
+                resolution_status: under_investigation
+                resolved_by: admin@example.com
+                tag: security-review
+            schema:
+              $ref: '#/components/schemas/IncidentUpdateRequest'
+        description: Request body containing incident IDs and the update details to
+          apply to those incidents.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                success: 1
+              schema:
+                $ref: '#/components/schemas/IncidentUpdateResults'
+          description: Successful!
+        '400':
+          description: Bad Request
+        '500':
+          description: Internal Server Error
+      security:
+      - Bearer: []
+      summary: Update Incident Management Properties
+      tags:
+      - Incidents API (Beta)
+  /v4/api/incidents/{id}:
+    get:
+      description: "Retrieve comprehensive details for a specific DLP incident using\
+        \ its unique identifier. This endpoint \nprovides complete incident information\
+        \ including all metadata and detection details.\n"
+      operationId: get-v4-api-incidents-id
+      parameters:
+      - description: The unique identifier of the incident to retrieve.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                rows:
+                - action: block
+                  app_id: '109'
+                  app_instance_id: test
+                  app_name: test
+                  app_tags:
+                  - test1
+                  - test2
+                  app_type: '0'
+                  asset_hash: test hash
+                  asset_id: 5ba587fd-4b83-416d-998f-16d79c7da889
+                  asset_name: UNKNOWN
+                  asset_risk: 25
+                  asset_size: test
+                  assigned_to: test
+                  assignee_email: test
+                  assignee_name: test
+                  category: test
+                  control_point: NGFW
+                  created_date: 1752910252943000
+                  data_patterns:
+                  - category_score: 0
+                    detection_frequency: 4
+                    high_confidence_frequency: 2
+                    id: 65779c793375232371f9886c
+                    language: test
+                    low_confidence_frequency: 4
+                    medium_confidence_frequency: 0
+                    name: test
+                    strict_detection_frequency: 0
+                    sub_category_score: 0
+                    technique: regex
+                    total_detection_frequency: 4
+                    total_strict_detection_frequency: 0
+                    type: predefined
+                    version: 1
+                    weighted_frequency: 0
+                  data_profiles:
+                  - id: '11995181'
+                    name: AEL_Granular
+                    version: test
+                  destination: 185.125.188.57
+                  device_info:
+                  - id: test
+                    ip: 188.188.188.10
+                    loggedin_users:
+                    - test
+                    name: test
+                    serial_number: 024401003837
+                  direction: upload
+                  endpoint_os_info:
+                    dlp_client_version: test
+                    gp_version: test
+                    os_type: test
+                    os_version: test
+                  exception_rule_results:
+                  - action: allow
+                    data_profile_id: '11995181'
+                    destination_app: Slack
+                    destination_url: https://slack.com
+                    id: rule-12345
+                    log_severity: medium
+                    source_group: Engineering
+                    source_user: john.doe@example.com
+                    version: 1
+                  exposure: test
+                  exposure_details:
+                    cloud_url: test cloud url
+                    is_exposed_by_parent_folder: false
+                    is_public_url: false
+                    is_shared_url: false
+                    is_sign_in_required: true
+                    public_url: test public url
+                  id: 5ba587fd-4b83-416d-998f-16d79c7da889
+                  modified_date: 1753137046114000
+                  notes: test
+                  peripheral_info:
+                    group_id: ''
+                    group_name: ''
+                    id: test id
+                    is_known: false
+                    manufacturer_name: General
+                    name: USB-4GB
+                    product_id: '1000'
+                    product_name: USB Flash Disk
+                    serial_number: 0415090000013290
+                    type: usb
+                    vendor_id: 090C
+                  policy:
+                    policy_id: test
+                    policy_type: network
+                    policy_version: test
+                  priority: 1
+                  reason_for_action: test
+                  report_date: 1752910252937000
+                  report_id: '229650498'
+                  resolved_by: test
+                  severity: '5'
+                  source: 188.188.188.10
+                  status: New
+                  tag: test
+                  tsg_id: '1016831479'
+                  url: test
+                  user_department: test
+                  user_email: test
+                  user_id: globaltestuser1
+                  user_location: test
+                  user_manager: test
+                  user_name: test
+                status: READY
+                status_description: Query results are ready.
+                total_rows: 1
+              schema:
+                $ref: '#/components/schemas/IncidentDetailResponse'
+          description: Successful!
+        '400':
+          description: Bad Request
+        '500':
+          description: Internal Server Error
+      security:
+      - Bearer: []
+      summary: Retrieve Incident Details by ID
+      tags:
+      - Incidents API (Beta)
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: Incidents API (Beta)

--- a/specs/dlp/IncidentsAPI.yaml
+++ b/specs/dlp/IncidentsAPI.yaml
@@ -1,0 +1,1118 @@
+components:
+  schemas:
+    IncidentAssignee:
+      properties:
+        createdAt:
+          description: The timestamp when the assignee record was created in the system.
+          example: yyyy-MMM-dd HH:mm:ss z
+          type: string
+        emailAddress:
+          description: The email address of the assignee for contact and notification
+            purposes.
+          type: string
+        firstName:
+          description: The first name of the assignee.
+          type: string
+        id:
+          description: The unique identifier of the assignee.
+          format: uuid
+          type: string
+        lastName:
+          description: The last name of the assignee.
+          type: string
+        status:
+          description: The current status of the assignee (active or inactive).
+          enum:
+          - ACTIVE
+          - INACTIVE
+          example: '"ACTIVE" or "INACTIVE"'
+          type: string
+        tenantId:
+          description: The Tenant Service Group (TSG) enabled tenant group ID associated
+            with the assignee.
+          type: string
+        updatedAt:
+          description: The timestamp when the assignee record was last updated.
+          example: yyyy-MMM-dd HH:mm:ss z
+          type: string
+      required:
+      - status
+      title: IncidentAssignee
+      type: object
+    IncidentAssigneeDTO:
+      properties:
+        emailAddress:
+          description: Email address of the assignee
+          type: string
+        firstName:
+          description: Assignees first name
+          type: string
+        id:
+          description: ID of the assignee(optional). If you do not provide an ID,
+            the API will create a new assignee.
+          format: uuid
+          type: string
+        lastName:
+          description: assignee last name
+          type: string
+        status:
+          description: active assignee or inactivate assignee
+          enum:
+          - ACTIVE
+          - INACTIVE
+          example: '"ACTIVE" or "INACTIVE"'
+          type: string
+      required:
+      - status
+      - emailAddress
+      - firstName
+      - lastName
+      title: IncidentAssigneeDTO
+      type: object
+    IncidentDTO:
+      properties:
+        action:
+          description: The action taken on the incident by the DLP system or administrator
+            (alert, block, or none).
+          enum:
+          - alert
+          - block
+          - none
+          type: string
+        app_id:
+          description: The unique identifier of the application associated with the
+            incident.
+          type: string
+        app_name:
+          description: The name of the application where the incident was detected.
+          type: string
+        channel:
+          description: The Palo Alto Networks product or channel through which the
+            incident was detected (ngfw or prisma-access).
+          enum:
+          - ngfw
+          - prisma-access
+          type: string
+        data_profile_id:
+          description: The unique identifier of the data profile used to detect the
+            incident.
+          format: int64
+          type: integer
+        data_profile_name:
+          description: The name of the data profile used to detect the incident.
+          type: string
+        file_name:
+          description: The name of the file associated with the incident.
+          type: string
+        file_sha:
+          description: The SHA-256 hash value of the file associated with the incident.
+          type: string
+        file_type:
+          description: The file type or extension of the file associated with the
+            incident.
+          type: string
+        incident_creation_time:
+          description: The timestamp when the incident was first detected and created.
+          example: yyyy-MMM-dd HH:mm:ss z
+          type: string
+        incident_id:
+          description: The unique identifier automatically assigned to the incident
+            by the system.
+          format: uuid
+          type: string
+        report_id:
+          description: The unique identifier automatically assigned to the associated
+            report.
+          type: string
+        source:
+          description: The Palo Alto Networks source system that detected the incident.
+          type: string
+        tenant_id:
+          description: The unique identifier of the Tenant Service Group (TSG) enabled
+            tenant.
+          type: string
+        user:
+          description: The user identified by the DLP engine as associated with the
+            incident.
+          type: string
+      title: IncidentDTO
+      type: object
+    IncidentResponse:
+      properties:
+        page:
+          $ref: '#/components/schemas/PageData'
+          description: The current page number in the paginated response.
+        resources:
+          description: The list of incident resources in the current response, including
+            their status (open, under review, resolved, or closed).
+          items:
+            $ref: '#/components/schemas/IncidentDTO'
+          type: array
+      required:
+      - page
+      title: PagedDataResponse<IncidentDTO>
+      type: object
+    IncidentResponseDTO:
+      example:
+        action: alert
+        assignee_id: 00d53ebf-c386-4b95-ad05-6819517c3450
+        channel: prisma-access
+        data_profile_id: 11995590
+        data_profile_name: PatricksDPwEDM
+        file_name: 100_rows_10_cols_tail.csv
+        file_sha: 9d8ce237eff10b5ac4b4c8fed0d7988ca6cc4f090f90230acd8dad36fb7da636
+        incident_creation_time: 2024-Jan-11 17:14:30 UTC
+        incident_id: 4adeefe4-8358-411e-8ba7-5f45e5625c58
+        incident_notes: test notes
+        match_info:
+          65a0209ce36cd3480011d677:
+            detection_technique: edm
+            edm_columns:
+            - credit_card_number
+            - social_security_number
+            hcf: 10
+            lcf: 10
+            mcf: 0
+            name: EDM - PatricksDataSet20240111
+            uhcf: 10
+            ulcf: 10
+            umcf: 0
+            version: 1
+        report_id: '530470823'
+        resolution_status: Assigned
+        source: prisma-access
+        tenant_id: '5886928188517009408'
+      properties:
+        action:
+          description: Action taken on the incident by the DLP system or administrator.
+          enum:
+          - alert
+          - block
+          type: string
+        app_id:
+          description: Palo Alto Networks assigned Application ID.
+          type: string
+        app_name:
+          description: The name of the application.
+          type: string
+        assignee_id:
+          description: Automatically assigned ID of the assignee.
+          type: string
+        channel:
+          description: The Palo Alto Networks channel that identified the incident.
+          enum:
+          - ngfw
+          - prisma-access
+          type: string
+        data_profile_id:
+          description: The data profile descriptor used to characterize the incident.
+          format: int64
+          type: integer
+        data_profile_name:
+          description: The data profile descriptor used to characterize the incident.
+          type: string
+        file_name:
+          description: The name of the file analyzed.
+          type: string
+        file_sha:
+          description: The SHA hash of the file analyzed.
+          type: string
+        file_type:
+          description: The type of file analyzed.
+          type: string
+        incident_creation_time:
+          description: The time the incident first occurred.
+          example: yyyy-MMM-dd HH:mm:ss z
+          type: string
+        incident_feedback_status:
+          description: Feedback status for the incident (e.g., true positive, false
+            positive).
+          type: string
+        incident_id:
+          description: The Palo Alto Networks automatically assigned incident ID.
+          format: uuid
+          type: string
+        incident_notes:
+          description: Notes or comments added to the incident for documentation and
+            tracking.
+          type: string
+        match_info:
+          $ref: '#/components/schemas/MatchInfo'
+          description: ''
+          example: "\"65a0209ce36cd3480011d677\": {\n            \"name\": \"EDM -\
+            \ PatricksDataSet20240111\",\n            \"version\": 1,\n          \
+            \  \"lcf\": 10,\n            \"hcf\": 10,\n            \"mcf\": 0,\n \
+            \           \"ulcf\": 10,\n            \"uhcf\": 10,\n            \"umcf\"\
+            : 0,\n            \"detection_technique\": \"edm\",\n            \"edm_columns\"\
+            : [\n                \"credit_card_number\",\n                \"social_security_number\"\
+            \n            ]\n        }\n"
+        report_id:
+          description: The Palo Alto Networks automatically assigned report ID.
+          type: string
+        resolution_status:
+          description: Resolution status for the incident (e.g., open, under review,
+            resolved, closed).
+          type: string
+        session_key:
+          description: Specifies a session key assosciated with the incident.
+          type: string
+        snippets:
+          description: A JSON structure containing snippet data, if snippets are not
+            enabled, the field returns as null.
+          type: string
+        source:
+          description: The Palo Alto Networks source that identified the incident.
+          type: string
+        tenant_id:
+          description: The TSG enabled tenant used to identify the incident.
+          type: string
+        user:
+          description: The user associated with the incident.
+          type: string
+      title: IncidentResponseDTO
+      type: object
+    MatchInfo:
+      properties:
+        detection_technique:
+          description: The technique used to identify the pattern match (e.g., regex,
+            machine learning, exact data matching).
+          enum:
+          - document_fingerprint
+          - edm
+          - file_property
+          - ml
+          - ml_document
+          - regex
+          - titus_tag
+          - trainable_classifier
+          - weighted_regex
+          type: string
+        edm_columns:
+          description: Exact Data Matching (EDM) columns used for detection. EDM is
+            a method of detecting and protecting sensitive content by using specific
+            data such as patient names, social security numbers, or bank account numbers
+            to identify matches.
+          items:
+            type: string
+          type: array
+          uniqueItems: true
+        hcf:
+          description: The count of high confidence frequency detections for this
+            pattern.
+          format: int32
+          type: integer
+        lcf:
+          description: The count of low confidence frequency detections for this pattern.
+          format: int32
+          type: integer
+        mcf:
+          description: The count of medium confidence frequency detections for this
+            pattern.
+          format: int32
+          type: integer
+        name:
+          description: The name of the data pattern that was matched.
+          type: string
+        uhcf:
+          description: The count of unique high confidence frequency detections for
+            this pattern.
+          format: int32
+          type: integer
+        ulcf:
+          description: The count of unique low confidence frequency detections for
+            this pattern.
+          format: int32
+          type: integer
+        umcf:
+          description: The count of unique medium confidence frequency detections
+            for this pattern.
+          format: int32
+          type: integer
+        version:
+          description: The version number of the data pattern definition used for
+            detection.
+          format: int32
+          type: integer
+      title: MatchInfo
+      type: object
+    PageData:
+      properties:
+        number:
+          description: The current page number for pagination.
+          format: int32
+          type: integer
+        size:
+          description: The number of items returned in the current page.
+          format: int32
+          type: integer
+        total_elements:
+          description: The total number of incidents matching the query criteria.
+          format: int32
+          type: integer
+        total_pages:
+          description: The total number of pages available for the query results.
+          format: int32
+          type: integer
+      title: PageData
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Manage and retrieve DLP incidents across v1 and v2 endpoints. This\
+    \ API group provides comprehensive \nincident lifecycle management including retrieval\
+    \ with advanced filtering, assignment management, \nnotes management, and resolution\
+    \ status tracking for both legacy and current API versions.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: Incidents API
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v1/api/incidents/assignee:
+    get:
+      description: "Retrieve information about all assignees in your organization.\
+        \ This allows you to programmatically \naccess a list of team members who\
+        \ can examine and manage DLP incidents.\n"
+      operationId: get-v1-api-incidents-assignee
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                assignees:
+                  value:
+                  - createdAt: 2024-Jan-11 23:16:33 UTC
+                    emailAddress: test@test.com
+                    firstName: test u
+                    id: 00d53ebf-c386-4b95-ad05-6819517c3450
+                    lastName: test
+                    status: ACTIVE
+                    tenantId: '5886928188517009408'
+                    updatedAt: 2024-Feb-14 19:13:01 UTC
+                  - createdAt: 2023-Aug-03 21:23:39 UTC
+                    emailAddress: user1@test.com
+                    firstName: user
+                    id: 133b9b0d-6e64-40ca-abec-15ff3b906b80
+                    lastName: my last name
+                    status: ACTIVE
+                    tenantId: '5886928188517009408'
+              schema:
+                items:
+                  $ref: '#/components/schemas/IncidentAssignee'
+                type: array
+          description: Successfully retrieved all assignees.
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Retrieve All Assignees
+      tags:
+      - Incidents API
+    put:
+      description: "Update information about assignees who can examine and manage\
+        \ DLP incidents. This allows you to \nprogrammatically maintain assignee details\
+        \ such as contact information and status.\n"
+      operationId: put-v1-api-incidents-assignee
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentAssigneeDTO'
+        description: Request body containing the assignee information to update.
+        required: true
+      responses:
+        '200':
+          description: Successfully updated assignee information.
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '500':
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Update Assignee Information
+      tags:
+      - Incidents API
+  /v1/api/incidents/assignee/{assigneeId}:
+    get:
+      description: "Retrieve detailed information about a specific assignee including\
+        \ contact information and status. \nThis allows you to programmatically access\
+        \ information about team members who can examine and manage DLP incidents.\n"
+      operationId: get-v1-api-incidents-assignee-assigneeid
+      parameters:
+      - description: The unique identifier of the assignee.
+        in: path
+        name: assigneeId
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                assignee:
+                  value:
+                    createdAt: 2024-Jan-11 23:16:33 UTC
+                    emailAddress: test@test.com
+                    firstName: test
+                    id: 00d53ebf-c386-4b95-ad05-6819517c3450
+                    lastName: test
+                    status: ACTIVE
+                    tenantId: '5886928188517009408'
+              schema:
+                $ref: '#/components/schemas/IncidentAssignee'
+          description: OK
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Retrieve Assignee Details
+      tags:
+      - Incidents API
+  /v1/api/incidents/{incidentID}/assignee:
+    put:
+      description: 'Assign a DLP incident to a specific user or team member. Once
+        assigned, the assignee can then:
+
+        * Update incident notes
+
+        * Update incident resolution status
+
+        * Manage incident lifecycle
+
+        '
+      operationId: put-v1-api-incidents-incidentid-assignee
+      parameters:
+      - description: The geographic region of the incident (defaults to US).
+        in: query
+        name: region
+        required: false
+        schema:
+          enum:
+          - us
+          - eu
+          - uk
+          - jp
+          - in
+          - ap
+          - ca
+          - au
+          - par
+          type: string
+      - description: The unique identifier of the incident to assign.
+        in: path
+        name: incidentID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            examples:
+              UUID of assignee:
+                value: 00d53ebf-c386-4b95-ad05-6819517c3450
+            schema:
+              type: string
+        description: Request body containing the assignee information (ID, email,
+          or display name) to assign to the incident.
+        required: true
+      responses:
+        '200':
+          description: Successfully updated the incident assignee.
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Assign Incident to User
+      tags:
+      - Incidents API
+  /v1/api/incidents/{incidentID}/notes:
+    delete:
+      description: "Programmatically delete notes from a DLP incident for auditing\
+        \ and team clarity purposes. \nThis removes previously added notes from the\
+        \ incident record.\n"
+      operationId: delete-v1-api-incidents-incidentid-notes
+      parameters:
+      - description: The unique identifier of the incident.
+        in: path
+        name: incidentID
+        required: true
+        schema:
+          type: string
+      - description: The geographic region of the incident (defaults to US).
+        in: query
+        name: region
+        required: false
+        schema:
+          enum:
+          - us
+          - eu
+          - uk
+          - jp
+          - in
+          - ap
+          - ca
+          - au
+          - par
+          type: string
+      responses:
+        '200':
+          description: Successfully deleted the incident notes.
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Delete Incident Notes
+      tags:
+      - Incidents API
+    put:
+      description: "Programmatically add or update notes on a DLP incident for additional\
+        \ auditing and team clarity. \nNotes provide a way to document findings, actions\
+        \ taken, or other relevant information about the incident.\n"
+      operationId: put-v1-api-incidents-incidentid-notes
+      parameters:
+      - description: The unique identifier of the incident.
+        in: path
+        name: incidentID
+        required: true
+        schema:
+          type: string
+      - description: The geographic region of the incident (defaults to US).
+        in: query
+        name: region
+        required: false
+        schema:
+          enum:
+          - us
+          - eu
+          - uk
+          - jp
+          - in
+          - ap
+          - ca
+          - au
+          - par
+          type: string
+      requestBody:
+        content:
+          application/json:
+            examples:
+              sample notes:
+                value: This is a note for incident
+            schema:
+              type: string
+        description: Request body containing the note content to add or update on
+          the incident.
+        required: true
+      responses:
+        '200':
+          description: Successfully updated the incident notes.
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Update Incident Notes
+      tags:
+      - Incidents API
+  /v1/api/incidents/{incidentID}/resolution-status:
+    put:
+      description: "Update the resolution status for a specific DLP incident. Track\
+        \ incident lifecycle by changing status \nas incidents are investigated and\
+        \ resolved.\n"
+      operationId: put-v1-api-incidents-incidentid-resolution-status
+      parameters:
+      - description: The unique identifier of the incident.
+        in: path
+        name: incidentID
+        required: true
+        schema:
+          type: string
+      - description: The geographic region of the incident (defaults to US).
+        in: query
+        name: region
+        required: false
+        schema:
+          enum:
+          - us
+          - eu
+          - uk
+          - jp
+          - in
+          - ap
+          - ca
+          - au
+          - par
+          type: string
+      requestBody:
+        content:
+          application/json:
+            examples:
+              resolution status:
+                value: assigned
+            schema:
+              type: string
+        description: Request body containing the new resolution status to apply to
+          the incident.
+        required: true
+      responses:
+        '200':
+          description: Successfully updated the incident resolution status.
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Update Incident Resolution Status
+      tags:
+      - Incidents API
+  /v2/api/incidents:
+    get:
+      description: "Retrieve a paginated list of DLP incidents with optional filtering\
+        \ and sorting capabilities. \nThis endpoint provides efficient access to incident\
+        \ datasets through pagination parameters. \nMultiple filtering parameters\
+        \ are combined using an \"AND\" operation for precise results.\n"
+      operationId: get-v2-api-incidents
+      parameters:
+      - description: 'Sort incidents in ascending order by creation time (default:
+          false).'
+        in: query
+        name: ascending
+        required: false
+        schema:
+          type: boolean
+      - description: Filter by channel source (ngfw or prisma-access).
+        in: query
+        name: channel
+        required: false
+        schema:
+          enum:
+          - ngfw
+          - prisma-access
+          type: string
+      - description: The end time of the incident(s) to query in UTC format (e.g.,
+          2023-10-17T02:29:04.402Z).
+        in: query
+        name: end_time
+        required: false
+        schema:
+          format: date-time
+          type: string
+      - description: Filter incidents by SHA-256 hash value(s) of associated file(s).
+          Provide comma-separated list.
+        in: query
+        name: file_shas
+        required: false
+        schema:
+          type: string
+      - description: The page number for pagination to retrieve a specific set of
+          incidents.
+        in: query
+        name: page_number
+        required: false
+        schema:
+          format: int32
+          type: integer
+      - description: The number of incidents to return per page for pagination.
+        in: query
+        name: page_size
+        required: false
+        schema:
+          format: int32
+          type: integer
+      - description: 'The geographic region where the incident was triggered (defaults
+          to US). Valid values: us, eu, uk, jp, in, ap, ca, au, par.'
+        in: query
+        name: region
+        required: false
+        schema:
+          enum:
+          - us
+          - eu
+          - uk
+          - jp
+          - in
+          - ap
+          - ca
+          - au
+          - par
+          type: string
+      - description: Filter incidents by one or more report ID(s).
+        in: query
+        name: report_ids
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      - description: The field to sort incidents by. The default sort order is by
+          creation time.
+        in: query
+        name: sort_by
+        required: false
+        schema:
+          type: string
+      - description: The start time of the incident(s) to query in UTC format (e.g.,
+          2023-10-17T02:29:04.402Z).
+        in: query
+        name: start_time
+        required: false
+        schema:
+          format: date-time
+          type: string
+      - description: Filter incidents by one or more user ID(s) associated with the
+          incident.
+        in: query
+        name: user_ids
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                incidentResponseExample:
+                  value:
+                    page:
+                      number: 1
+                      size: 10
+                      total_elements: 290
+                      total_pages: 29
+                    resources:
+                    - action: alert
+                      channel: ngfw
+                      data_profile_id: 11995044
+                      data_profile_name: PII
+                      file_name: SSNpattern
+                      file_sha: a4d58aa3caeb73b56028f597de2b3263d64e2835f277f31c97be53bc76a29e47
+                      file_type: pdf
+                      incident_creation_time: 2023-Dec-07 18:41:12 UTC
+                      incident_id: 7c3dca3d-1c08-4147-b171-9faba84739d4
+                      report_id: '1572154781'
+                      source: ngfw
+                      tenant_id: '5886928188517009408'
+                    - action: alert
+                      channel: ngfw
+                      data_profile_id: 11995410
+                      data_profile_name: Portugal_LNAME_high
+                      file_name: test_portugal_LNAME.txt
+                      file_sha: 6c25d79cd1dee00b3a6ee6bbb985dae6ee5bdfa31a8dfcffa241786c8c3893a7
+                      file_type: txt
+                      incident_creation_time: 2023-Dec-07 18:39:38 UTC
+                      incident_id: 81985a40-dae5-4e80-8147-678892ccfc00
+                      report_id: '2968440380'
+                      source: ngfw
+                      tenant_id: '5886928188517009408'
+                    - action: alert
+                      channel: ngfw
+                      data_profile_id: 11995355
+                      data_profile_name: inline_timing_11_12_edm
+                      file_name: all_patterns_data_1_MB.txt
+                      file_sha: 6c8d18c544aba3b44cfa487d5020ec102a6317a6a5164e270bbecf6ea37df925
+                      file_type: txt
+                      incident_creation_time: 2023-Dec-06 19:39:46 UTC
+                      incident_id: 08f014d8-ed13-490e-bfc4-7363f43a4af1
+                      report_id: '1347859663'
+                      source: ngfw
+                      tenant_id: '5886928188517009408'
+                    - action: alert
+                      channel: ngfw
+                      data_profile_id: 11995295
+                      data_profile_name: DemoWideNestedProfile
+                      file_name: SSNpattern
+                      file_sha: a4d58aa3caeb73b56028f597de2b3263d64e2835f277f31c97be53bc76a29e47
+                      file_type: pdf
+                      incident_creation_time: 2023-Dec-05 21:54:21 UTC
+                      incident_id: 6c7d838a-1b25-44fe-8917-1ff760c0eae5
+                      report_id: '3741398016'
+                      source: ngfw
+                      tenant_id: '5886928188517009408'
+              schema:
+                $ref: '#/components/schemas/IncidentResponse'
+          description: OK
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Retrieve DLP Incidents
+      tags:
+      - Incidents API
+  /v2/api/incidents/{incidentID}:
+    get:
+      description: "Retrieve comprehensive details for a specific DLP incident using\
+        \ its unique incident ID. Similar to \nviewing DLP Incidents on Panorama,\
+        \ this API allows you to programmatically access detailed incident \ninformation.\n\
+        \nWhen using this API, note the following:\n* Multiple filtering parameters\
+        \ (such as report ID, user ID, file SHA, and channel) are combined using an\
+        \ \"AND\" operation\n* All filters perform exact matches\n* Fields with null\
+        \ values are excluded from the response\n"
+      operationId: get-v2-api-incidents-incidentid
+      parameters:
+      - description: The unique identifier of the incident to retrieve.
+        examples:
+          IncidentID Example:
+            value: 3fb38abe-a83b-44e5-99d5-4bec3765bba6
+        in: path
+        name: incidentID
+        required: true
+        schema:
+          type: string
+      - description: region(default to us)
+        in: query
+        name: region
+        schema:
+          enum:
+          - us
+          - eu
+          - uk
+          - jp
+          - in
+          - ap
+          - ca
+          - au
+          - par
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                incident detail:
+                  value:
+                    action: alert
+                    channel: ngfw
+                    data_profile_id: 11995044
+                    data_profile_name: PII
+                    file_name: SSNpattern
+                    file_sha: a4d58aa3caeb73b56028f597de2b3263d64e2835f277f31c97be53bc76a29e47
+                    incident_creation_time: 2024-Jan-18 21:46:54 UTC
+                    incident_id: 1a762308-3735-4d29-8edd-4595d4e3f982
+                    match_info:
+                      6374e1b4dee31d91c40b1705:
+                        detection_technique: regex
+                        hcf: 0
+                        lcf: 5
+                        mcf: 0
+                        name: Driver License - Slovenia
+                        uhcf: 0
+                        ulcf: 5
+                        umcf: 0
+                        version: 1
+                      6374e1b4dee31d91c40b1708:
+                        detection_technique: regex
+                        hcf: 0
+                        lcf: 13
+                        mcf: 0
+                        name: Driver License - Canada
+                        uhcf: 0
+                        ulcf: 13
+                        umcf: 0
+                        version: 1
+                      6374e1b4dee31d91c40b1709:
+                        detection_technique: regex
+                        hcf: 0
+                        lcf: 17
+                        mcf: 0
+                        name: Driver License - US
+                        uhcf: 0
+                        ulcf: 17
+                        umcf: 0
+                        version: 1
+                    report_id: '1107089697'
+                    snippets:
+                      6374e1b4dee31d91c40b1705:
+                        low_confidence_detections:
+                        - detection: '*******00'
+                          left: "\n\n\n\n\n\n tax id number ***-**-**99 abs cupp\n\
+                            IBAN CH9300762011623852957 cusip "
+                          origOffSet: 75
+                          original_text: '*******00'
+                          right: " | *****0BG4 DEA *****3839 | *****5341 CLIA 24C3872984\
+                            \ | 05D0911402\nHETU number ******-856E | *******0490\L\
+                            \nCPF | **************1-30 CNPJ\L\n*-****-****-6246 SHAKAI\
+                            \ HOSH\u014C ZEI BANG\u014C SEIDO MAINANBA ****-**"
+                          textLength: 0
+                        - detection: '*******55'
+                          left: "HOSH\u014C ZEI BANG\u014C SEIDO MAINANBA ****-****-6333\n\
+                            UK Tax UTR ******1030 ******1031 NINO GP 32 76 63 *****280B\
+                            \ Germany Tax ID *******1827 *******8911 *******8796 visa\
+                            \ 4556501518562241 4929091695478411 aba "
+                          origOffSet: 446
+                          original_text: '*******55'
+                          right: ' *****3532 ssn 098-07-33 16 480-33-1945 Canada SIN
+                            *** *** 425 *****3197 Australia Tax ID 45322 1716 98754015
+                            Access Key ID 022QF06E7MXBSH9DHM02 AWS Secret Key kWcrlUX5JEDGM/LtmEENI/
+                            aVmYvHNif5zB+d9+c'
+                          textLength: 0
+                        - detection: '*****3532'
+                          left: "BANG\u014C SEIDO MAINANBA ****-****-6333\nUK Tax\
+                            \ UTR ******1030 ******1031 NINO GP 32 76 63 *****280B\
+                            \ Germany Tax ID *******1827 *******8911 *******8796 visa\
+                            \ 4556501518562241 4929091695478411 aba *******55 "
+                          origOffSet: 456
+                          original_text: '*****3532'
+                          right: ' ssn 098-07-33 16 480-33-1945 Canada SIN *** ***
+                            425 *****3197 Australia Tax ID 45322 1716 98754015 Access
+                            Key ID 022QF06E7MXBSH9DHM02 AWS Secret Key kWcrlUX5JEDGM/LtmEENI/
+                            aVmYvHNif5zB+d9+ct ;5301250'
+                          textLength: 0
+                        version: 1
+                      6374e1b4dee31d91c40b1708:
+                        low_confidence_detections:
+                        - detection: '*******00'
+                          left: "\n\n\n\n\n\n tax id number ***-**-**99 abs cupp\n\
+                            IBAN CH9300762011623852957 cusip "
+                          origOffSet: 75
+                          original_text: '*******00'
+                          right: " | *****0BG4 DEA *****3839 | *****5341 CLIA 24C3872984\
+                            \ | 05D0911402\nHETU number ******-856E | *******0490\L\
+                            \nCPF | **************1-30 CNPJ\L\n*-****-****-6246 SHAKAI\
+                            \ HOSH\u014C ZEI BANG\u014C SEIDO MAINANBA ****-**"
+                          textLength: 0
+                        - detection: '*****5341'
+                          left: "\n\n\n\n\n\n tax id number ***-**-**99 abs cupp\n\
+                            IBAN CH9300762011623852957 cusip *******00 | *****0BG4\
+                            \ DEA *****3839 | "
+                          origOffSet: 113
+                          original_text: '*****5341'
+                          right: " CLIA 24C3872984 | 05D0911402\nHETU number ******-856E\
+                            \ | *******0490\L\nCPF | **************1-30 CNPJ\L\n*-****-****-6246\
+                            \ SHAKAI HOSH\u014C ZEI BANG\u014C SEIDO MAINANBA ****-****-6333\n\
+                            UK Tax UTR ******1030 ******10"
+                          textLength: 0
+                        - detection: '*****3839'
+                          left: "\n\n\n\n\n\n tax id number ***-**-**99 abs cupp\n\
+                            IBAN CH9300762011623852957 cusip *******00 | *****0BG4\
+                            \ DEA "
+                          origOffSet: 101
+                          original_text: '*****3839'
+                          right: " | *****5341 CLIA 24C3872984 | 05D0911402\nHETU\
+                            \ number ******-856E | *******0490\L\nCPF | **************1-30\
+                            \ CNPJ\L\n*-****-****-6246 SHAKAI HOSH\u014C ZEI BANG\u014C\
+                            \ SEIDO MAINANBA ****-****-6333\nUK Tax UTR ******1"
+                          textLength: 0
+                        version: 1
+                      6374e1b4dee31d91c40b1709:
+                        low_confidence_detections:
+                        - detection: '*******00'
+                          left: "\n\n\n\n\n\n tax id number ***-**-**99 abs cupp\n\
+                            IBAN CH9300762011623852957 cusip "
+                          origOffSet: 75
+                          original_text: '*******00'
+                          right: " | *****0BG4 DEA *****3839 | *****5341 CLIA 24C3872984\
+                            \ | 05D0911402\nHETU number ******-856E | *******0490\L\
+                            \nCPF | **************1-30 CNPJ\L\n*-****-****-6246 SHAKAI\
+                            \ HOSH\u014C ZEI BANG\u014C SEIDO MAINANBA ****-**"
+                          textLength: 0
+                        - detection: '******'
+                          left: "\n\n\n\n\n\n tax id number ***-**-**99 abs cupp\n\
+                            IBAN CH9300762011623852957 cusip *******00 | *****0BG4\
+                            \ DEA *****3839 | *****5341 CLIA 24C3872984 | 05D0911402\n\
+                            HETU number "
+                          origOffSet: 164
+                          original_text: '******'
+                          right: "-856E | *******0490\L\nCPF | **************1-30\
+                            \ CNPJ\L\n*-****-****-6246 SHAKAI HOSH\u014C ZEI BANG\u014C\
+                            \ SEIDO MAINANBA ****-****-6333\nUK Tax UTR ******1030\
+                            \ ******1031 NINO GP 32 76 63 *****280B Germany Tax ID\
+                            \ ***"
+                          textLength: 0
+                        - detection: '***-**-**99'
+                          left: "\n\n\n\n\n\n tax id number "
+                          origOffSet: 21
+                          original_text: '***-**-**99'
+                          right: " abs cupp\nIBAN CH9300762011623852957 cusip *******00\
+                            \ | *****0BG4 DEA *****3839 | *****5341 CLIA 24C3872984\
+                            \ | 05D0911402\nHETU number ******-856E | *******0490\L\
+                            \nCPF | **************1-30 CNPJ\L\n*-****-***"
+                          textLength: 0
+                        version: 1
+                    source: ngfw
+                    tenant_id: '5886928188517009408'
+              schema:
+                $ref: '#/components/schemas/IncidentResponseDTO'
+          description: OK
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Internal server error
+      security:
+      - Bearer: []
+      summary: Retrieve Specific DLP Incident Details
+      tags:
+      - Incidents API
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: Incidents API

--- a/specs/dlp/OCREnablement.yaml
+++ b/specs/dlp/OCREnablement.yaml
@@ -1,0 +1,154 @@
+components:
+  schemas:
+    AuditResponse:
+      description: Audit metadata tracking creation and last-update information
+      properties:
+        created_at:
+          description: Timestamp when the resource was created
+          format: date-time
+          type: string
+        created_by:
+          description: Username or service that created the resource
+          type: string
+        updated_at:
+          description: Timestamp when the resource was last updated
+          format: date-time
+          type: string
+        updated_by:
+          description: Username or service that last updated the resource
+          type: string
+      type: object
+    OcrEnablementRequest:
+      description: Request payload for updating OCR enablement settings
+      properties:
+        ocr_enablement:
+          description: OCR enablement state
+          enum:
+          - REQUESTED
+          - ENABLED
+          - DISABLED
+          type: string
+        target_service_name:
+          description: Target service to apply the OCR setting to
+          enum:
+          - gpcs
+          - aperture
+          - redlock
+          - prisma-cloud
+          - prisma-saas
+          - prisma-access
+          - ngfw
+          - dlp
+          - email-dlp
+          - cortex-xdr
+          - endpoint-dlp
+          - prisma-access-browser
+          type: string
+      required:
+      - ocr_enablement
+      - target_service_name
+      type: object
+    OcrEnablementResponse:
+      description: OCR enablement configuration for a service
+      properties:
+        audit_metadata:
+          $ref: '#/components/schemas/AuditResponse'
+        ocr_enablement:
+          description: Current OCR enablement state
+          enum:
+          - REQUESTED
+          - ENABLED
+          - DISABLED
+          type: string
+        ocr_enablement_banner:
+          description: Whether the OCR enablement banner is shown to users
+          type: boolean
+        service_name:
+          description: Service this configuration applies to
+          enum:
+          - gpcs
+          - aperture
+          - redlock
+          - prisma-cloud
+          - prisma-saas
+          - prisma-access
+          - ngfw
+          - dlp
+          - email-dlp
+          - cortex-xdr
+          - endpoint-dlp
+          - prisma-access-browser
+          type: string
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Optical Character Recognition (OCR) enablement APIs for enhanced document\
+    \ scanning and text extraction \ncapabilities. Enable OCR processing to detect\
+    \ sensitive information in scanned documents and images.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: OCR Enablement API v2
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v2/api/ocr:
+    get:
+      description: Retrieves OCR enablement settings for the authenticated tenant,
+        optionally filtered by target service.
+      operationId: get-v2-api-ocr
+      parameters:
+      - description: Filter results to a specific service name
+        in: query
+        name: target-service-name
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OcrEnablementResponse'
+          description: OCR enablement settings found
+        '400':
+          description: Invalid target-service-name
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: Get OCR Enablement
+      tags:
+      - OCR Enablement
+    put:
+      description: Updates the OCR enablement setting for a specific service.
+      operationId: put-v2-api-ocr
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OcrEnablementRequest'
+        required: true
+      responses:
+        '204':
+          description: OCR enablement updated
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: Update OCR Enablement
+      tags:
+      - OCR Enablement
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: OCR Enablement

--- a/specs/dlp/Peripherals.yaml
+++ b/specs/dlp/Peripherals.yaml
@@ -1,0 +1,473 @@
+components:
+  schemas:
+    AuditResponse:
+      description: Audit metadata tracking creation and last-update information
+      properties:
+        created_at:
+          description: Timestamp when the resource was created
+          format: date-time
+          type: string
+        created_by:
+          description: Username or service that created the resource
+          type: string
+        updated_at:
+          description: Timestamp when the resource was last updated
+          format: date-time
+          type: string
+        updated_by:
+          description: Username or service that last updated the resource
+          type: string
+      type: object
+    NetworkSharePeripheralRequest:
+      allOf:
+      - $ref: '#/components/schemas/PeripheralRequest'
+      - properties:
+          description:
+            description: Optional description
+            type: string
+          directory_path:
+            description: Directory path on the network share (e.g. /documents)
+            type: string
+          name:
+            description: Display name
+            maxLength: 128
+            minLength: 1
+            type: string
+          server_address:
+            description: Server hostname or IP address of the network share
+            type: string
+          type:
+            description: "Peripheral type discriminator \u2014 must be 'network_share'"
+            enum:
+            - usb
+            - printer
+            - network_share
+            example: network_share
+            type: string
+        type: object
+      description: Network share peripheral device request. Use type='network_share'.
+      required:
+      - name
+      - server_address
+      - type
+      type: object
+    PagePeripheralResponse:
+      properties:
+        content:
+          items:
+            $ref: '#/components/schemas/PeripheralResponse'
+          type: array
+        empty:
+          type: boolean
+        first:
+          type: boolean
+        last:
+          type: boolean
+        number:
+          format: int32
+          type: integer
+        numberOfElements:
+          format: int32
+          type: integer
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        size:
+          format: int32
+          type: integer
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        totalElements:
+          format: int64
+          type: integer
+        totalPages:
+          format: int32
+          type: integer
+      type: object
+    PageableObject:
+      properties:
+        offset:
+          format: int64
+          type: integer
+        pageNumber:
+          format: int32
+          type: integer
+        pageSize:
+          format: int32
+          type: integer
+        paged:
+          type: boolean
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+      type: object
+    PeripheralRequest:
+      description: Request payload for creating or updating a peripheral device. Use
+        'type' to specify the subtype.
+      discriminator:
+        propertyName: type
+      oneOf:
+      - $ref: '#/components/schemas/UsbPeripheralRequest'
+      - $ref: '#/components/schemas/PrinterPeripheralRequest'
+      - $ref: '#/components/schemas/NetworkSharePeripheralRequest'
+      properties:
+        type:
+          type: string
+      required:
+      - type
+      type: object
+    PeripheralResponse:
+      description: Peripheral device resource returned by the API
+      properties:
+        audit_metadata:
+          $ref: '#/components/schemas/AuditResponse'
+        description:
+          description: Optional description
+          type: string
+        directory_path:
+          description: Directory path (for network share peripherals)
+          type: string
+        groups:
+          description: Groups this peripheral belongs to
+          items:
+            description: Groups this peripheral belongs to
+            type: string
+          type: array
+        id:
+          description: Unique identifier of the peripheral
+          type: string
+        ip_address:
+          description: IP address (for network printer peripherals)
+          type: string
+        manufacturer_name:
+          description: Device manufacturer name
+          type: string
+        model_name:
+          description: Device model name
+          type: string
+        name:
+          description: Display name of the peripheral
+          type: string
+        printer_name:
+          description: Printer share name (for printer peripherals)
+          type: string
+        printer_type:
+          description: Printer type (for printer peripherals)
+          type: string
+        product_id:
+          description: USB product ID (for USB/printer peripherals)
+          type: string
+        serial_number:
+          description: Device serial number
+          type: string
+        server_address:
+          description: Server hostname or IP (for network share peripherals)
+          type: string
+        type:
+          description: 'Peripheral type: usb, printer, or network_share'
+          enum:
+          - usb
+          - printer
+          - network_share
+          type: string
+        vendor_id:
+          description: USB vendor ID (for USB/printer peripherals)
+          type: string
+        version:
+          description: Version number, incremented on each update
+          format: int32
+          type: integer
+      type: object
+    PrinterPeripheralRequest:
+      allOf:
+      - $ref: '#/components/schemas/PeripheralRequest'
+      - properties:
+          description:
+            description: Optional description
+            type: string
+          ip_address:
+            description: IP address of network printer
+            type: string
+          manufacturer_name:
+            description: Device manufacturer name
+            type: string
+          model_name:
+            description: Device model name
+            type: string
+          name:
+            description: Display name
+            maxLength: 128
+            minLength: 1
+            type: string
+          printer_name:
+            description: Printer share name or UNC path
+            type: string
+          printer_type:
+            description: Printer type (e.g. local, network)
+            type: string
+          product_id:
+            description: USB product ID
+            type: string
+          serial_number:
+            description: Device serial number
+            type: string
+          type:
+            description: "Peripheral type discriminator \u2014 must be 'printer'"
+            enum:
+            - usb
+            - printer
+            - network_share
+            example: printer
+            type: string
+          vendor_id:
+            description: USB vendor ID
+            type: string
+        type: object
+      description: Printer peripheral device request. Use type='printer'.
+      required:
+      - name
+      - printer_type
+      - type
+      type: object
+    SortObject:
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+      type: object
+    UsbPeripheralRequest:
+      allOf:
+      - $ref: '#/components/schemas/PeripheralRequest'
+      - properties:
+          description:
+            description: Optional description
+            type: string
+          manufacturer_name:
+            description: Device manufacturer name
+            type: string
+          model_name:
+            description: Device model name
+            type: string
+          name:
+            description: Display name
+            maxLength: 128
+            minLength: 1
+            type: string
+          product_id:
+            description: USB product ID (e.g. c52b)
+            type: string
+          serial_number:
+            description: Device serial number
+            type: string
+          type:
+            description: "Peripheral type discriminator \u2014 must be 'usb'"
+            enum:
+            - usb
+            - printer
+            - network_share
+            example: usb
+            type: string
+          vendor_id:
+            description: USB vendor ID (e.g. 046d)
+            type: string
+        type: object
+      description: USB peripheral device request. Use type='usb'.
+      required:
+      - name
+      - type
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Manage peripheral device configurations and policies for DLP protection.\
+    \ Configure USB devices, printers, \nand other peripherals to enforce DLP policies\
+    \ and prevent unauthorized data transfers.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: Peripherals API v2
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v2/api/peripherals:
+    get:
+      description: Returns a paginated list of peripheral devices for the authenticated
+        tenant.
+      operationId: get-v2-api-peripherals
+      parameters:
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          default: 20
+          minimum: 1
+          type: integer
+      - description: 'Sorting criteria in the format: property,(asc|desc). Default
+          sort order is ascending. Multiple sort criteria are supported.'
+        in: query
+        name: sort
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      - description: Comma-separated list of peripheral types to filter (usb, printer,
+          network_share)
+        in: query
+        name: peripheral-type
+        schema:
+          type: string
+      - description: If true, include group membership information
+        in: query
+        name: with-groups
+        schema:
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagePeripheralResponse'
+          description: Paginated list of peripherals
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: List Peripherals
+      tags:
+      - Peripherals
+    post:
+      description: Creates a new peripheral device for the authenticated tenant.
+      operationId: post-v2-api-peripherals
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PeripheralRequest'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PeripheralResponse'
+          description: Peripheral created
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+      security:
+      - Bearer: []
+      summary: Create Peripheral
+      tags:
+      - Peripherals
+  /v2/api/peripherals/{resourceId}:
+    delete:
+      description: Deletes a peripheral device by its ID.
+      operationId: delete-v2-api-peripherals-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Peripheral deleted
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Peripheral not found
+      security:
+      - Bearer: []
+      summary: Delete Peripheral
+      tags:
+      - Peripherals
+    get:
+      description: Retrieves a single peripheral device by its ID.
+      operationId: get-v2-api-peripherals-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PeripheralResponse'
+          description: Peripheral found
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Peripheral not found
+      security:
+      - Bearer: []
+      summary: Get Peripheral
+      tags:
+      - Peripherals
+    put:
+      description: Fully replaces an existing peripheral device with the provided
+        payload.
+      operationId: put-v2-api-peripherals-resourceid
+      parameters:
+      - in: path
+        name: resourceId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PeripheralRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PeripheralResponse'
+          description: Peripheral updated
+        '400':
+          description: Invalid request payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - insufficient privileges
+        '404':
+          description: Peripheral not found
+      security:
+      - Bearer: []
+      summary: Update Peripheral
+      tags:
+      - Peripherals
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: Peripherals

--- a/specs/dlp/ReportsAPI.yaml
+++ b/specs/dlp/ReportsAPI.yaml
@@ -1,0 +1,260 @@
+components:
+  schemas:
+    ScanContentResponse:
+      properties:
+        data_pattern_rule_1_verdict:
+          enum:
+          - MATCHED
+          - NOT_EVALUATED
+          - NOT_MATCHED
+          type: string
+        data_pattern_rule_2_verdict:
+          enum:
+          - MATCHED
+          - NOT_EVALUATED
+          - NOT_MATCHED
+          type: string
+        data_profile_name:
+          description: Profile of the detection rules
+          type: string
+        file_name:
+          description: Name of the scanned file
+          type: string
+        report_id:
+          description: ID of the retrieved report
+          type: string
+        scanContentRawReport:
+          description: List of report data
+          type: string
+        tenant_id:
+          description: DLP tenant ID
+          type: string
+      title: ScanContentResponse
+      type: object
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      type: http
+info:
+  contact: {}
+  description: "Retrieve and analyze DLP scan reports containing comprehensive metadata\
+    \ and detection information \nabout files and payloads. Reports provide detailed\
+    \ insights into pattern matches, detection techniques, \nand sensitive content\
+    \ findings without including unique incident information.\n"
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  title: Reports API
+  version: 1.0.0
+openapi: 3.0.2
+paths:
+  /v1/public/report/{reportId}:
+    get:
+      description: "Retrieve detailed information about a specific DLP report. A report\
+        \ contains metadata and detection \ninformation about a file or payload, such\
+        \ as pattern matches, but does not include unique incident \ninformation.\
+        \ For user, application, URL, and channel information, refer to the Get Incident\
+        \ Details endpoint.\n\nA single report can contain multiple incidents. You\
+        \ can optionally retrieve snippets in the response. \nSnippets are evidence\
+        \ or identifiable information associated with a pattern match. For example,\
+        \ if you \nspecified a data pattern of \"Credit Card Number\", the API returns\
+        \ the actual credit card number as the \nmatched snippet.\n\nFor more information,\
+        \ see [Set Up Enterprise Data Loss Prevention](https://docs.paloaltonetworks.com/enterprise-dlp/enterprise-dlp-admin/set-up-enterprise-data-loss-prevention).\n"
+      operationId: get-v1-public-report-reportid
+      parameters:
+      - description: The unique identifier of the DLP report to retrieve.
+        in: path
+        name: reportId
+        required: true
+        schema:
+          type: string
+      - description: (Optional) Boolean field when set to true, retrieves snippets
+          from the DLP report.
+        in: query
+        name: fetchSnippets
+        schema:
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                report with snippets:
+                  value:
+                    action: block
+                    data_pattern_rule_1_verdict: MATCHED
+                    data_profile_id: '11995044'
+                    data_profile_name: PII
+                    data_profile_version: 1
+                    detection_time: 02/10/2024 23:34:14 GMT
+                    extracted_file_size_in_bytes: 937
+                    fileSha: a4d58aa3caeb73b56028f597de2b3263d64e2835f277f31c97be53bc76a29e47
+                    file_name: SSNpattern
+                    file_size_in_bytes: 930
+                    file_type: pdf
+                    report_id: '163570374'
+                    scanContentRawReport:
+                      data_pattern_rule_1_results:
+                      - data_pattern_id: 6374e1b4dee31d91c40b179d
+                        detection_frequency: 7
+                        detections:
+                        - detection: '*******00'
+                          left: "\n\n\n\n\n\n tax id number ***-**-**99 abs cupp\n\
+                            IBAN CH9300762011623852957 cusip "
+                          origOffSet: 75
+                          original_text: '*******00'
+                          right: " | *****0BG4 DEA *****3839 | *****5341 CLIA 24C3872984\
+                            \ | 05D0911402\nHETU number ******-856E | *******0490\L\
+                            \nCPF | **************1-30 CNPJ\L\n*-****-****-6246 SHAKAI\
+                            \ HOSH\u014C ZEI BANG\u014C SEIDO MAINANBA ****-**"
+                          textLength: 0
+                        - detection: '*******55'
+                          left: "HOSH\u014C ZEI BANG\u014C SEIDO MAINANBA ****-****-6333\n\
+                            UK Tax UTR ******1030 ******1031 NINO GP 32 76 63 *****280B\
+                            \ Germany Tax ID *******1827 *******8911 *******8796 visa\
+                            \ 4556501518562241 4929091695478411 aba "
+                          origOffSet: 446
+                          original_text: '*******55'
+                          right: ' *****3532 ssn 098-07-33 16 480-33-1945 Canada SIN
+                            *** *** 425 *****3197 Australia Tax ID 45322 1716 98754015
+                            Access Key ID 022QF06E7MXBSH9DHM02 AWS Secret Key kWcrlUX5JEDGM/LtmEENI/
+                            aVmYvHNif5zB+d9+c'
+                          textLength: 0
+                        - detection: '***-**-**99'
+                          left: "\n\n\n\n\n\n tax id number "
+                          origOffSet: 21
+                          original_text: '***-**-**99'
+                          right: " abs cupp\nIBAN CH9300762011623852957 cusip *******00\
+                            \ | *****0BG4 DEA *****3839 | *****5341 CLIA 24C3872984\
+                            \ | 05D0911402\nHETU number ******-856E | *******0490\L\
+                            \nCPF | **************1-30 CNPJ\L\n*-****-***"
+                          textLength: 0
+                        edm_columns: []
+                        high_confidence_detections: {}
+                        high_confidence_frequency: 7
+                        low_confidence_detections: {}
+                        low_confidence_frequency: 7
+                        matched_confidence_level: high
+                        medium_confidence_detections: {}
+                        medium_confidence_frequency: 0
+                        name: National Id - US Social Security Number - SSN
+                        proximity_detection_frequency: 7
+                        state: EVALUATED
+                        strict_detection_frequency: 0
+                        technique: regex
+                        type: predefined
+                        unique_checksum_detection_frequency: 0
+                        unique_detection_frequency: 7
+                        unique_high_confidence_frequency: 7
+                        unique_low_confidence_frequency: 7
+                        unique_medium_confidence_frequency: 0
+                        unique_proximity_detection_frequency: 7
+                        unique_strict_detection_frequency: 0
+                        version: 1
+                        weighted_frequency: 0
+                    tenant_id: '5886928188517009408'
+                    txn_id: '163570374'
+                    type: basic
+                sample report:
+                  value:
+                    data_pattern_rule_1_verdict: MATCHED
+                    data_profile_id: '11995014'
+                    data_profile_name: Sensitive Content
+                    detection_time: 10/15/2020 21:16:24 UTC
+                    extracted_file_size_in_bytes: 1005635
+                    fileSha: 90d068df2381ebd8342c99cf59907e7c9fc7ab3d7c4c6fdc2a3d814eb7ed374f
+                    file_name: google_finance_template_1mb.txt
+                    file_size_in_bytes: 1005626
+                    file_type: txt
+                    report_id: '483332512'
+                    scanContentRawReport:
+                      data_pattern_rule_1_results:
+                      - data_pattern_id: 5ee3c51c99025d000161ab9a
+                        detection_frequency: 0
+                        high_confidence_frequency: 0
+                        low_confidence_frequency: 0
+                        medium_confidence_frequency: 0
+                        name: Bank - American Bankers Association Routing Number -
+                          ABA
+                        proximity_detection_frequency: 0
+                        state: EVALUATED
+                        strict_detection_frequency: 0
+                        technique: regex
+                        type: predefined
+                        unique_checksum_detection_frequency: 0
+                        unique_detection_frequency: 0
+                        unique_high_confidence_frequency: 0
+                        unique_low_confidence_frequency: 0
+                        unique_medium_confidence_frequency: 0
+                        unique_proximity_detection_frequency: 0
+                        unique_strict_detection_frequency: 0
+                        version: 1
+                        weighted_frequency: 0
+                      - data_pattern_id: 5ee3c51c99025d000161aba6
+                        detection_frequency: 0
+                        high_confidence_frequency: 0
+                        low_confidence_frequency: 0
+                        medium_confidence_frequency: 0
+                        name: Voyager Credit Card
+                        proximity_detection_frequency: 0
+                        state: EVALUATED
+                        strict_detection_frequency: 0
+                        technique: regex
+                        type: predefined
+                        unique_checksum_detection_frequency: 0
+                        unique_detection_frequency: 0
+                        unique_high_confidence_frequency: 0
+                        unique_low_confidence_frequency: 0
+                        unique_medium_confidence_frequency: 0
+                        unique_proximity_detection_frequency: 0
+                        unique_strict_detection_frequency: 0
+                        version: 1
+                        weighted_frequency: 0
+                      - data_pattern_id: 5ee3c51d99025d000161ac52
+                        detection_frequency: 3
+                        high_confidence_frequency: 3
+                        low_confidence_frequency: 3
+                        matched_confidence_level: high
+                        medium_confidence_frequency: 0
+                        name: NationalId - US Social Security Number - SSN
+                        proximity_detection_frequency: 3
+                        state: EVALUATED
+                        strict_detection_frequency: 0
+                        technique: regex
+                        type: predefined
+                        unique_checksum_detection_frequency: 0
+                        unique_detection_frequency: 3
+                        unique_high_confidence_frequency: 3
+                        unique_low_confidence_frequency: 3
+                        unique_medium_confidence_frequency: 0
+                        unique_proximity_detection_frequency: 3
+                        unique_strict_detection_frequency: 0
+                        version: 1
+                        weighted_frequency: 0
+                    tenant_id: '7830962012064884736'
+                    txn_id: '483332512'
+                    type: basic
+              schema:
+                $ref: '#/components/schemas/ScanContentResponse'
+          description: OK
+        '400':
+          description: Bad Request. Got an invalid JSON.
+        '401':
+          description: Unauthorized access. An issue occurred during authentication.
+            This can indicate an incorrect key, ID, or other invalid authentication
+            parameters.
+        '403':
+          description: Forbidden access. The provided API Key does not have the required
+            permissions to run this API.
+        '500':
+          description: Internal server error. A unified status for API communication
+            type errors.
+      security:
+      - Bearer: []
+      summary: Retrieve Report Details
+      tags:
+      - Reports API
+servers:
+- url: https://api.dlp.paloaltonetworks.com
+tags:
+- name: Reports API


### PR DESCRIPTION
## Summary

Adds 12 OpenAPI 3 specifications for Palo Alto Networks DLP management APIs (base URL `https://api.dlp.paloaltonetworks.com`).

These will be referenced by the upcoming **DLP API Coverage** milestone. Committing them to `main` first so every follow-up issue/PR has a stable spec reference.

## Files

- `DataFilteringProfiles.yaml`
- `DataPatterns.yaml`
- `DataProfiles.yaml`
- `Dictionaries.yaml`
- `DocumentTypes.yaml`
- `EDMDatasets.yaml`
- `EndpointPolicies.yaml`
- `IncidentsAPI.yaml`
- `IncidentsAPI(Beta).yaml`
- `OCREnablement.yaml`
- `Peripherals.yaml`
- `ReportsAPI.yaml`

## Test plan

- [ ] No code changes; visual review of specs only
- [ ] Confirm `npm run lint` / `npm run typecheck` still pass (unaffected)