### PR TITLE
feat(dlp): add Dictionaries subclient

### DIFF
--- a/.changeset/0026-dlp-dictionaries.md
+++ b/.changeset/0026-dlp-dictionaries.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Add DLP Dictionaries subclient (`management.dlp.dictionaries`) covering list, create (multipart keyword-file upload), get, replace (PUT, handles 200+body or 204 empty), patch (JSON Merge Patch), and delete. Adds `allowEmptyBody` flag on the HTTP request pipeline so endpoints that return either 200 with a body or 204 with no body parse correctly.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,6 +89,7 @@ export const DEFAULT_DLP_ENDPOINT = 'https://api.dlp.paloaltonetworks.com';
 // DLP API paths
 export const DLP_DATA_FILTERING_PROFILES_PATH = '/v2/api/data-filtering-profiles';
 export const DLP_DATA_PATTERNS_PATH = '/v2/api/data-patterns';
+export const DLP_DICTIONARIES_PATH = '/v2/api/dictionaries';
 
 // Model Security API defaults
 export const DEFAULT_MODEL_SEC_DATA_ENDPOINT = 'https://api.sase.paloaltonetworks.com/aims/data';

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -71,6 +71,13 @@ export async function request<TResponse = void>(spec: RequestSpec<TResponse>): P
     return undefined as TResponse;
   }
 
+  // Endpoints that may return either 200+body or 204+no-body (e.g. DLP dictionaries PUT)
+  // opt into returning `undefined` when the body is empty rather than the usual `{}`
+  // hydration. Skips schema validation entirely on empty body.
+  if (spec.allowEmptyBody && !text) {
+    return undefined as TResponse;
+  }
+
   let parsed: unknown;
   try {
     // Hydrate empty 2xx bodies as `{}` so all-optional-fields schemas parse cleanly

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -53,6 +53,12 @@ export interface RequestSpec<TResponse = void> {
   // is consumed at runtime.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   responseSchema?: z.ZodType<TResponse, any, any>;
+  /**
+   * When true, an empty 2xx body resolves to `undefined` instead of hydrating to `{}` for
+   * schema validation. Used by DLP endpoints that can return either 200 + body or 204 + no
+   * body from the same call (e.g. `PUT /v2/api/dictionaries/{id}`).
+   */
+  allowEmptyBody?: boolean;
   numRetries: number;
   auth: AuthAdapter;
 }

--- a/src/management/dlp/dictionaries.ts
+++ b/src/management/dlp/dictionaries.ts
@@ -1,0 +1,195 @@
+import { DLP_DICTIONARIES_PATH } from '../../constants.js';
+import { request } from '../../http/request.js';
+import type { AuthAdapter } from '../../http/types.js';
+import {
+  DictionaryResponseSchema,
+  PageDictionaryResponseSchema,
+  type DictionaryPatchRequest,
+  type DictionaryRequest,
+  type DictionaryResponse,
+  type PageDictionaryResponse,
+} from '../../models/dlp-dictionary.js';
+
+/** Accepted shapes for the dictionary keyword-file payload. */
+export type DictionaryFileInput = Blob | ArrayBuffer | Uint8Array | string;
+
+/** Query parameters accepted by {@link DictionariesClient.list}. */
+export interface DictionaryListParams {
+  page?: number;
+  size?: number;
+  sort?: string[];
+  /** When true, the API includes the `keywords` array in each response entry. */
+  keywords?: boolean;
+}
+
+/** Parameters accepted by {@link DictionariesClient.get}. */
+export interface DictionaryGetParams {
+  /** When true, request that the response include the dictionary's keyword list. */
+  includeKeywords?: boolean;
+}
+
+/** Parameters accepted by {@link DictionariesClient.create} and {@link DictionariesClient.replace}. */
+export interface DictionaryUploadParams {
+  metadata: DictionaryRequest;
+  file: DictionaryFileInput;
+  /** When true, the response will include the keyword list (`keywords=true` query param). */
+  includeKeywords?: boolean;
+}
+
+/** @internal */
+export interface DictionariesClientOptions {
+  baseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+}
+
+function toBlob(file: DictionaryFileInput): Blob {
+  if (file instanceof Blob) return file;
+  if (typeof file === 'string') return new Blob([file], { type: 'text/plain' });
+  if (file instanceof Uint8Array) return new Blob([file as Uint8Array<ArrayBuffer>]);
+  return new Blob([file]);
+}
+
+function buildFormData(metadata: DictionaryRequest, file: DictionaryFileInput): FormData {
+  const fd = new FormData();
+  fd.append(
+    'json',
+    new Blob([JSON.stringify(metadata)], { type: 'application/json' }),
+    'metadata.json',
+  );
+  fd.append('file', toBlob(file), metadata.original_file_name);
+  return fd;
+}
+
+/**
+ * Client for the DLP Dictionaries resource (`/v2/api/dictionaries`).
+ *
+ * POST and PUT take a multipart body with `json` (the metadata) and `file` (the keyword
+ * file) parts. PATCH uses JSON Merge Patch. DELETE returns 204 No Content. PUT can return
+ * either a 200 with the resource or a 204 with no body, so {@link DictionariesClient.replace}
+ * returns `DictionaryResponse | undefined`.
+ */
+export class DictionariesClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: DictionariesClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /** List dictionaries. Returns the Spring `Page<>` envelope verbatim. */
+  async list(params: DictionaryListParams = {}): Promise<PageDictionaryResponse> {
+    const queryParams: Record<string, string | string[]> = {};
+    if (params.page !== undefined) queryParams.page = String(params.page);
+    if (params.size !== undefined) queryParams.size = String(params.size);
+    if (params.sort !== undefined) queryParams.sort = params.sort;
+    if (params.keywords !== undefined) queryParams.keywords = String(params.keywords);
+
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: DLP_DICTIONARIES_PATH,
+      params: queryParams,
+      responseSchema: PageDictionaryResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Create a dictionary by uploading a keyword file. Sends a multipart body — the SDK does
+   * not set Content-Type so the runtime can write the correct boundary.
+   */
+  async create({
+    metadata,
+    file,
+    includeKeywords,
+  }: DictionaryUploadParams): Promise<DictionaryResponse> {
+    const queryParams: Record<string, string> = {};
+    if (includeKeywords !== undefined) queryParams.keywords = String(includeKeywords);
+
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: DLP_DICTIONARIES_PATH,
+      params: queryParams,
+      formData: buildFormData(metadata, file),
+      responseSchema: DictionaryResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /** Get a single dictionary by resource ID, optionally including its keyword list. */
+  async get(resourceId: string, params: DictionaryGetParams = {}): Promise<DictionaryResponse> {
+    const queryParams: Record<string, string> = {};
+    if (params.includeKeywords !== undefined) queryParams.keywords = String(params.includeKeywords);
+
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${DLP_DICTIONARIES_PATH}/${encodeURIComponent(resourceId)}`,
+      params: queryParams,
+      responseSchema: DictionaryResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Full-replace the dictionary at `resourceId` via multipart upload.
+   *
+   * The API may respond with either 200 + body or 204 + no body — both are normal. Returns
+   * the parsed body on 200 and `undefined` on 204.
+   */
+  async replace(
+    resourceId: string,
+    { metadata, file, includeKeywords }: DictionaryUploadParams,
+  ): Promise<DictionaryResponse | undefined> {
+    const queryParams: Record<string, string> = {};
+    if (includeKeywords !== undefined) queryParams.keywords = String(includeKeywords);
+
+    return request<DictionaryResponse | undefined>({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${DLP_DICTIONARIES_PATH}/${encodeURIComponent(resourceId)}`,
+      params: queryParams,
+      formData: buildFormData(metadata, file),
+      responseSchema: DictionaryResponseSchema.optional(),
+      allowEmptyBody: true,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Partial update via JSON Merge Patch (RFC 7396). Sent with
+   * `Content-Type: application/merge-patch+json`.
+   */
+  async patch(resourceId: string, body: DictionaryPatchRequest): Promise<DictionaryResponse> {
+    return request({
+      method: 'PATCH',
+      baseUrl: this.baseUrl,
+      path: `${DLP_DICTIONARIES_PATH}/${encodeURIComponent(resourceId)}`,
+      body,
+      contentType: 'application/merge-patch+json',
+      responseSchema: DictionaryResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /** Delete a dictionary. Resolves to `undefined` on the 204 No Content response. */
+  async delete(resourceId: string): Promise<void> {
+    await request<void>({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${DLP_DICTIONARIES_PATH}/${encodeURIComponent(resourceId)}`,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/management/dlp/index.ts
+++ b/src/management/dlp/index.ts
@@ -1,6 +1,7 @@
 import type { AuthAdapter } from '../../http/types.js';
 import { DataFilteringProfilesClient } from './data-filtering-profiles.js';
 import { DataPatternsClient } from './data-patterns.js';
+import { DictionariesClient } from './dictionaries.js';
 
 /** @internal */
 export interface DlpNamespaceOptions {
@@ -23,6 +24,7 @@ export class DlpNamespace {
 
   public readonly dataFilteringProfiles: DataFilteringProfilesClient;
   public readonly dataPatterns: DataPatternsClient;
+  public readonly dictionaries: DictionariesClient;
 
   constructor(opts: DlpNamespaceOptions) {
     this.baseUrl = opts.baseUrl;
@@ -35,6 +37,11 @@ export class DlpNamespace {
       numRetries: opts.numRetries,
     });
     this.dataPatterns = new DataPatternsClient({
+      baseUrl: opts.baseUrl,
+      auth: opts.auth,
+      numRetries: opts.numRetries,
+    });
+    this.dictionaries = new DictionariesClient({
       baseUrl: opts.baseUrl,
       auth: opts.auth,
       numRetries: opts.numRetries,

--- a/src/management/index.ts
+++ b/src/management/index.ts
@@ -17,3 +17,10 @@ export {
   type DataFilteringProfileListParams,
 } from './dlp/data-filtering-profiles.js';
 export { DataPatternsClient, type DataPatternListParams } from './dlp/data-patterns.js';
+export {
+  DictionariesClient,
+  type DictionaryFileInput,
+  type DictionaryListParams,
+  type DictionaryGetParams,
+  type DictionaryUploadParams,
+} from './dlp/dictionaries.js';

--- a/src/models/dlp-dictionary.ts
+++ b/src/models/dlp-dictionary.ts
@@ -1,0 +1,149 @@
+import { z } from 'zod';
+import { AuditResponseSchema } from './dlp-audit.js';
+import { jsonNullable } from './dlp-json-nullable.js';
+import { pageSchema } from './dlp-page.js';
+
+/** Top-level dictionary type. */
+export const DictionaryTypeSchema = z.enum(['predefined', 'custom']);
+export type DictionaryType = z.infer<typeof DictionaryTypeSchema>;
+
+/**
+ * Dictionary category. Note `'Source Code'` includes a literal space — preserved verbatim per
+ * the OpenAPI spec.
+ */
+export const DictionaryCategorySchema = z.enum([
+  'Academic',
+  'Confidential',
+  'Employment',
+  'Financial',
+  'Government',
+  'Healthcare',
+  'Legal',
+  'Marketing',
+  'Source Code',
+]);
+export type DictionaryCategory = z.infer<typeof DictionaryCategorySchema>;
+
+/** Classification tag values supported on a dictionary. */
+export const DictionaryClassificationSchema = z.enum(['pab', 'endpoint']);
+export type DictionaryClassification = z.infer<typeof DictionaryClassificationSchema>;
+
+/** Detection technique reported on a dictionary response. Shares the technique vocabulary
+ *  used by data-patterns. */
+export const DictionaryDetectionTechniqueSchema = z.enum([
+  'edm',
+  'document_fingerprint',
+  'trainable_classifier',
+  'ml_document',
+  'regex',
+  'weighted_regex',
+  'ml',
+  'titus_tag',
+  'wildfire',
+  'file_property',
+  'dictionary',
+  'pab',
+  'document_classifier',
+]);
+export type DictionaryDetectionTechnique = z.infer<typeof DictionaryDetectionTechniqueSchema>;
+
+/** Detection sub-technique reported on a dictionary response. */
+export const DictionaryDetectionSubTechniqueSchema = z.enum([
+  'dnn',
+  'gamma',
+  'ml_gateway',
+  'encoding',
+  'password_protected',
+  'encryption',
+  'compression',
+  'threshold',
+]);
+export type DictionaryDetectionSubTechnique = z.infer<typeof DictionaryDetectionSubTechniqueSchema>;
+
+/** Metadata about the uploaded keyword file. */
+export const DictionaryMetaDataDTOSchema = z
+  .object({
+    number_of_keywords: z.number().optional(),
+    original_file_name: z.string().optional(),
+    original_file_size_in_byte: z.number().optional(),
+  })
+  .passthrough();
+export type DictionaryMetaDataDTO = z.infer<typeof DictionaryMetaDataDTOSchema>;
+
+/** Tag block attached to a dictionary. */
+export const DictionaryTagsSchema = z
+  .object({
+    classification: z.array(DictionaryClassificationSchema).optional(),
+  })
+  .passthrough();
+export type DictionaryTags = z.infer<typeof DictionaryTagsSchema>;
+
+/** Free-form k/v extension entry returned on dictionary responses. */
+export const ResourceModelExtensionSchema = z
+  .object({
+    key: z.string().optional(),
+    value: z.string().optional(),
+  })
+  .passthrough();
+export type ResourceModelExtension = z.infer<typeof ResourceModelExtensionSchema>;
+
+/**
+ * Metadata payload sent as the `json` part of the multipart upload on POST/PUT. The binary
+ * keyword `file` part is supplied separately.
+ */
+export const DictionaryRequestSchema = z
+  .object({
+    category: DictionaryCategorySchema,
+    name: z.string(),
+    original_file_name: z.string(),
+    region_name: z.string(),
+    description: z.string().optional(),
+    is_case_sensitive: z.boolean().optional(),
+    type: DictionaryTypeSchema.optional(),
+  })
+  .passthrough();
+export type DictionaryRequest = z.infer<typeof DictionaryRequestSchema>;
+
+/**
+ * Request payload for PATCH (JSON Merge Patch, RFC 7396). `category`, `name`, and
+ * `original_file_name` are required even on patch — every other field may be omitted or
+ * set to `null`.
+ */
+export const DictionaryPatchRequestSchema = z
+  .object({
+    category: DictionaryCategorySchema,
+    name: z.string(),
+    original_file_name: z.string(),
+    description: jsonNullable(z.string()),
+    is_case_sensitive: jsonNullable(z.boolean()),
+    region_name: jsonNullable(z.string()),
+  })
+  .passthrough();
+export type DictionaryPatchRequest = z.infer<typeof DictionaryPatchRequestSchema>;
+
+/** Response payload returned by GET / POST / PUT / PATCH on a dictionary. */
+export const DictionaryResponseSchema = z
+  .object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    description: z.string().optional(),
+    category: z.string().optional(),
+    region_name: z.string().optional(),
+    type: DictionaryTypeSchema.optional(),
+    is_case_sensitive: z.boolean().optional(),
+    is_parent_managed: z.boolean().optional(),
+    detection_technique: DictionaryDetectionTechniqueSchema.optional(),
+    detection_sub_technique: DictionaryDetectionSubTechniqueSchema.optional(),
+    dictionary_metadata: DictionaryMetaDataDTOSchema.optional(),
+    /** Keyword list — populated only when `keywords=true` is passed as a query parameter. */
+    keywords: z.array(z.string()).optional(),
+    tags: DictionaryTagsSchema.optional(),
+    attributes: z.array(ResourceModelExtensionSchema).optional(),
+    audit_metadata: AuditResponseSchema.optional(),
+  })
+  .passthrough();
+export type DictionaryResponse = z.infer<typeof DictionaryResponseSchema>;
+
+/** Spring `Page<DictionaryResponse>` envelope returned by the list endpoint. */
+export const PageDictionaryResponseSchema = pageSchema(DictionaryResponseSchema);
+export type PageDictionaryResponse = z.infer<typeof PageDictionaryResponseSchema>;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -226,6 +226,32 @@ export {
 } from './dlp-page.js';
 export { jsonNullable, type JsonNullable } from './dlp-json-nullable.js';
 export {
+  DictionaryTypeSchema,
+  type DictionaryType,
+  DictionaryCategorySchema,
+  type DictionaryCategory,
+  DictionaryClassificationSchema,
+  type DictionaryClassification,
+  DictionaryDetectionTechniqueSchema,
+  type DictionaryDetectionTechnique,
+  DictionaryDetectionSubTechniqueSchema,
+  type DictionaryDetectionSubTechnique,
+  DictionaryMetaDataDTOSchema,
+  type DictionaryMetaDataDTO,
+  DictionaryTagsSchema,
+  type DictionaryTags,
+  ResourceModelExtensionSchema,
+  type ResourceModelExtension,
+  DictionaryRequestSchema,
+  type DictionaryRequest,
+  DictionaryPatchRequestSchema,
+  type DictionaryPatchRequest,
+  DictionaryResponseSchema,
+  type DictionaryResponse,
+  PageDictionaryResponseSchema,
+  type PageDictionaryResponse,
+} from './dlp-dictionary.js';
+export {
   DataPatternTypeSchema,
   type DataPatternType,
   DataPatternTechniqueSchema,

--- a/test/http/request.spec.ts
+++ b/test/http/request.spec.ts
@@ -415,6 +415,38 @@ describe('request — schema parsing', () => {
     expect(result).toEqual({});
   });
 
+  it('returns undefined on empty 2xx body when allowEmptyBody=true (skips schema)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(undefined, 204));
+
+    const result = await request<Item | undefined>({
+      method: 'PUT',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items/1',
+      responseSchema: ItemSchema.optional(),
+      allowEmptyBody: true,
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('still parses body with schema when allowEmptyBody=true and body is present', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ id: 'i-1', name: 'X' }, 200));
+
+    const result = await request<Item | undefined>({
+      method: 'PUT',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items/1',
+      responseSchema: ItemSchema.optional(),
+      allowEmptyBody: true,
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    expect(result).toEqual({ id: 'i-1', name: 'X' });
+  });
+
   it('still fails RESPONSE_VALIDATION on empty 2xx body when schema has required fields', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(undefined, 200));
 

--- a/test/management/client.spec.ts
+++ b/test/management/client.spec.ts
@@ -11,6 +11,7 @@ import { OAuthManagementClient } from '../../src/management/oauth-management.js'
 import { DlpNamespace } from '../../src/management/dlp/index.js';
 import { DataFilteringProfilesClient } from '../../src/management/dlp/data-filtering-profiles.js';
 import { DataPatternsClient } from '../../src/management/dlp/data-patterns.js';
+import { DictionariesClient } from '../../src/management/dlp/dictionaries.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 describe('ManagementClient', () => {
@@ -158,6 +159,15 @@ describe('ManagementClient', () => {
       tsgId: '1',
     });
     expect(client.dlp.dataPatterns).toBeInstanceOf(DataPatternsClient);
+  });
+
+  it('exposes dlp.dictionaries subclient', () => {
+    const client = new ManagementClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+    });
+    expect(client.dlp.dictionaries).toBeInstanceOf(DictionariesClient);
   });
 
   it('dlpEndpoint option overrides default DLP base URL', () => {

--- a/test/management/dlp/dictionaries.spec.ts
+++ b/test/management/dlp/dictionaries.spec.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DictionariesClient } from '../../../src/management/dlp/dictionaries.js';
+import type { AuthAdapter } from '../../../src/http/types.js';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () =>
+      Promise.resolve(
+        data === undefined ? '' : typeof data === 'string' ? data : JSON.stringify(data),
+      ),
+  });
+}
+
+const dictionaryFixture = {
+  id: 'dict-1',
+  name: 'PII',
+  category: 'Confidential',
+  region_name: 'us',
+  type: 'custom',
+};
+
+const pageFixture = {
+  content: [dictionaryFixture],
+  empty: false,
+  first: true,
+  last: true,
+  number: 0,
+  numberOfElements: 1,
+  size: 20,
+  totalElements: 1,
+  totalPages: 1,
+};
+
+describe('DictionariesClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: DictionariesClient;
+
+  beforeEach(() => {
+    client = new DictionariesClient({
+      baseUrl: 'https://api.dlp.paloaltonetworks.com',
+      auth: passthroughAuth(),
+      numRetries: 1,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('list', () => {
+    it('GETs /v2/api/dictionaries with no params', async () => {
+      mockFetch(pageFixture);
+      const r = await client.list();
+      expect(r.content[0].id).toBe('dict-1');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.dlp.paloaltonetworks.com/v2/api/dictionaries');
+      expect(init.method).toBe('GET');
+    });
+
+    it('passes page/size/sort + keywords=true', async () => {
+      mockFetch(pageFixture);
+      await client.list({ page: 1, size: 50, sort: ['name,asc'], keywords: true });
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const u = new URL(url);
+      expect(u.searchParams.get('page')).toBe('1');
+      expect(u.searchParams.get('size')).toBe('50');
+      expect(u.searchParams.getAll('sort')).toEqual(['name,asc']);
+      expect(u.searchParams.get('keywords')).toBe('true');
+    });
+
+    it('passes keywords=false explicitly when requested', async () => {
+      mockFetch(pageFixture);
+      await client.list({ keywords: false });
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(new URL(url).searchParams.get('keywords')).toBe('false');
+    });
+  });
+
+  describe('create', () => {
+    it('POSTs multipart with json + file parts, no Content-Type header', async () => {
+      mockFetch(dictionaryFixture, 201);
+      const file = new Blob(['ssn\ndob\n'], { type: 'text/plain' });
+      const metadata = {
+        category: 'Confidential' as const,
+        name: 'PII',
+        original_file_name: 'pii.txt',
+        region_name: 'us',
+      };
+      const r = await client.create({ metadata, file });
+      expect(r.id).toBe('dict-1');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.dlp.paloaltonetworks.com/v2/api/dictionaries');
+      expect(init.method).toBe('POST');
+      expect(init.body).toBeInstanceOf(FormData);
+      const fd = init.body as FormData;
+      expect(fd.get('file')).toBeInstanceOf(Blob);
+      const jsonPart = fd.get('json');
+      expect(jsonPart).toBeInstanceOf(Blob);
+      const jsonText = await (jsonPart as Blob).text();
+      expect(JSON.parse(jsonText)).toEqual(metadata);
+      expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+    });
+
+    it('passes keywords=true query param when requested', async () => {
+      mockFetch(dictionaryFixture, 201);
+      await client.create({
+        metadata: {
+          category: 'Financial',
+          name: 'D',
+          original_file_name: 'd.txt',
+          region_name: 'us',
+        },
+        file: new Blob(['x']),
+        includeKeywords: true,
+      });
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(new URL(url).searchParams.get('keywords')).toBe('true');
+    });
+
+    it('accepts string content as file (normalized to Blob)', async () => {
+      mockFetch(dictionaryFixture, 201);
+      await client.create({
+        metadata: {
+          category: 'Financial',
+          name: 'D',
+          original_file_name: 'd.txt',
+          region_name: 'us',
+        },
+        file: 'hello',
+      });
+      const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const fd = init.body as FormData;
+      const filePart = fd.get('file');
+      expect(filePart).toBeInstanceOf(Blob);
+      expect(await (filePart as Blob).text()).toBe('hello');
+    });
+  });
+
+  describe('get', () => {
+    it('GETs /v2/api/dictionaries/{id} with no query', async () => {
+      mockFetch(dictionaryFixture);
+      const r = await client.get('dict-1');
+      expect(r.id).toBe('dict-1');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.dlp.paloaltonetworks.com/v2/api/dictionaries/dict-1');
+      expect(init.method).toBe('GET');
+    });
+
+    it('passes keywords=true when includeKeywords requested', async () => {
+      mockFetch(dictionaryFixture);
+      await client.get('dict-1', { includeKeywords: true });
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(new URL(url).searchParams.get('keywords')).toBe('true');
+    });
+
+    it('URL-encodes resourceIds with special characters', async () => {
+      mockFetch(dictionaryFixture);
+      await client.get('weird id/slash');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('weird%20id%2Fslash');
+    });
+  });
+
+  describe('replace', () => {
+    it('PUTs multipart with json + file parts', async () => {
+      mockFetch(dictionaryFixture);
+      await client.replace('dict-1', {
+        metadata: {
+          category: 'Confidential',
+          name: 'PII',
+          original_file_name: 'pii.txt',
+          region_name: 'us',
+        },
+        file: new Blob(['new content']),
+      });
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.dlp.paloaltonetworks.com/v2/api/dictionaries/dict-1');
+      expect(init.method).toBe('PUT');
+      expect(init.body).toBeInstanceOf(FormData);
+      expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+    });
+
+    it('returns DictionaryResponse on 200', async () => {
+      mockFetch(dictionaryFixture, 200);
+      const r = await client.replace('dict-1', {
+        metadata: {
+          category: 'Confidential',
+          name: 'PII',
+          original_file_name: 'pii.txt',
+          region_name: 'us',
+        },
+        file: new Blob(['x']),
+      });
+      expect(r?.id).toBe('dict-1');
+    });
+
+    it('returns undefined on 204 no body', async () => {
+      mockFetch(undefined, 204);
+      const r = await client.replace('dict-1', {
+        metadata: {
+          category: 'Confidential',
+          name: 'PII',
+          original_file_name: 'pii.txt',
+          region_name: 'us',
+        },
+        file: new Blob(['x']),
+      });
+      expect(r).toBeUndefined();
+    });
+  });
+
+  describe('patch', () => {
+    it('PATCHes with Content-Type application/merge-patch+json', async () => {
+      mockFetch(dictionaryFixture);
+      const body = {
+        category: 'Confidential' as const,
+        name: 'PII',
+        original_file_name: 'pii.txt',
+        description: null,
+      };
+      const r = await client.patch('dict-1', body);
+      expect(r.id).toBe('dict-1');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.dlp.paloaltonetworks.com/v2/api/dictionaries/dict-1');
+      expect(init.method).toBe('PATCH');
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+        'application/merge-patch+json',
+      );
+      expect(init.body).toBe(JSON.stringify(body));
+    });
+  });
+
+  describe('delete', () => {
+    it('DELETEs /v2/api/dictionaries/{id} and resolves undefined on 204', async () => {
+      mockFetch(undefined, 204);
+      const r = await client.delete('dict-1');
+      expect(r).toBeUndefined();
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.dlp.paloaltonetworks.com/v2/api/dictionaries/dict-1');
+      expect(init.method).toBe('DELETE');
+    });
+  });
+});

--- a/test/models/dlp-dictionary.spec.ts
+++ b/test/models/dlp-dictionary.spec.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DictionaryMetaDataDTOSchema,
+  DictionaryPatchRequestSchema,
+  DictionaryRequestSchema,
+  DictionaryResponseSchema,
+  DictionaryTagsSchema,
+  PageDictionaryResponseSchema,
+  ResourceModelExtensionSchema,
+} from '../../src/models/dlp-dictionary.js';
+
+const responseFixture = {
+  id: 'dict-abc',
+  name: 'PII Keywords',
+  description: 'PII keyword list',
+  category: 'Confidential',
+  region_name: 'us',
+  type: 'custom',
+  is_case_sensitive: false,
+  is_parent_managed: false,
+  detection_technique: 'dictionary',
+  detection_sub_technique: 'threshold',
+  dictionary_metadata: {
+    number_of_keywords: 42,
+    original_file_name: 'pii.txt',
+    original_file_size_in_byte: 2048,
+  },
+  keywords: ['ssn', 'dob'],
+  tags: { classification: ['pab', 'endpoint'] },
+  attributes: [
+    { key: 'k1', value: 'v1' },
+    { key: 'k2', value: 'v2' },
+  ],
+  audit_metadata: {
+    created_at: '2026-01-01T00:00:00Z',
+    created_by: 'alice@example.com',
+    updated_at: '2026-02-01T00:00:00Z',
+    updated_by: 'bob@example.com',
+  },
+};
+
+describe('DictionaryMetaDataDTOSchema', () => {
+  it('parses sample metadata', () => {
+    expect(
+      DictionaryMetaDataDTOSchema.safeParse({
+        number_of_keywords: 5,
+        original_file_name: 'a.txt',
+        original_file_size_in_byte: 100,
+      }).success,
+    ).toBe(true);
+  });
+  it('parses empty metadata', () => {
+    expect(DictionaryMetaDataDTOSchema.safeParse({}).success).toBe(true);
+  });
+});
+
+describe('DictionaryTagsSchema', () => {
+  it('accepts pab/endpoint classification values', () => {
+    for (const cls of ['pab', 'endpoint'] as const) {
+      expect(DictionaryTagsSchema.safeParse({ classification: [cls] }).success).toBe(true);
+    }
+  });
+  it('rejects unknown classification value', () => {
+    expect(DictionaryTagsSchema.safeParse({ classification: ['mobile'] }).success).toBe(false);
+  });
+});
+
+describe('ResourceModelExtensionSchema', () => {
+  it('parses k/v pair', () => {
+    expect(ResourceModelExtensionSchema.safeParse({ key: 'k', value: 'v' }).success).toBe(true);
+  });
+});
+
+describe('DictionaryRequestSchema', () => {
+  it('parses a minimal valid request (required: category, name, original_file_name, region_name)', () => {
+    expect(
+      DictionaryRequestSchema.safeParse({
+        category: 'Financial',
+        name: 'D1',
+        original_file_name: 'd.txt',
+        region_name: 'us',
+      }).success,
+    ).toBe(true);
+  });
+  it('accepts all 9 category enum values (including "Source Code" with a space)', () => {
+    for (const category of [
+      'Academic',
+      'Confidential',
+      'Employment',
+      'Financial',
+      'Government',
+      'Healthcare',
+      'Legal',
+      'Marketing',
+      'Source Code',
+    ] as const) {
+      expect(
+        DictionaryRequestSchema.safeParse({
+          category,
+          name: 'D',
+          original_file_name: 'd.txt',
+          region_name: 'us',
+        }).success,
+      ).toBe(true);
+    }
+  });
+  it('rejects unknown category', () => {
+    expect(
+      DictionaryRequestSchema.safeParse({
+        category: 'Mystery',
+        name: 'D',
+        original_file_name: 'd.txt',
+        region_name: 'us',
+      }).success,
+    ).toBe(false);
+  });
+  it('rejects when category missing', () => {
+    expect(
+      DictionaryRequestSchema.safeParse({
+        name: 'D',
+        original_file_name: 'd.txt',
+        region_name: 'us',
+      }).success,
+    ).toBe(false);
+  });
+  it('rejects when name missing', () => {
+    expect(
+      DictionaryRequestSchema.safeParse({
+        category: 'Financial',
+        original_file_name: 'd.txt',
+        region_name: 'us',
+      }).success,
+    ).toBe(false);
+  });
+  it('rejects when original_file_name missing', () => {
+    expect(
+      DictionaryRequestSchema.safeParse({
+        category: 'Financial',
+        name: 'D',
+        region_name: 'us',
+      }).success,
+    ).toBe(false);
+  });
+  it('rejects when region_name missing', () => {
+    expect(
+      DictionaryRequestSchema.safeParse({
+        category: 'Financial',
+        name: 'D',
+        original_file_name: 'd.txt',
+      }).success,
+    ).toBe(false);
+  });
+  it('accepts predefined / custom type', () => {
+    for (const type of ['predefined', 'custom'] as const) {
+      expect(
+        DictionaryRequestSchema.safeParse({
+          category: 'Financial',
+          name: 'D',
+          original_file_name: 'd.txt',
+          region_name: 'us',
+          type,
+        }).success,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('DictionaryPatchRequestSchema', () => {
+  it('parses a patch clearing description with null', () => {
+    const r = DictionaryPatchRequestSchema.safeParse({
+      category: 'Financial',
+      name: 'D',
+      original_file_name: 'd.txt',
+      description: null,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.description).toBeNull();
+  });
+  it('parses a patch with all jsonNullable fields omitted', () => {
+    expect(
+      DictionaryPatchRequestSchema.safeParse({
+        category: 'Financial',
+        name: 'D',
+        original_file_name: 'd.txt',
+      }).success,
+    ).toBe(true);
+  });
+  it('rejects when required name missing', () => {
+    expect(
+      DictionaryPatchRequestSchema.safeParse({
+        category: 'Financial',
+        original_file_name: 'd.txt',
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('DictionaryResponseSchema', () => {
+  it('parses the full response fixture', () => {
+    const r = DictionaryResponseSchema.safeParse(responseFixture);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.id).toBe('dict-abc');
+      expect(r.data.dictionary_metadata?.number_of_keywords).toBe(42);
+      expect(r.data.keywords).toEqual(['ssn', 'dob']);
+    }
+  });
+  it('accepts all 8 detection_sub_technique enum values', () => {
+    for (const v of [
+      'dnn',
+      'gamma',
+      'ml_gateway',
+      'encoding',
+      'password_protected',
+      'encryption',
+      'compression',
+      'threshold',
+    ] as const) {
+      expect(DictionaryResponseSchema.safeParse({ detection_sub_technique: v }).success).toBe(true);
+    }
+  });
+  it('accepts all 13 detection_technique enum values', () => {
+    for (const v of [
+      'edm',
+      'document_fingerprint',
+      'trainable_classifier',
+      'ml_document',
+      'regex',
+      'weighted_regex',
+      'ml',
+      'titus_tag',
+      'wildfire',
+      'file_property',
+      'dictionary',
+      'pab',
+      'document_classifier',
+    ] as const) {
+      expect(DictionaryResponseSchema.safeParse({ detection_technique: v }).success).toBe(true);
+    }
+  });
+  it('rejects unknown detection_sub_technique', () => {
+    expect(DictionaryResponseSchema.safeParse({ detection_sub_technique: 'mystery' }).success).toBe(
+      false,
+    );
+  });
+  it('passes through unknown fields', () => {
+    expect(
+      DictionaryResponseSchema.safeParse({ ...responseFixture, future_field: 'ok' }).success,
+    ).toBe(true);
+  });
+});
+
+describe('PageDictionaryResponseSchema', () => {
+  it('parses a Spring Page envelope', () => {
+    const r = PageDictionaryResponseSchema.safeParse({
+      content: [responseFixture],
+      empty: false,
+      first: true,
+      last: true,
+      number: 0,
+      numberOfElements: 1,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+      pageable: {
+        offset: 0,
+        pageNumber: 0,
+        pageSize: 20,
+        paged: true,
+        unpaged: false,
+        sort: { empty: true, sorted: false, unsorted: true },
+      },
+      sort: { empty: true, sorted: false, unsorted: true },
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.content[0].id).toBe('dict-abc');
+  });
+});


### PR DESCRIPTION
## Summary
- `management.dlp.dictionaries` with list / create / get / replace (PUT) / patch (merge-patch) / delete
- Multipart keyword-file upload (`Blob | ArrayBuffer | Uint8Array | string` input)
- PUT can return 200 + body or 204 empty — both handled cleanly
- New `allowEmptyBody` flag on the HTTP request pipeline for 200-or-204 endpoints

## Test plan
- [x] Unit tests for schemas (22)
- [x] Unit tests for subclient (14)
- [x] HTTP request `allowEmptyBody` regression tests
- [x] Lint / format / typecheck / full test suite

Closes #145