### PR TITLE
feat(dlp): add dataFilteringProfiles subclient (list/get/replace)

### DIFF
--- a/.changeset/0024-dlp-data-filtering-profiles.md
+++ b/.changeset/0024-dlp-data-filtering-profiles.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Add `management.dlp.dataFilteringProfiles` subclient covering the DLP Data Filtering Profiles API: `list(params?)` (page/size/sort[]/status/name filters with Spring `Page<>` envelope), `get(resourceId)`, and `replace(resourceId, body)` (full PUT). Typed Zod schemas for the full nested object graph (`DataFilteringProfileRequest`/`Response`, `DataFilteringDetails`, `ExceptionRuleDTO`, `Exclusions`, `Source/DestinationAttributes`, `App/URLExclusion`, `DataFilteringRuleDTO`). Restructure `src/management/dlp.ts` → `src/management/dlp/` to host subsequent DLP subclients.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,6 +86,9 @@ export const MGMT_OAUTH_TOKEN_PATH = '/v1/mgmt/oauth/client_credential/accesstok
 // DLP (Data Loss Prevention) API defaults
 export const DEFAULT_DLP_ENDPOINT = 'https://api.dlp.paloaltonetworks.com';
 
+// DLP API paths
+export const DLP_DATA_FILTERING_PROFILES_PATH = '/v2/api/data-filtering-profiles';
+
 // Model Security API defaults
 export const DEFAULT_MODEL_SEC_DATA_ENDPOINT = 'https://api.sase.paloaltonetworks.com/aims/data';
 export const DEFAULT_MODEL_SEC_MGMT_ENDPOINT = 'https://api.sase.paloaltonetworks.com/aims/mgmt';

--- a/src/management/client.ts
+++ b/src/management/client.ts
@@ -9,7 +9,7 @@ import { DlpProfilesClient } from './dlp-profiles.js';
 import { DeploymentProfilesClient } from './deployment-profiles.js';
 import { ScanLogsClient } from './scan-logs.js';
 import { OAuthManagementClient } from './oauth-management.js';
-import { DlpNamespace } from './dlp.js';
+import { DlpNamespace } from './dlp/index.js';
 
 /** Options for constructing a {@link ManagementClient}. */
 export interface ManagementClientOptions {

--- a/src/management/dlp/data-filtering-profiles.ts
+++ b/src/management/dlp/data-filtering-profiles.ts
@@ -1,0 +1,107 @@
+import { DLP_DATA_FILTERING_PROFILES_PATH } from '../../constants.js';
+import { request } from '../../http/request.js';
+import type { AuthAdapter } from '../../http/types.js';
+import {
+  DataFilteringProfileResponseSchema,
+  PageDataFilteringProfileResponseSchema,
+  type DataFilteringProfileRequest,
+  type DataFilteringProfileResponse,
+  type PageDataFilteringProfileResponse,
+} from '../../models/dlp-data-filtering-profile.js';
+
+/** Query parameters accepted by {@link DataFilteringProfilesClient.list}. */
+export interface DataFilteringProfileListParams {
+  /** Zero-based page index. Defaults server-side to 0. */
+  page?: number;
+  /** Page size. Defaults server-side to 20. */
+  size?: number;
+  /**
+   * Sort criteria in `property,(asc|desc)` form. Pass multiple entries to sort by several fields;
+   * each entry is emitted as a separate `sort=` query parameter.
+   */
+  sort?: string[];
+  /** Filter by profile lifecycle status. */
+  status?: 'enabled' | 'disabled';
+  /** Partial-match filter on profile name. */
+  name?: string;
+}
+
+/** @internal */
+export interface DataFilteringProfilesClientOptions {
+  baseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+}
+
+/**
+ * Client for the DLP Data Filtering Profiles resource (`/v2/api/data-filtering-profiles`).
+ *
+ * Read + full-replace surface only — the underlying API does not expose create or delete.
+ */
+export class DataFilteringProfilesClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: DataFilteringProfilesClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List data filtering profiles. Returns the Spring `Page<>` envelope verbatim so callers can
+   * inspect `totalElements`, `pageable`, etc. without a second round-trip.
+   */
+  async list(
+    params: DataFilteringProfileListParams = {},
+  ): Promise<PageDataFilteringProfileResponse> {
+    const queryParams: Record<string, string | string[]> = {};
+    if (params.page !== undefined) queryParams.page = String(params.page);
+    if (params.size !== undefined) queryParams.size = String(params.size);
+    if (params.sort !== undefined) queryParams.sort = params.sort;
+    if (params.status !== undefined) queryParams.status = params.status;
+    if (params.name !== undefined) queryParams.name = params.name;
+
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: DLP_DATA_FILTERING_PROFILES_PATH,
+      params: queryParams,
+      responseSchema: PageDataFilteringProfileResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /** Get a single data filtering profile by resource ID. */
+  async get(resourceId: string): Promise<DataFilteringProfileResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${DLP_DATA_FILTERING_PROFILES_PATH}/${encodeURIComponent(resourceId)}`,
+      responseSchema: DataFilteringProfileResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Full-replace (PUT) the profile at `resourceId`. Returns the updated resource as the API
+   * echoes it back.
+   */
+  async replace(
+    resourceId: string,
+    body: DataFilteringProfileRequest,
+  ): Promise<DataFilteringProfileResponse> {
+    return request({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${DLP_DATA_FILTERING_PROFILES_PATH}/${encodeURIComponent(resourceId)}`,
+      body,
+      responseSchema: DataFilteringProfileResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/management/dlp/index.ts
+++ b/src/management/dlp/index.ts
@@ -1,4 +1,5 @@
-import type { AuthAdapter } from '../http/types.js';
+import type { AuthAdapter } from '../../http/types.js';
+import { DataFilteringProfilesClient } from './data-filtering-profiles.js';
 
 /** @internal */
 export interface DlpNamespaceOptions {
@@ -11,9 +12,6 @@ export interface DlpNamespaceOptions {
  * Grouping for the DLP (Data Loss Prevention) management subclients exposed under
  * `ManagementClient.dlp`. The DLP service lives on a separate base URL from the rest of
  * the management API but reuses the same OAuth2 credentials and token endpoint.
- *
- * Subclients (DataFilteringProfiles, DataPatterns, Dictionaries, DataProfiles) attach in
- * follow-up PRs; the namespace itself is the foundation surface that those PRs build on.
  */
 export class DlpNamespace {
   public readonly baseUrl: string;
@@ -22,9 +20,17 @@ export class DlpNamespace {
   /** @internal */
   public readonly numRetries: number;
 
+  public readonly dataFilteringProfiles: DataFilteringProfilesClient;
+
   constructor(opts: DlpNamespaceOptions) {
     this.baseUrl = opts.baseUrl;
     this.auth = opts.auth;
     this.numRetries = opts.numRetries;
+
+    this.dataFilteringProfiles = new DataFilteringProfilesClient({
+      baseUrl: opts.baseUrl,
+      auth: opts.auth,
+      numRetries: opts.numRetries,
+    });
   }
 }

--- a/src/management/index.ts
+++ b/src/management/index.ts
@@ -11,4 +11,8 @@ export {
 } from './deployment-profiles.js';
 export { ScanLogsClient, type ScanLogQueryOptions } from './scan-logs.js';
 export { OAuthManagementClient, type GetTokenOptions } from './oauth-management.js';
-export { DlpNamespace } from './dlp.js';
+export { DlpNamespace } from './dlp/index.js';
+export {
+  DataFilteringProfilesClient,
+  type DataFilteringProfileListParams,
+} from './dlp/data-filtering-profiles.js';

--- a/src/models/dlp-data-filtering-profile.ts
+++ b/src/models/dlp-data-filtering-profile.ts
@@ -1,0 +1,170 @@
+import { z } from 'zod';
+import { AuditResponseSchema } from './dlp-audit.js';
+import { pageSchema } from './dlp-page.js';
+
+/** App exclusion entry — application-level bypass for DLP scanning. */
+export const AppExclusionSchema = z
+  .object({
+    app_id: z.string().optional(),
+    app_name: z.string().optional(),
+    type: z.string().optional(),
+  })
+  .passthrough();
+export type AppExclusion = z.infer<typeof AppExclusionSchema>;
+
+/** URL exclusion entry — URL-level bypass for DLP scanning. */
+export const URLExclusionSchema = z
+  .object({
+    type: z.string().optional(),
+    url_id: z.string().optional(),
+    url_name: z.string().optional(),
+  })
+  .passthrough();
+export type URLExclusion = z.infer<typeof URLExclusionSchema>;
+
+/** Exclusions block — wraps app, URL, and arbitrary keyword exclusion lists. */
+export const ExclusionsSchema = z
+  .object({
+    app_exclusion_list: z.array(AppExclusionSchema).optional(),
+    url_exclusion_list: z.array(URLExclusionSchema).optional(),
+    /**
+     * Map of category-name → string-array. `additionalProperties: { type: array of string }`
+     * in the OpenAPI spec; modeled here as `z.record(z.array(z.string()))`.
+     */
+    exclusion_list: z.record(z.array(z.string())).optional(),
+  })
+  .passthrough();
+export type Exclusions = z.infer<typeof ExclusionsSchema>;
+
+/** Source attributes for an exception rule. */
+export const SourceAttributesSchema = z
+  .object({
+    match_any: z.boolean().optional(),
+    user_group_ids: z.array(z.string()).optional(),
+    user_ids: z.array(z.string()).optional(),
+  })
+  .passthrough();
+export type SourceAttributes = z.infer<typeof SourceAttributesSchema>;
+
+/** Destination attributes for an exception rule. */
+export const DestinationAttributesSchema = z
+  .object({
+    match_any: z.boolean().optional(),
+    app_ids: z.array(z.string()).optional(),
+    url_patterns: z.array(z.string()).optional(),
+  })
+  .passthrough();
+export type DestinationAttributes = z.infer<typeof DestinationAttributesSchema>;
+
+/** Exception rule — bypass that fires before the main filter logic. */
+export const ExceptionRuleDTOSchema = z
+  .object({
+    id: z.string().optional(),
+    action: z.enum(['ALLOW', 'ALERT', 'BLOCK']).optional(),
+    log_severity: z.enum(['INFORMATIONAL', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL']).optional(),
+    /**
+     * `int64` per spec; declared as `z.number()` since JS numbers cover any realistic
+     * data_profile_id and the SDK never round-trips these unmodified.
+     */
+    data_profile_ids: z.array(z.number()).optional(),
+    destination_attributes: DestinationAttributesSchema.optional(),
+    source_attributes: SourceAttributesSchema.optional(),
+  })
+  .passthrough();
+export type ExceptionRuleDTO = z.infer<typeof ExceptionRuleDTOSchema>;
+
+/** Secondary filtering rule (rule1 / rule2 slots on a profile). */
+export const DataFilteringRuleDTOSchema = z
+  .object({
+    action: z.string().optional(),
+    response_page: z.string().optional(),
+    show_rsp_page: z.string().optional(),
+  })
+  .passthrough();
+export type DataFilteringRuleDTO = z.infer<typeof DataFilteringRuleDTOSchema>;
+
+/**
+ * Granular criteria-detail block. Note the spec uses camelCase for these specific fields
+ * (e.g. `dataProfileId`, `fileBased`, `scanType`) where the surrounding profile uses
+ * snake_case — preserved verbatim to match the wire shape.
+ */
+export const DataFilteringDetailsSchema = z
+  .object({
+    action: z.string().optional(),
+    dataProfileId: z.number().optional(),
+    direction: z.string().optional(),
+    euc_template_id: z.string().optional(),
+    fileBased: z.string().optional(),
+    fileTypes: z.array(z.string()).optional(),
+    is_end_user_coaching_enabled: z.boolean().optional(),
+    logSeverity: z.string().optional(),
+    nonFileBased: z.string().optional(),
+    scanType: z.string().optional(),
+  })
+  .passthrough();
+export type DataFilteringDetails = z.infer<typeof DataFilteringDetailsSchema>;
+
+/** Request payload for a full-replace PUT on a Data Filtering Profile. */
+export const DataFilteringProfileRequestSchema = z
+  .object({
+    file_based: z.boolean(),
+    non_file_based: z.boolean(),
+    description: z.string().optional(),
+    direction: z.enum(['BOTH', 'UPLOAD', 'DOWNLOAD']).optional(),
+    log_severity: z.enum(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFORMATIONAL']).optional(),
+    scan_type: z.enum(['include', 'exclude']).optional(),
+    /**
+     * `int64` per spec; declared as `z.number()`. JS will lose precision above 2^53 but
+     * real-world IDs stay well under that ceiling.
+     */
+    data_profile_id: z.number().optional(),
+    euc_template_id: z.string().optional(),
+    is_end_user_coaching_enabled: z.boolean().optional(),
+    is_granular_profile: z.boolean().optional(),
+    file_type: z.array(z.string()).optional(),
+    criteria_details: z.array(DataFilteringDetailsSchema).optional(),
+    exception_rules: z.array(ExceptionRuleDTOSchema).optional(),
+    exclusions: ExclusionsSchema.optional(),
+    rule1: DataFilteringRuleDTOSchema.optional(),
+    rule2: DataFilteringRuleDTOSchema.optional(),
+  })
+  .passthrough();
+export type DataFilteringProfileRequest = z.infer<typeof DataFilteringProfileRequestSchema>;
+
+/** Response payload returned by GET / PUT on a Data Filtering Profile. */
+export const DataFilteringProfileResponseSchema = z
+  .object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    description: z.string().optional(),
+    tenant_id: z.string().optional(),
+    type: z.string().optional(),
+    data_profile_id: z.number().optional(),
+    direction: z.string().optional(),
+    file_based: z.boolean().optional(),
+    non_file_based: z.boolean().optional(),
+    log_severity: z.string().optional(),
+    scan_type: z.enum(['include', 'exclude']).optional(),
+    is_end_user_coaching_enabled: z.boolean().optional(),
+    is_granular_profile: z.boolean().optional(),
+    is_parent_managed: z.boolean().optional(),
+    euc_template_id: z.string().optional(),
+    version: z.number().optional(),
+    file_type: z.array(z.string()).optional(),
+    audit_metadata: AuditResponseSchema.optional(),
+    criteria_details: z.array(DataFilteringDetailsSchema).optional(),
+    exception_rules: z.array(ExceptionRuleDTOSchema).optional(),
+    exclusions: ExclusionsSchema.optional(),
+    rule1: DataFilteringRuleDTOSchema.optional(),
+    rule2: DataFilteringRuleDTOSchema.optional(),
+  })
+  .passthrough();
+export type DataFilteringProfileResponse = z.infer<typeof DataFilteringProfileResponseSchema>;
+
+/** Spring `Page<DataFilteringProfileResponse>` envelope returned by the list endpoint. */
+export const PageDataFilteringProfileResponseSchema = pageSchema(
+  DataFilteringProfileResponseSchema,
+);
+export type PageDataFilteringProfileResponse = z.infer<
+  typeof PageDataFilteringProfileResponseSchema
+>;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -215,6 +215,40 @@ export {
   Oauth2TokenSchema,
   type Oauth2Token,
 } from './mgmt-oauth.js';
+export { AuditResponseSchema, type AuditResponse } from './dlp-audit.js';
+export {
+  SortObjectSchema,
+  type SortObject,
+  PageableObjectSchema,
+  type PageableObject,
+  pageSchema,
+  type Page,
+} from './dlp-page.js';
+export { jsonNullable, type JsonNullable } from './dlp-json-nullable.js';
+export {
+  AppExclusionSchema,
+  type AppExclusion,
+  URLExclusionSchema,
+  type URLExclusion,
+  ExclusionsSchema,
+  type Exclusions,
+  SourceAttributesSchema,
+  type SourceAttributes,
+  DestinationAttributesSchema,
+  type DestinationAttributes,
+  ExceptionRuleDTOSchema,
+  type ExceptionRuleDTO,
+  DataFilteringRuleDTOSchema,
+  type DataFilteringRuleDTO,
+  DataFilteringDetailsSchema,
+  type DataFilteringDetails,
+  DataFilteringProfileRequestSchema,
+  type DataFilteringProfileRequest,
+  DataFilteringProfileResponseSchema,
+  type DataFilteringProfileResponse,
+  PageDataFilteringProfileResponseSchema,
+  type PageDataFilteringProfileResponse,
+} from './dlp-data-filtering-profile.js';
 export * from './model-security-enums.js';
 export * from './model-security.js';
 export * from './red-team-enums.js';

--- a/test/management/client.spec.ts
+++ b/test/management/client.spec.ts
@@ -8,7 +8,8 @@ import { DlpProfilesClient } from '../../src/management/dlp-profiles.js';
 import { DeploymentProfilesClient } from '../../src/management/deployment-profiles.js';
 import { ScanLogsClient } from '../../src/management/scan-logs.js';
 import { OAuthManagementClient } from '../../src/management/oauth-management.js';
-import { DlpNamespace } from '../../src/management/dlp.js';
+import { DlpNamespace } from '../../src/management/dlp/index.js';
+import { DataFilteringProfilesClient } from '../../src/management/dlp/data-filtering-profiles.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 describe('ManagementClient', () => {
@@ -138,6 +139,15 @@ describe('ManagementClient', () => {
     });
     expect(client.dlp).toBeInstanceOf(DlpNamespace);
     expect(client.dlp.baseUrl).toBe('https://api.dlp.paloaltonetworks.com');
+  });
+
+  it('exposes dlp.dataFilteringProfiles subclient', () => {
+    const client = new ManagementClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+    });
+    expect(client.dlp.dataFilteringProfiles).toBeInstanceOf(DataFilteringProfilesClient);
   });
 
   it('dlpEndpoint option overrides default DLP base URL', () => {

--- a/test/management/dlp/data-filtering-profiles.spec.ts
+++ b/test/management/dlp/data-filtering-profiles.spec.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DataFilteringProfilesClient } from '../../../src/management/dlp/data-filtering-profiles.js';
+import type { AuthAdapter } from '../../../src/http/types.js';
+import { ErrorType } from '../../../src/errors.js';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+
+function authWith401Then200(): AuthAdapter & { refreshes: () => number } {
+  let count = 0;
+  return {
+    prepare: async (req) => req,
+    onUnauthorized: async () => {
+      count++;
+      return true;
+    },
+    refreshes: () => count,
+  } as AuthAdapter & { refreshes: () => number };
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(typeof data === 'string' ? data : JSON.stringify(data)),
+  });
+}
+
+const profileFixture = {
+  id: 'dfp-1',
+  name: 'Finance',
+  file_based: true,
+  non_file_based: false,
+};
+
+const pageFixture = {
+  content: [profileFixture],
+  empty: false,
+  first: true,
+  last: true,
+  number: 0,
+  numberOfElements: 1,
+  size: 20,
+  totalElements: 1,
+  totalPages: 1,
+};
+
+describe('DataFilteringProfilesClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: DataFilteringProfilesClient;
+
+  beforeEach(() => {
+    client = new DataFilteringProfilesClient({
+      baseUrl: 'https://api.dlp.paloaltonetworks.com',
+      auth: passthroughAuth(),
+      numRetries: 1,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('list', () => {
+    it('GETs /v2/api/data-filtering-profiles with no params', async () => {
+      mockFetch(pageFixture);
+      const r = await client.list();
+      expect(r.content).toHaveLength(1);
+      expect(r.content[0].id).toBe('dfp-1');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.dlp.paloaltonetworks.com/v2/api/data-filtering-profiles');
+      expect(init.method).toBe('GET');
+    });
+
+    it('passes page + size as query params', async () => {
+      mockFetch(pageFixture);
+      await client.list({ page: 2, size: 50 });
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('page=2');
+      expect(url).toContain('size=50');
+    });
+
+    it('passes status + name filter params', async () => {
+      mockFetch(pageFixture);
+      await client.list({ status: 'enabled', name: 'finance' });
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('status=enabled');
+      expect(url).toContain('name=finance');
+    });
+
+    it('repeats the sort query parameter once per array entry', async () => {
+      mockFetch(pageFixture);
+      await client.list({ sort: ['name,asc', 'id,desc'] });
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const urlObj = new URL(url);
+      expect(urlObj.searchParams.getAll('sort')).toEqual(['name,asc', 'id,desc']);
+    });
+
+    it('parses the Spring Page envelope and returns typed content', async () => {
+      mockFetch(pageFixture);
+      const r = await client.list();
+      expect(r.totalElements).toBe(1);
+      expect(r.content[0].name).toBe('Finance');
+    });
+
+    it('throws RESPONSE_VALIDATION when the body fails schema parsing', async () => {
+      mockFetch({ content: 'not-an-array' });
+      await expect(client.list()).rejects.toMatchObject({
+        errorType: ErrorType.RESPONSE_VALIDATION,
+      });
+    });
+  });
+
+  describe('get', () => {
+    it('GETs /v2/api/data-filtering-profiles/{resourceId}', async () => {
+      mockFetch(profileFixture);
+      const r = await client.get('dfp-1');
+      expect(r.id).toBe('dfp-1');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.dlp.paloaltonetworks.com/v2/api/data-filtering-profiles/dfp-1');
+      expect(init.method).toBe('GET');
+    });
+
+    it('URL-encodes resourceIds with special characters', async () => {
+      mockFetch(profileFixture);
+      await client.get('weird id/with slash');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('weird%20id%2Fwith%20slash');
+    });
+  });
+
+  describe('replace', () => {
+    it('PUTs the JSON body to /v2/api/data-filtering-profiles/{resourceId}', async () => {
+      mockFetch(profileFixture);
+      const body = { file_based: true, non_file_based: false, description: 'updated' };
+      const r = await client.replace('dfp-1', body);
+      expect(r.id).toBe('dfp-1');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.dlp.paloaltonetworks.com/v2/api/data-filtering-profiles/dfp-1');
+      expect(init.method).toBe('PUT');
+      expect(init.body).toBe(JSON.stringify(body));
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    });
+  });
+
+  describe('auth', () => {
+    it('invokes the auth adapter refresh path on 401', async () => {
+      const auth = authWith401Then200();
+      client = new DataFilteringProfilesClient({
+        baseUrl: 'https://api.dlp.paloaltonetworks.com',
+        auth,
+        numRetries: 1,
+      });
+
+      // First call → 401, second → 200
+      const fetchSpy = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          text: () => Promise.resolve(''),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify(pageFixture)),
+        });
+      globalThis.fetch = fetchSpy;
+
+      const r = await client.list();
+      expect(r.content[0].id).toBe('dfp-1');
+      expect(auth.refreshes()).toBe(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/test/models/dlp-data-filtering-profile.spec.ts
+++ b/test/models/dlp-data-filtering-profile.spec.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AppExclusionSchema,
+  DataFilteringDetailsSchema,
+  DataFilteringProfileRequestSchema,
+  DataFilteringProfileResponseSchema,
+  DataFilteringRuleDTOSchema,
+  DestinationAttributesSchema,
+  ExceptionRuleDTOSchema,
+  ExclusionsSchema,
+  PageDataFilteringProfileResponseSchema,
+  SourceAttributesSchema,
+  URLExclusionSchema,
+} from '../../src/models/dlp-data-filtering-profile.js';
+
+const responseFixture = {
+  id: 'dfp-abc-123',
+  name: 'Finance Files',
+  description: 'Profile for finance department',
+  tenant_id: 'tenant-xyz',
+  type: 'standard',
+  data_profile_id: 4242,
+  direction: 'BOTH',
+  file_based: true,
+  non_file_based: false,
+  log_severity: 'HIGH',
+  scan_type: 'include',
+  is_end_user_coaching_enabled: true,
+  is_granular_profile: false,
+  is_parent_managed: false,
+  euc_template_id: 'euc-1',
+  version: 7,
+  file_type: ['pdf', 'docx'],
+  audit_metadata: {
+    created_at: '2026-01-02T03:04:05Z',
+    created_by: 'alice@example.com',
+    updated_at: '2026-02-03T04:05:06Z',
+    updated_by: 'bob@example.com',
+  },
+  criteria_details: [
+    {
+      action: 'BLOCK',
+      dataProfileId: 99,
+      direction: 'UPLOAD',
+      euc_template_id: 'euc-2',
+      fileBased: 'true',
+      fileTypes: ['csv'],
+      is_end_user_coaching_enabled: true,
+      logSeverity: 'CRITICAL',
+      nonFileBased: 'false',
+      scanType: 'include',
+    },
+  ],
+  exception_rules: [
+    {
+      id: 'ex-1',
+      action: 'ALLOW',
+      data_profile_ids: [1, 2, 3],
+      log_severity: 'MEDIUM',
+      destination_attributes: {
+        match_any: true,
+        app_ids: ['app-1'],
+        url_patterns: ['https://*.example.com'],
+      },
+      source_attributes: {
+        match_any: false,
+        user_group_ids: ['ug-1'],
+        user_ids: ['u-1', 'u-2'],
+      },
+    },
+  ],
+  exclusions: {
+    app_exclusion_list: [{ app_id: 'a-1', app_name: 'A1', type: 'cloud' }],
+    url_exclusion_list: [{ url_id: 'u-1', url_name: 'U1', type: 'regex' }],
+    exclusion_list: {
+      'cc-numbers': ['4111-*', '4222-*'],
+      ssn: ['123-*'],
+    },
+  },
+  rule1: { action: 'BLOCK', response_page: 'rp-1', show_rsp_page: 'true' },
+  rule2: { action: 'ALERT', response_page: 'rp-2', show_rsp_page: 'false' },
+};
+
+describe('AppExclusionSchema', () => {
+  it('parses with all fields', () => {
+    expect(AppExclusionSchema.safeParse({ app_id: 'a', app_name: 'A', type: 't' }).success).toBe(
+      true,
+    );
+  });
+  it('parses with all fields omitted (all optional)', () => {
+    expect(AppExclusionSchema.safeParse({}).success).toBe(true);
+  });
+});
+
+describe('URLExclusionSchema', () => {
+  it('parses with all fields', () => {
+    expect(URLExclusionSchema.safeParse({ type: 't', url_id: 'u', url_name: 'n' }).success).toBe(
+      true,
+    );
+  });
+});
+
+describe('SourceAttributesSchema', () => {
+  it('parses sample source attributes', () => {
+    expect(
+      SourceAttributesSchema.safeParse({
+        match_any: true,
+        user_group_ids: ['g1'],
+        user_ids: ['u1'],
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe('DestinationAttributesSchema', () => {
+  it('parses sample destination attributes', () => {
+    expect(
+      DestinationAttributesSchema.safeParse({
+        match_any: false,
+        app_ids: ['a1'],
+        url_patterns: ['p1'],
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe('DataFilteringRuleDTOSchema', () => {
+  it('parses a rule', () => {
+    expect(
+      DataFilteringRuleDTOSchema.safeParse({
+        action: 'BLOCK',
+        response_page: 'rp',
+        show_rsp_page: 'true',
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe('DataFilteringDetailsSchema', () => {
+  it('parses details with camelCase keys per spec', () => {
+    expect(
+      DataFilteringDetailsSchema.safeParse({
+        action: 'ALERT',
+        dataProfileId: 7,
+        direction: 'DOWNLOAD',
+        fileBased: 'true',
+        fileTypes: ['pdf'],
+        is_end_user_coaching_enabled: true,
+        logSeverity: 'LOW',
+        nonFileBased: 'false',
+        scanType: 'exclude',
+        euc_template_id: 'euc',
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe('ExceptionRuleDTOSchema', () => {
+  it('accepts ALLOW/ALERT/BLOCK actions', () => {
+    for (const action of ['ALLOW', 'ALERT', 'BLOCK'] as const) {
+      expect(ExceptionRuleDTOSchema.safeParse({ action }).success).toBe(true);
+    }
+  });
+  it('rejects unknown action', () => {
+    expect(ExceptionRuleDTOSchema.safeParse({ action: 'DENY' }).success).toBe(false);
+  });
+  it('accepts all 5 log_severity values', () => {
+    for (const log_severity of ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFORMATIONAL'] as const) {
+      expect(ExceptionRuleDTOSchema.safeParse({ log_severity }).success).toBe(true);
+    }
+  });
+});
+
+describe('ExclusionsSchema', () => {
+  it('parses exclusion_list as a record of string-array', () => {
+    const r = ExclusionsSchema.safeParse({
+      exclusion_list: { foo: ['a', 'b'], bar: ['c'] },
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.exclusion_list).toEqual({ foo: ['a', 'b'], bar: ['c'] });
+    }
+  });
+  it('rejects exclusion_list values that are not string arrays', () => {
+    expect(ExclusionsSchema.safeParse({ exclusion_list: { foo: [1, 2] } }).success).toBe(false);
+  });
+});
+
+describe('DataFilteringProfileRequestSchema', () => {
+  it('parses a minimal request (required fields only)', () => {
+    expect(
+      DataFilteringProfileRequestSchema.safeParse({
+        file_based: true,
+        non_file_based: false,
+      }).success,
+    ).toBe(true);
+  });
+  it('rejects when file_based is missing', () => {
+    expect(DataFilteringProfileRequestSchema.safeParse({ non_file_based: false }).success).toBe(
+      false,
+    );
+  });
+  it('rejects when non_file_based is missing', () => {
+    expect(DataFilteringProfileRequestSchema.safeParse({ file_based: true }).success).toBe(false);
+  });
+  it('accepts all direction enums', () => {
+    for (const direction of ['BOTH', 'UPLOAD', 'DOWNLOAD'] as const) {
+      expect(
+        DataFilteringProfileRequestSchema.safeParse({
+          file_based: true,
+          non_file_based: false,
+          direction,
+        }).success,
+      ).toBe(true);
+    }
+  });
+  it('rejects unknown direction', () => {
+    expect(
+      DataFilteringProfileRequestSchema.safeParse({
+        file_based: true,
+        non_file_based: false,
+        direction: 'SIDEWAYS',
+      }).success,
+    ).toBe(false);
+  });
+  it('accepts all log_severity enums', () => {
+    for (const log_severity of ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFORMATIONAL'] as const) {
+      expect(
+        DataFilteringProfileRequestSchema.safeParse({
+          file_based: true,
+          non_file_based: false,
+          log_severity,
+        }).success,
+      ).toBe(true);
+    }
+  });
+  it('accepts include/exclude scan_type', () => {
+    for (const scan_type of ['include', 'exclude'] as const) {
+      expect(
+        DataFilteringProfileRequestSchema.safeParse({
+          file_based: true,
+          non_file_based: false,
+          scan_type,
+        }).success,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('DataFilteringProfileResponseSchema', () => {
+  it('parses the full response fixture', () => {
+    const r = DataFilteringProfileResponseSchema.safeParse(responseFixture);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.id).toBe('dfp-abc-123');
+      expect(r.data.audit_metadata?.created_by).toBe('alice@example.com');
+      expect(r.data.exclusions?.exclusion_list?.['cc-numbers']).toEqual(['4111-*', '4222-*']);
+    }
+  });
+  it('passes through unknown fields (forward-compat)', () => {
+    expect(
+      DataFilteringProfileResponseSchema.safeParse({
+        ...responseFixture,
+        future_field: 'ok',
+      }).success,
+    ).toBe(true);
+  });
+  it('parses an empty response', () => {
+    expect(DataFilteringProfileResponseSchema.safeParse({}).success).toBe(true);
+  });
+});
+
+describe('PageDataFilteringProfileResponseSchema', () => {
+  it('parses a Spring Page envelope with content', () => {
+    const r = PageDataFilteringProfileResponseSchema.safeParse({
+      content: [responseFixture],
+      empty: false,
+      first: true,
+      last: true,
+      number: 0,
+      numberOfElements: 1,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+      pageable: {
+        offset: 0,
+        pageNumber: 0,
+        pageSize: 20,
+        paged: true,
+        unpaged: false,
+        sort: { empty: true, sorted: false, unsorted: true },
+      },
+      sort: { empty: true, sorted: false, unsorted: true },
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.content).toHaveLength(1);
+      expect(r.data.content[0].name).toBe('Finance Files');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

First DLP subclient on top of the foundation merged in #148.

- `management.dlp.dataFilteringProfiles.list(params?)` — Spring `Page<>` envelope, with `page`, `size`, `sort[]`, `status` (`enabled`/`disabled`), and `name` (partial-match) filters
- `management.dlp.dataFilteringProfiles.get(resourceId)`
- `management.dlp.dataFilteringProfiles.replace(resourceId, body)` — full-replace PUT
- Typed Zod schemas for the full nested graph: `DataFilteringProfileRequest`/`Response`, `DataFilteringDetails`, `ExceptionRuleDTO` (with `ALLOW`/`ALERT`/`BLOCK` and 5-level severity enums), `Exclusions` (with `z.record(z.array(z.string()))` for the open-keyed `exclusion_list`), `Source`/`DestinationAttributes`, `App`/`URLExclusion`, `DataFilteringRuleDTO`
- Restructure `src/management/dlp.ts` → `src/management/dlp/` so subsequent DLP subclients can live alongside

## Test plan

- [x] `npm test` — 1101 / 1101 pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format` clean
- [x] 23 schema tests (happy-path fixture, enum acceptance/rejection, required-field enforcement, forward-compat passthrough, exclusion_list record shape, Spring Page envelope)
- [x] 10 subclient tests (all 5 list filter params incl. multi-value `sort`, URL encoding, PUT body+headers, schema-error path, OAuth 401 refresh)
- [ ] Reviewer: confirm `replace(...)` (PUT full-replace) reads naturally vs `update(...)`; rename if needed

Closes #143