### PR TITLE
feat(dlp): foundation — namespace, shared models, request pipeline

### DIFF
--- a/.changeset/0023-dlp-foundation.md
+++ b/.changeset/0023-dlp-foundation.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Foundation for DLP (Data Loss Prevention) management APIs: new `management.dlp` namespace targeting `https://api.dlp.paloaltonetworks.com` (overridable via `dlpEndpoint` constructor option; reuses `PANW_MGMT_*` OAuth credentials). Add shared model primitives `AuditResponseSchema`, `pageSchema<T>` (Spring `Page<T>` envelope), and `jsonNullable<T>` (JSON Merge Patch fields). Extend the request pipeline to support `application/merge-patch+json` content-type override and multipart `FormData` bodies. Subclients (DataFilteringProfiles, DataPatterns, Dictionaries, DataProfiles) ship in follow-up releases.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,6 +83,9 @@ export const MGMT_CUSTOMER_APPS_TSG_PATH = '/v1/mgmt/customerapp/tsg';
 export const MGMT_OAUTH_INVALIDATE_PATH = '/v1/mgmt/oauth/invalidateToken';
 export const MGMT_OAUTH_TOKEN_PATH = '/v1/mgmt/oauth/client_credential/accesstoken';
 
+// DLP (Data Loss Prevention) API defaults
+export const DEFAULT_DLP_ENDPOINT = 'https://api.dlp.paloaltonetworks.com';
+
 // Model Security API defaults
 export const DEFAULT_MODEL_SEC_DATA_ENDPOINT = 'https://api.sase.paloaltonetworks.com/aims/data';
 export const DEFAULT_MODEL_SEC_MGMT_ENDPOINT = 'https://api.sase.paloaltonetworks.com/aims/mgmt';

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -35,9 +35,13 @@ export async function request<TResponse = void>(spec: RequestSpec<TResponse>): P
 
       const headers: Record<string, string> = { 'User-Agent': USER_AGENT };
       let bodyText: string | undefined;
-      if (spec.body !== undefined) {
-        headers['Content-Type'] = 'application/json';
+      let bodyForFetch: FormData | string | undefined;
+      if (spec.formData !== undefined) {
+        bodyForFetch = spec.formData;
+      } else if (spec.body !== undefined) {
+        headers['Content-Type'] = spec.contentType ?? 'application/json';
         bodyText = JSON.stringify(spec.body);
+        bodyForFetch = bodyText;
       }
 
       const prepared: PreparedRequest = { method: spec.method, url, headers, bodyText };
@@ -46,7 +50,7 @@ export async function request<TResponse = void>(spec: RequestSpec<TResponse>): P
       return fetch(final.url.toString(), {
         method: final.method,
         headers: final.headers,
-        body: final.bodyText,
+        body: spec.formData !== undefined ? bodyForFetch : final.bodyText,
       });
     },
     onRetryableFailure: async (res) => {

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -36,6 +36,18 @@ export interface RequestSpec<TResponse = void> {
   path: string;
   params?: Record<string, string | string[]>;
   body?: unknown;
+  /**
+   * Override the request Content-Type when a JSON `body` is sent. Defaults to `application/json`.
+   * Used by DLP endpoints that require `application/merge-patch+json` (RFC 7396).
+   * Ignored when `body` is omitted or when `formData` is set.
+   */
+  contentType?: string;
+  /**
+   * Multipart payload. When set, the body is sent as-is and Content-Type is left to the runtime
+   * (so the browser/Node fetch impl writes the correct multipart boundary). Takes precedence
+   * over `body`.
+   */
+  formData?: FormData;
   // `any` for Zod's def/input generics so schemas where input ≠ output (e.g. those built with
   // `.default()` or `.passthrough()`) still satisfy the constraint. Only the parsed output shape
   // is consumed at runtime.

--- a/src/management/client.ts
+++ b/src/management/client.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MGMT_ENDPOINT, MGMT_ENDPOINT } from '../constants.js';
+import { DEFAULT_DLP_ENDPOINT, DEFAULT_MGMT_ENDPOINT, MGMT_ENDPOINT } from '../constants.js';
 import { OAuthAuth } from '../http/auth/oauth.js';
 import { resolveOAuthConfig } from '../oauth-config.js';
 import { ProfilesClient } from './profiles.js';
@@ -9,6 +9,7 @@ import { DlpProfilesClient } from './dlp-profiles.js';
 import { DeploymentProfilesClient } from './deployment-profiles.js';
 import { ScanLogsClient } from './scan-logs.js';
 import { OAuthManagementClient } from './oauth-management.js';
+import { DlpNamespace } from './dlp.js';
 
 /** Options for constructing a {@link ManagementClient}. */
 export interface ManagementClientOptions {
@@ -20,6 +21,12 @@ export interface ManagementClientOptions {
   tsgId?: string;
   /** Management API endpoint URL. Falls back to `PANW_MGMT_ENDPOINT` env var. */
   apiEndpoint?: string;
+  /**
+   * DLP (Data Loss Prevention) API endpoint URL. Used by the `dlp` subclients.
+   * Defaults to `https://api.dlp.paloaltonetworks.com`. Constructor-only — no env var override
+   * (DLP shares OAuth credentials with the management API).
+   */
+  dlpEndpoint?: string;
   /** OAuth2 token endpoint URL. Falls back to `PANW_MGMT_TOKEN_ENDPOINT` env var. */
   tokenEndpoint?: string;
   /** Max retry attempts (0–5). Defaults to 5. */
@@ -39,9 +46,11 @@ export class ManagementClient {
   public readonly deploymentProfiles: DeploymentProfilesClient;
   public readonly scanLogs: ScanLogsClient;
   public readonly oauth: OAuthManagementClient;
+  public readonly dlp: DlpNamespace;
 
   constructor(opts: ManagementClientOptions = {}) {
     const apiEndpoint = opts.apiEndpoint ?? process.env[MGMT_ENDPOINT] ?? DEFAULT_MGMT_ENDPOINT;
+    const dlpEndpoint = opts.dlpEndpoint ?? DEFAULT_DLP_ENDPOINT;
 
     const { baseUrl, oauthClient, numRetries, tsgId } = resolveOAuthConfig({
       clientId: opts.clientId,
@@ -63,5 +72,6 @@ export class ManagementClient {
     this.deploymentProfiles = new DeploymentProfilesClient({ baseUrl, auth, numRetries });
     this.scanLogs = new ScanLogsClient({ baseUrl, auth, numRetries });
     this.oauth = new OAuthManagementClient({ baseUrl, auth, numRetries });
+    this.dlp = new DlpNamespace({ baseUrl: dlpEndpoint, auth, numRetries });
   }
 }

--- a/src/management/dlp.ts
+++ b/src/management/dlp.ts
@@ -1,0 +1,30 @@
+import type { AuthAdapter } from '../http/types.js';
+
+/** @internal */
+export interface DlpNamespaceOptions {
+  baseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+}
+
+/**
+ * Grouping for the DLP (Data Loss Prevention) management subclients exposed under
+ * `ManagementClient.dlp`. The DLP service lives on a separate base URL from the rest of
+ * the management API but reuses the same OAuth2 credentials and token endpoint.
+ *
+ * Subclients (DataFilteringProfiles, DataPatterns, Dictionaries, DataProfiles) attach in
+ * follow-up PRs; the namespace itself is the foundation surface that those PRs build on.
+ */
+export class DlpNamespace {
+  public readonly baseUrl: string;
+  /** @internal */
+  public readonly auth: AuthAdapter;
+  /** @internal */
+  public readonly numRetries: number;
+
+  constructor(opts: DlpNamespaceOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+}

--- a/src/management/index.ts
+++ b/src/management/index.ts
@@ -11,3 +11,4 @@ export {
 } from './deployment-profiles.js';
 export { ScanLogsClient, type ScanLogQueryOptions } from './scan-logs.js';
 export { OAuthManagementClient, type GetTokenOptions } from './oauth-management.js';
+export { DlpNamespace } from './dlp.js';

--- a/src/models/dlp-audit.ts
+++ b/src/models/dlp-audit.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Audit metadata block shared by every DLP resource response. Tracks who created
+ * and last updated the resource.
+ *
+ * All fields are optional; the DLP API may omit some on partially-managed records
+ * (e.g. system-seeded predefined patterns).
+ */
+export const AuditResponseSchema = z
+  .object({
+    created_at: z.string().optional(),
+    created_by: z.string().optional(),
+    updated_at: z.string().optional(),
+    updated_by: z.string().optional(),
+  })
+  .passthrough();
+
+export type AuditResponse = z.infer<typeof AuditResponseSchema>;

--- a/src/models/dlp-json-nullable.ts
+++ b/src/models/dlp-json-nullable.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+/**
+ * Wraps a Zod schema for use in a JSON Merge Patch (RFC 7396) request body.
+ *
+ * Merge-patch semantics:
+ * - Field omitted → leave unchanged on the server.
+ * - Field set to `null` → clear/null on the server.
+ * - Field set to a value → replace on the server.
+ *
+ * The DLP OpenAPI generator emits a `JsonNullable<T>` wrapper type with a
+ * `present: boolean` discriminator, but the actual wire shape is just
+ * `T | null | undefined`. This helper keeps the Zod surface minimal while
+ * documenting the intent.
+ *
+ * @example
+ * const PatchBody = z.object({
+ *   description: jsonNullable(z.string()),
+ *   tags: jsonNullable(z.array(z.string())),
+ * });
+ * // Clear `description`, leave `tags` untouched:
+ * const body = { description: null };
+ */
+export function jsonNullable<T extends z.ZodTypeAny>(inner: T) {
+  return inner.nullable().optional();
+}
+
+/** Resolved type of a `jsonNullable<T>` field. */
+export type JsonNullable<T extends z.ZodTypeAny> = z.infer<T> | null | undefined;

--- a/src/models/dlp-page.ts
+++ b/src/models/dlp-page.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+/**
+ * Spring `Sort` descriptor. Returned inside every Spring `Page<T>` envelope.
+ * All fields optional + passthrough for forward-compat.
+ */
+export const SortObjectSchema = z
+  .object({
+    empty: z.boolean().optional(),
+    sorted: z.boolean().optional(),
+    unsorted: z.boolean().optional(),
+  })
+  .passthrough();
+
+export type SortObject = z.infer<typeof SortObjectSchema>;
+
+/**
+ * Spring `Pageable` descriptor — the current-page slice metadata returned
+ * inside `Page<T>.pageable`.
+ */
+export const PageableObjectSchema = z
+  .object({
+    offset: z.number().optional(),
+    pageNumber: z.number().optional(),
+    pageSize: z.number().optional(),
+    paged: z.boolean().optional(),
+    unpaged: z.boolean().optional(),
+    sort: SortObjectSchema.optional(),
+  })
+  .passthrough();
+
+export type PageableObject = z.infer<typeof PageableObjectSchema>;
+
+/**
+ * Spring-style `Page<T>` envelope factory. Every DLP `/v2/api/*` list endpoint
+ * wraps its results in this shape (`content[]` + pagination metadata).
+ *
+ * Returns a Zod schema parametrized on the inner item shape.
+ */
+export function pageSchema<T extends z.ZodTypeAny>(itemSchema: T) {
+  return z
+    .object({
+      content: z.array(itemSchema),
+      empty: z.boolean().optional(),
+      first: z.boolean().optional(),
+      last: z.boolean().optional(),
+      number: z.number().optional(),
+      numberOfElements: z.number().optional(),
+      pageable: PageableObjectSchema.optional(),
+      size: z.number().optional(),
+      sort: SortObjectSchema.optional(),
+      totalElements: z.number().optional(),
+      totalPages: z.number().optional(),
+    })
+    .passthrough();
+}
+
+/** Resolved type of a Spring `Page<T>` envelope for a given item schema. */
+export type Page<T extends z.ZodTypeAny> = z.infer<ReturnType<typeof pageSchema<T>>>;

--- a/test/http/request.spec.ts
+++ b/test/http/request.spec.ts
@@ -169,6 +169,140 @@ describe('request — body handling', () => {
   });
 });
 
+describe('request — content type override', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('sends application/merge-patch+json when contentType is set', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'PATCH',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items/1',
+      body: { description: null, name: 'updated' },
+      contentType: 'application/merge-patch+json',
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+      'application/merge-patch+json',
+    );
+    // Body is still JSON-stringified (merge-patch is a JSON dialect).
+    expect(init.body).toBe(JSON.stringify({ description: null, name: 'updated' }));
+  });
+
+  it('contentType is ignored when no body is set', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      contentType: 'application/merge-patch+json',
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+    expect(init.body).toBeUndefined();
+  });
+
+  it('defaults to application/json when contentType is omitted', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'POST',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      body: { name: 'foo' },
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+  });
+});
+
+describe('request — multipart form-data', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('passes FormData straight through to fetch', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    const fd = new FormData();
+    fd.append('file', new Blob(['hello']), 'hello.txt');
+
+    await request({
+      method: 'POST',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/uploads',
+      formData: fd,
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    // Same instance — don't serialize or wrap.
+    expect(init.body).toBe(fd);
+  });
+
+  it('does not set Content-Type when sending FormData (runtime sets boundary)', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    const fd = new FormData();
+    fd.append('field', 'value');
+
+    await request({
+      method: 'POST',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/uploads',
+      formData: fd,
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+  });
+
+  it('formData takes precedence over body when both are set', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    const fd = new FormData();
+    fd.append('field', 'value');
+
+    await request({
+      method: 'POST',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/uploads',
+      formData: fd,
+      body: { ignored: true },
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.body).toBe(fd);
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+  });
+});
+
 describe('request — schema parsing', () => {
   const originalFetch = globalThis.fetch;
   afterEach(() => {

--- a/test/management/client.spec.ts
+++ b/test/management/client.spec.ts
@@ -8,6 +8,7 @@ import { DlpProfilesClient } from '../../src/management/dlp-profiles.js';
 import { DeploymentProfilesClient } from '../../src/management/deployment-profiles.js';
 import { ScanLogsClient } from '../../src/management/scan-logs.js';
 import { OAuthManagementClient } from '../../src/management/oauth-management.js';
+import { DlpNamespace } from '../../src/management/dlp.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 describe('ManagementClient', () => {
@@ -32,6 +33,7 @@ describe('ManagementClient', () => {
     expect(client.deploymentProfiles).toBeInstanceOf(DeploymentProfilesClient);
     expect(client.scanLogs).toBeInstanceOf(ScanLogsClient);
     expect(client.oauth).toBeInstanceOf(OAuthManagementClient);
+    expect(client.dlp).toBeInstanceOf(DlpNamespace);
   });
 
   it('reads credentials from env vars', () => {
@@ -126,5 +128,35 @@ describe('ManagementClient', () => {
       tsgId: '1',
     });
     expect(client.profiles).toBeInstanceOf(ProfilesClient);
+  });
+
+  it('exposes dlp namespace with default DLP endpoint', () => {
+    const client = new ManagementClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+    });
+    expect(client.dlp).toBeInstanceOf(DlpNamespace);
+    expect(client.dlp.baseUrl).toBe('https://api.dlp.paloaltonetworks.com');
+  });
+
+  it('dlpEndpoint option overrides default DLP base URL', () => {
+    const client = new ManagementClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+      dlpEndpoint: 'https://dlp.staging.example.com',
+    });
+    expect(client.dlp.baseUrl).toBe('https://dlp.staging.example.com');
+  });
+
+  it('does NOT read DLP endpoint from a DLP-specific env var', () => {
+    process.env.PANW_DLP_ENDPOINT = 'https://should-be-ignored.example.com';
+    const client = new ManagementClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+    });
+    expect(client.dlp.baseUrl).toBe('https://api.dlp.paloaltonetworks.com');
   });
 });

--- a/test/models/dlp-audit.spec.ts
+++ b/test/models/dlp-audit.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { AuditResponseSchema } from '../../src/models/dlp-audit.js';
+
+describe('AuditResponseSchema', () => {
+  it('parses a full audit_metadata block', () => {
+    const r = AuditResponseSchema.safeParse({
+      created_at: '2026-05-23T08:17:00Z',
+      created_by: 'calvin@cdot.io',
+      updated_at: '2026-05-23T09:30:00Z',
+      updated_by: 'service-account',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('treats all four fields as optional', () => {
+    const r = AuditResponseSchema.safeParse({});
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects non-string created_by', () => {
+    const r = AuditResponseSchema.safeParse({ created_by: 42 });
+    expect(r.success).toBe(false);
+  });
+
+  it('passes through unknown fields (forward compat)', () => {
+    const r = AuditResponseSchema.safeParse({
+      created_at: '2026-05-23T08:17:00Z',
+      future_field: 'whatever',
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/test/models/dlp-json-nullable.spec.ts
+++ b/test/models/dlp-json-nullable.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { jsonNullable } from '../../src/models/dlp-json-nullable.js';
+
+describe('jsonNullable()', () => {
+  it('accepts the inner value', () => {
+    const schema = jsonNullable(z.string());
+    const r = schema.safeParse('hello');
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toBe('hello');
+  });
+
+  it('accepts null (used to clear a field via merge-patch)', () => {
+    const schema = jsonNullable(z.string());
+    const r = schema.safeParse(null);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toBeNull();
+  });
+
+  it('accepts undefined (field omitted entirely)', () => {
+    const schema = jsonNullable(z.string());
+    const r = schema.safeParse(undefined);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toBeUndefined();
+  });
+
+  it('rejects the wrong inner type', () => {
+    const schema = jsonNullable(z.string());
+    const r = schema.safeParse(42);
+    expect(r.success).toBe(false);
+  });
+
+  it('round-trips through JSON.stringify preserving null semantics', () => {
+    const PatchBody = z.object({
+      description: jsonNullable(z.string()),
+      tags: jsonNullable(z.array(z.string())),
+    });
+
+    // Clear `description`, keep `tags` unchanged (omit).
+    const body: z.infer<typeof PatchBody> = { description: null };
+    const wire = JSON.parse(JSON.stringify(body));
+    const r = PatchBody.safeParse(wire);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.description).toBeNull();
+      expect(r.data.tags).toBeUndefined();
+    }
+  });
+
+  it('composes with nested array inner', () => {
+    const schema = jsonNullable(z.array(z.number()));
+    expect(schema.safeParse([1, 2, 3]).success).toBe(true);
+    expect(schema.safeParse(null).success).toBe(true);
+    expect(schema.safeParse([1, 'bad']).success).toBe(false);
+  });
+});

--- a/test/models/dlp-page.spec.ts
+++ b/test/models/dlp-page.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { pageSchema, PageableObjectSchema, SortObjectSchema } from '../../src/models/dlp-page.js';
+
+const ItemSchema = z.object({ id: z.string(), name: z.string() });
+
+const samplePage = {
+  content: [
+    { id: 'p1', name: 'Pattern 1' },
+    { id: 'p2', name: 'Pattern 2' },
+  ],
+  empty: false,
+  first: true,
+  last: false,
+  number: 0,
+  numberOfElements: 2,
+  pageable: {
+    offset: 0,
+    pageNumber: 0,
+    pageSize: 20,
+    paged: true,
+    unpaged: false,
+    sort: { empty: true, sorted: false, unsorted: true },
+  },
+  size: 20,
+  sort: { empty: true, sorted: false, unsorted: true },
+  totalElements: 47,
+  totalPages: 3,
+};
+
+describe('pageSchema()', () => {
+  it('parses a full Spring-style Page payload', () => {
+    const schema = pageSchema(ItemSchema);
+    const r = schema.safeParse(samplePage);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.content).toHaveLength(2);
+      expect(r.data.totalElements).toBe(47);
+      expect(r.data.content[0].name).toBe('Pattern 1');
+    }
+  });
+
+  it('parses an empty page', () => {
+    const schema = pageSchema(ItemSchema);
+    const r = schema.safeParse({
+      content: [],
+      empty: true,
+      first: true,
+      last: true,
+      number: 0,
+      numberOfElements: 0,
+      size: 20,
+      totalElements: 0,
+      totalPages: 0,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects invalid item shape', () => {
+    const schema = pageSchema(ItemSchema);
+    const r = schema.safeParse({
+      ...samplePage,
+      content: [{ id: 1, name: 'bad-id' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('passes through unknown envelope fields', () => {
+    const schema = pageSchema(ItemSchema);
+    const r = schema.safeParse({ ...samplePage, server_added_field: 'ok' });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('PageableObjectSchema', () => {
+  it('parses standalone pageable block', () => {
+    const r = PageableObjectSchema.safeParse({
+      offset: 40,
+      pageNumber: 2,
+      pageSize: 20,
+      paged: true,
+      unpaged: false,
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('SortObjectSchema', () => {
+  it('parses standalone sort block', () => {
+    const r = SortObjectSchema.safeParse({ empty: true, sorted: false, unsorted: true });
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Foundation work for DLP (Data Loss Prevention) management APIs. Subclients (DataFilteringProfiles, DataPatterns, Dictionaries, DataProfiles) ship in follow-up PRs against the same milestone.

- New `management.dlp` namespace exposed on `ManagementClient`. Targets `https://api.dlp.paloaltonetworks.com` by default; overridable via the constructor-only `dlpEndpoint` option. Reuses `PANW_MGMT_*` OAuth credentials — no new env vars.
- Shared model primitives:
  - `AuditResponseSchema` — `audit_metadata` shape across all DLP resources
  - `pageSchema<T>` — Spring `Page<T>` envelope factory used by every list endpoint
  - `jsonNullable<T>` — JSON Merge Patch field wrapper (omit / null / value)
- Request pipeline extensions in `src/http/request.ts`:
  - `contentType` override (for `application/merge-patch+json` on PATCH bodies)
  - `formData` bypass (multipart uploads; runtime writes the boundary)
- Changeset (minor).

## Test plan

- [x] `npm test` — 1067 / 1067 pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format` clean
- [ ] Reviewer: confirm `management.dlp.baseUrl` is the right surface for subclients to read from
- [ ] Reviewer: confirm the no-DLP-env-var choice (`PANW_MGMT_*` only) matches expectations

Closes #142