### PR TITLE
docs(dlp): mkdocs pages, examples, preflight + live-audit polish

### DIFF
--- a/.changeset/0028-dlp-docs-release.md
+++ b/.changeset/0028-dlp-docs-release.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Documentation and release polish for the DLP API coverage milestone. Adds `docs/services/dlp/` with one mkdocs page per subclient (data filtering profiles, data patterns, data profiles, dictionaries), runnable `examples/mgmt-dlp-*.ts` walkthroughs with matching `example:dlp-*` npm scripts, recursive `specs/` traversal in the preflight script (with a whitelist limiting DLP loading to implemented specs), and read-only DLP list probes in `scripts/live-audit.ts`.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ client.dlpProfiles; // DLP data profile listing
 client.deploymentProfiles; // Deployment profile listing
 client.scanLogs; // Scan activity log queries
 client.oauth; // OAuth token management (get/invalidate)
+
+// DLP namespace — separate base URL, same OAuth credentials:
+client.dlp.dataFilteringProfiles; // list / get / replace
+client.dlp.dataPatterns; // full CRUD + JSON Merge Patch
+client.dlp.dataProfiles; // CRUD without DELETE + JSON Merge Patch
+client.dlp.dictionaries; // multipart upload + CRUD + JSON Merge Patch
 ```
 
 ### Model Security — ML Model Scanning (OAuth2)

--- a/docs/services/dlp/data-filtering-profiles.md
+++ b/docs/services/dlp/data-filtering-profiles.md
@@ -1,0 +1,53 @@
+# DLP — Data Filtering Profiles
+
+Manage Data Filtering Profiles on the DLP service (`/v2/api/data-filtering-profiles`).
+
+Subclient lives at `client.dlp.dataFilteringProfiles`. Surface is read + full-replace only — the underlying API does not expose create or delete.
+
+Spec source: [`specs/dlp/DataFilteringProfiles.yaml`](https://github.com/cdot65/prisma-airs-sdk/blob/main/specs/dlp/DataFilteringProfiles.yaml)
+
+## Setup
+
+Same OAuth2 credentials as the rest of the Management API — reuses `PANW_MGMT_CLIENT_ID`, `PANW_MGMT_CLIENT_SECRET`, `PANW_MGMT_TSG_ID`. The DLP base URL defaults to `https://api.dlp.paloaltonetworks.com`; override via the `dlpEndpoint` constructor option (no env var).
+
+```ts
+import { ManagementClient } from '@cdot65/prisma-airs-sdk';
+
+const client = new ManagementClient();
+```
+
+## list
+
+Paginated `Page<DataFilteringProfileResponse>`. Optional filters: `status` (`enabled`/`disabled`), `name` (partial match). Sort entries emit one `sort=` query param each.
+
+```ts
+const page = await client.dlp.dataFilteringProfiles.list({
+  page: 0,
+  size: 20,
+  sort: ['name,asc'],
+  status: 'enabled',
+});
+console.log(page.totalElements, page.content.length);
+```
+
+## get
+
+```ts
+const profile = await client.dlp.dataFilteringProfiles.get('dfp-123');
+console.log(profile.name, profile.direction);
+```
+
+## replace
+
+Full PUT — body must satisfy `DataFilteringProfileRequest`. `file_based` and `non_file_based` are required. Returns the updated resource.
+
+```ts
+const updated = await client.dlp.dataFilteringProfiles.replace('dfp-123', {
+  file_based: true,
+  non_file_based: true,
+  description: 'Outbound HR block',
+  direction: 'UPLOAD',
+  log_severity: 'HIGH',
+  data_profile_id: 1001,
+});
+```

--- a/docs/services/dlp/data-patterns.md
+++ b/docs/services/dlp/data-patterns.md
@@ -1,0 +1,84 @@
+# DLP — Data Patterns
+
+Manage Data Patterns on the DLP service (`/v2/api/data-patterns`).
+
+Subclient lives at `client.dlp.dataPatterns`. Full CRUD: list, create, get, replace (PUT), patch (RFC 7396 JSON Merge Patch), delete. DELETE soft-deletes (archives) server-side.
+
+Spec source: [`specs/dlp/DataPatterns.yaml`](https://github.com/cdot65/prisma-airs-sdk/blob/main/specs/dlp/DataPatterns.yaml)
+
+## Setup
+
+```ts
+import { ManagementClient } from '@cdot65/prisma-airs-sdk';
+
+const client = new ManagementClient();
+```
+
+## list
+
+```ts
+const page = await client.dlp.dataPatterns.list({
+  page: 0,
+  size: 20,
+  sort: ['name,asc', 'id,desc'],
+});
+for (const p of page.content) console.log(p.id, p.name);
+```
+
+## create
+
+`name`, `type`, and `detection_config` are required.
+
+```ts
+const created = await client.dlp.dataPatterns.create({
+  name: 'cc-numbers-strict',
+  type: 'custom',
+  detection_config: { technique: 'regex' },
+  matching_rules: {
+    regexes: [{ regex: '\\b\\d{16}\\b', weight: 1.0 }],
+  },
+});
+console.log(created.id);
+```
+
+## get
+
+```ts
+const pattern = await client.dlp.dataPatterns.get('pat-001');
+```
+
+## replace
+
+Full PUT.
+
+```ts
+const replaced = await client.dlp.dataPatterns.replace('pat-001', {
+  name: 'cc-numbers-strict',
+  type: 'custom',
+  detection_config: { technique: 'regex' },
+  matching_rules: {
+    regexes: [{ regex: '\\b\\d{15,16}\\b', weight: 1.0 }],
+  },
+});
+```
+
+## patch
+
+JSON Merge Patch. `name`, `type`, and `detection_config` are required even on patch. Other fields use nullable semantics — omit to leave unchanged, send `null` to clear.
+
+```ts
+const patched = await client.dlp.dataPatterns.patch('pat-001', {
+  name: 'cc-numbers-strict-v2',
+  type: 'custom',
+  detection_config: { technique: 'regex' },
+  description: null,
+});
+```
+
+## delete
+
+204 No Content. Returns `void`.
+
+```ts
+await client.dlp.dataPatterns.delete('pat-001');
+```

--- a/docs/services/dlp/data-profiles.md
+++ b/docs/services/dlp/data-profiles.md
@@ -1,0 +1,87 @@
+# DLP — Data Profiles
+
+Manage Data Profiles on the DLP service (`/v2/api/data-profiles`).
+
+Subclient lives at `client.dlp.dataProfiles`. CRUD without DELETE — the spec does not expose a DELETE for data profiles. To remove a profile, patch its lifecycle state via the underlying API (typically `profile_status: 'deleted'`).
+
+Spec source: [`specs/dlp/DataProfiles.yaml`](https://github.com/cdot65/prisma-airs-sdk/blob/main/specs/dlp/DataProfiles.yaml)
+
+## Setup
+
+```ts
+import { ManagementClient } from '@cdot65/prisma-airs-sdk';
+
+const client = new ManagementClient();
+```
+
+## list
+
+```ts
+const page = await client.dlp.dataProfiles.list({
+  page: 0,
+  size: 20,
+  sort: ['name,asc'],
+});
+for (const p of page.content) console.log(p.id, p.name, p.profile_type);
+```
+
+## create
+
+Two rule shapes — `expression_tree` (recursive boolean tree of detection rule items) or `multi_profile` (composes other profiles by id).
+
+```ts
+const created = await client.dlp.dataProfiles.create({
+  name: 'PII Confidential',
+  detection_rules: [
+    {
+      rule_type: 'expression_tree',
+      expression_tree: {
+        operator_type: 'and',
+        rule_item: {
+          detection_technique: 'regex',
+          match_type: 'include',
+        },
+      },
+    },
+  ],
+});
+console.log(created.id);
+```
+
+## get
+
+```ts
+const profile = await client.dlp.dataProfiles.get('prof-1');
+```
+
+## replace
+
+Full PUT.
+
+```ts
+const replaced = await client.dlp.dataProfiles.replace('prof-1', {
+  name: 'PII Confidential v2',
+  detection_rules: [
+    {
+      rule_type: 'multi_profile',
+      multi_profile: {
+        operator_type: 'or',
+        data_profile_ids: [1001, 1002],
+      },
+    },
+  ],
+});
+```
+
+## patch
+
+JSON Merge Patch. `name` and `profile_type` are required; other fields use nullable semantics — omit to leave unchanged, send `null` to clear.
+
+```ts
+const patched = await client.dlp.dataProfiles.patch('prof-1', {
+  name: 'PII Confidential',
+  profile_type: 'advanced',
+  description: 'Updated description',
+  detection_rules: null,
+});
+```

--- a/docs/services/dlp/dictionaries.md
+++ b/docs/services/dlp/dictionaries.md
@@ -1,0 +1,91 @@
+# DLP — Dictionaries
+
+Manage Dictionaries on the DLP service (`/v2/api/dictionaries`).
+
+Subclient lives at `client.dlp.dictionaries`. Full CRUD with a multipart upload twist: `create` and `replace` take a metadata object + keyword file. PATCH uses JSON Merge Patch. PUT can return 200+body or 204+empty — `replace()` returns `DictionaryResponse | undefined`.
+
+Spec source: [`specs/dlp/Dictionaries.yaml`](https://github.com/cdot65/prisma-airs-sdk/blob/main/specs/dlp/Dictionaries.yaml)
+
+## Setup
+
+```ts
+import { ManagementClient } from '@cdot65/prisma-airs-sdk';
+
+const client = new ManagementClient();
+```
+
+## list
+
+`keywords: true` includes the keyword array in each response entry.
+
+```ts
+const page = await client.dlp.dictionaries.list({
+  page: 0,
+  size: 20,
+  keywords: false,
+});
+for (const d of page.content) console.log(d.id, d.name);
+```
+
+## create
+
+Multipart upload — `file` accepts `Blob | ArrayBuffer | Uint8Array | string`. The SDK builds the multipart boundary; do not set Content-Type manually. `category`, `name`, `original_file_name`, and `region_name` are required on the metadata.
+
+```ts
+const created = await client.dlp.dictionaries.create({
+  metadata: {
+    category: 'Confidential',
+    name: 'project-codenames',
+    original_file_name: 'codenames.txt',
+    region_name: 'us-west-2',
+    type: 'custom',
+  },
+  file: 'alpha\nbravo\ncharlie\n',
+  includeKeywords: true,
+});
+console.log(created.id);
+```
+
+## get
+
+```ts
+const dict = await client.dlp.dictionaries.get('dict-1', { includeKeywords: true });
+```
+
+## replace
+
+Full multipart replace. Returns `DictionaryResponse | undefined` since the API may answer 200 with body or 204 with no body.
+
+```ts
+const replaced = await client.dlp.dictionaries.replace('dict-1', {
+  metadata: {
+    category: 'Confidential',
+    name: 'project-codenames',
+    original_file_name: 'codenames.txt',
+    region_name: 'us-west-2',
+    type: 'custom',
+  },
+  file: 'alpha\nbravo\ncharlie\ndelta\n',
+});
+if (replaced) console.log('200:', replaced.id);
+else console.log('204 — empty body');
+```
+
+## patch
+
+JSON Merge Patch. `category`, `name`, and `original_file_name` are required even on patch. Other fields are nullable — omit to leave unchanged, send `null` to clear.
+
+```ts
+const patched = await client.dlp.dictionaries.patch('dict-1', {
+  category: 'Confidential',
+  name: 'project-codenames-v2',
+  original_file_name: 'codenames.txt',
+  description: null,
+});
+```
+
+## delete
+
+```ts
+await client.dlp.dictionaries.delete('dict-1');
+```

--- a/examples/mgmt-dlp-data-filtering-profiles.ts
+++ b/examples/mgmt-dlp-data-filtering-profiles.ts
@@ -1,0 +1,50 @@
+import { ManagementClient, AISecSDKException } from '@cdot65/prisma-airs-sdk';
+
+async function main() {
+  const client = new ManagementClient();
+
+  try {
+    console.log('Listing data filtering profiles...');
+    const page = await client.dlp.dataFilteringProfiles.list({ size: 5 });
+    console.log(`  totalElements=${page.totalElements} returned=${page.content.length}`);
+    for (const p of page.content) {
+      console.log(`  - ${p.name ?? '(unnamed)'} id=${p.id ?? '?'} direction=${p.direction ?? '?'}`);
+    }
+
+    if (page.content.length === 0) {
+      console.log('No profiles to inspect — done.');
+      return;
+    }
+
+    const first = page.content[0];
+    const id = first.id;
+    if (!id) {
+      console.log('First profile has no id — skipping get/replace.');
+      return;
+    }
+
+    console.log(`\nGetting profile ${id}...`);
+    const got = await client.dlp.dataFilteringProfiles.get(id);
+    console.log(
+      `  name=${got.name ?? '?'} file_based=${got.file_based} non_file_based=${got.non_file_based}`,
+    );
+
+    // NOTE: replace is destructive — uncomment + adapt to a profile you own before running.
+    // const replaced = await client.dlp.dataFilteringProfiles.replace(id, {
+    //   file_based: got.file_based ?? true,
+    //   non_file_based: got.non_file_based ?? true,
+    //   description: got.description,
+    //   data_profile_id: got.data_profile_id,
+    // });
+    // console.log('Replaced:', replaced.name);
+  } catch (error) {
+    if (error instanceof AISecSDKException) {
+      console.error('Error:', error.message);
+      console.error('Type:', error.errorType);
+    } else {
+      throw error;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/mgmt-dlp-data-patterns.ts
+++ b/examples/mgmt-dlp-data-patterns.ts
@@ -1,0 +1,54 @@
+import { ManagementClient, AISecSDKException } from '@cdot65/prisma-airs-sdk';
+
+async function main() {
+  const client = new ManagementClient();
+
+  try {
+    console.log('Listing data patterns...');
+    const page = await client.dlp.dataPatterns.list({ size: 5, sort: ['name,asc'] });
+    console.log(`  totalElements=${page.totalElements} returned=${page.content.length}`);
+    for (const p of page.content) {
+      console.log(`  - ${p.name ?? '(unnamed)'} id=${p.id ?? '?'} type=${p.type ?? '?'}`);
+    }
+
+    console.log('\nCreating example custom pattern...');
+    const created = await client.dlp.dataPatterns.create({
+      name: `sdk-example-${Date.now()}`,
+      type: 'custom',
+      detection_config: { technique: 'regex' },
+      matching_rules: {
+        regexes: [{ regex: '\\bexample\\b', weight: 1.0 }],
+      },
+    });
+    console.log(`  created id=${created.id}`);
+
+    const id = created.id;
+    if (id) {
+      console.log(`\nGetting ${id}...`);
+      const got = await client.dlp.dataPatterns.get(id);
+      console.log(`  name=${got.name}`);
+
+      console.log('\nPatching description...');
+      const patched = await client.dlp.dataPatterns.patch(id, {
+        name: got.name ?? 'example',
+        type: got.type ?? 'custom',
+        detection_config: got.detection_config ?? { technique: 'regex' },
+        description: 'Updated by SDK example',
+      });
+      console.log(`  description=${patched.description}`);
+
+      console.log('\nDeleting...');
+      await client.dlp.dataPatterns.delete(id);
+      console.log('  deleted (204)');
+    }
+  } catch (error) {
+    if (error instanceof AISecSDKException) {
+      console.error('Error:', error.message);
+      console.error('Type:', error.errorType);
+    } else {
+      throw error;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/mgmt-dlp-data-profiles.ts
+++ b/examples/mgmt-dlp-data-profiles.ts
@@ -1,0 +1,59 @@
+import { ManagementClient, AISecSDKException } from '@cdot65/prisma-airs-sdk';
+
+async function main() {
+  const client = new ManagementClient();
+
+  try {
+    console.log('Listing data profiles...');
+    const page = await client.dlp.dataProfiles.list({ size: 5, sort: ['name,asc'] });
+    console.log(`  totalElements=${page.totalElements} returned=${page.content.length}`);
+    for (const p of page.content) {
+      console.log(`  - ${p.name ?? '(unnamed)'} id=${p.id ?? '?'} type=${p.profile_type ?? '?'}`);
+    }
+
+    console.log('\nCreating example data profile...');
+    const created = await client.dlp.dataProfiles.create({
+      name: `sdk-example-${Date.now()}`,
+      detection_rules: [
+        {
+          rule_type: 'expression_tree',
+          expression_tree: {
+            operator_type: 'and',
+            rule_item: {
+              detection_technique: 'regex',
+              match_type: 'include',
+            },
+          },
+        },
+      ],
+    });
+    console.log(`  created id=${created.id}`);
+
+    const id = created.id;
+    if (id) {
+      console.log(`\nGetting ${id}...`);
+      const got = await client.dlp.dataProfiles.get(id);
+      console.log(`  name=${got.name} profile_type=${got.profile_type}`);
+
+      console.log('\nPatching description...');
+      const patched = await client.dlp.dataProfiles.patch(id, {
+        name: got.name ?? 'example',
+        profile_type: got.profile_type ?? 'advanced',
+        description: 'Updated by SDK example',
+      });
+      console.log(`  description=${patched.description}`);
+
+      // Data profiles have no DELETE — lifecycle removal is patch-driven.
+      console.log('\nNo DELETE endpoint for data profiles — done.');
+    }
+  } catch (error) {
+    if (error instanceof AISecSDKException) {
+      console.error('Error:', error.message);
+      console.error('Type:', error.errorType);
+    } else {
+      throw error;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/mgmt-dlp-dictionaries.ts
+++ b/examples/mgmt-dlp-dictionaries.ts
@@ -1,0 +1,62 @@
+import { ManagementClient, AISecSDKException } from '@cdot65/prisma-airs-sdk';
+
+async function main() {
+  const client = new ManagementClient();
+
+  try {
+    console.log('Listing dictionaries...');
+    const page = await client.dlp.dictionaries.list({ size: 5 });
+    console.log(`  totalElements=${page.totalElements} returned=${page.content.length}`);
+    for (const d of page.content) {
+      console.log(`  - ${d.name ?? '(unnamed)'} id=${d.id ?? '?'}`);
+    }
+
+    console.log('\nCreating example dictionary (multipart upload)...');
+    const created = await client.dlp.dictionaries.create({
+      metadata: {
+        category: 'Confidential',
+        name: `sdk-example-${Date.now()}`,
+        original_file_name: 'keywords.txt',
+        region_name: 'us-west-2',
+        type: 'custom',
+      },
+      file: 'alpha\nbravo\ncharlie\n',
+      includeKeywords: true,
+    });
+    console.log(`  created id=${created.id}`);
+
+    const id = created.id;
+    if (id) {
+      console.log(`\nGetting ${id} with keywords...`);
+      const got = await client.dlp.dictionaries.get(id, { includeKeywords: true });
+      console.log(`  name=${got.name} keywords=${got.keywords?.length ?? 0}`);
+
+      console.log('\nReplacing with extra keyword (PUT may return 200+body or 204+empty)...');
+      const replaced = await client.dlp.dictionaries.replace(id, {
+        metadata: {
+          category: 'Confidential',
+          name: got.name ?? 'example',
+          original_file_name: 'keywords.txt',
+          region_name: got.region_name ?? 'us-west-2',
+          type: 'custom',
+        },
+        file: 'alpha\nbravo\ncharlie\ndelta\n',
+      });
+      if (replaced) console.log(`  200 — id=${replaced.id ?? '?'}`);
+      else console.log('  204 — empty body');
+
+      console.log('\nDeleting...');
+      await client.dlp.dictionaries.delete(id);
+      console.log('  deleted (204)');
+    }
+  } catch (error) {
+    if (error instanceof AISecSDKException) {
+      console.error('Error:', error.message);
+      console.error('Type:', error.errorType);
+    } else {
+      throw error;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,11 @@ nav:
       - OAuth Lifecycle: services/oauth-lifecycle.md
       - Model Security API: services/model-security-api.md
       - Red Team API: services/red-team-api.md
+      - DLP:
+          - Data Filtering Profiles: services/dlp/data-filtering-profiles.md
+          - Data Patterns: services/dlp/data-patterns.md
+          - Data Profiles: services/dlp/data-profiles.md
+          - Dictionaries: services/dlp/dictionaries.md
   - Examples:
       - API Key Rotation: examples/api-key-rotation.md
   - Reference:

--- a/package.json
+++ b/package.json
@@ -64,7 +64,11 @@
     "example:profiles-get": "npx tsx examples/profiles-get-validation.ts",
     "example:profiles-crud": "npx tsx examples/profiles-crud-validation.ts",
     "example:oauth-lifecycle": "npx tsx examples/oauth-lifecycle-validation.ts",
-    "example:red-team-mgmt": "npx tsx examples/red-team-mgmt-validation.ts"
+    "example:red-team-mgmt": "npx tsx examples/red-team-mgmt-validation.ts",
+    "example:dlp-data-filtering-profiles": "npx tsx --env-file=.env examples/mgmt-dlp-data-filtering-profiles.ts",
+    "example:dlp-data-patterns": "npx tsx --env-file=.env examples/mgmt-dlp-data-patterns.ts",
+    "example:dlp-data-profiles": "npx tsx --env-file=.env examples/mgmt-dlp-data-profiles.ts",
+    "example:dlp-dictionaries": "npx tsx --env-file=.env examples/mgmt-dlp-dictionaries.ts"
   },
   "dependencies": {
     "zod": "^3.24.0"

--- a/scripts/live-audit.ts
+++ b/scripts/live-audit.ts
@@ -68,6 +68,27 @@ function buildManagementProbes(): void {
             filter: 'all',
           }),
       },
+      // ── DLP list endpoints (separate base URL, same OAuth credentials) ──
+      {
+        domain: 'mgmt',
+        endpoint: 'dlp.dataFilteringProfiles.list',
+        call: () => c.dlp.dataFilteringProfiles.list({ size: 10 }),
+      },
+      {
+        domain: 'mgmt',
+        endpoint: 'dlp.dataPatterns.list',
+        call: () => c.dlp.dataPatterns.list({ size: 10 }),
+      },
+      {
+        domain: 'mgmt',
+        endpoint: 'dlp.dataProfiles.list',
+        call: () => c.dlp.dataProfiles.list({ size: 10 }),
+      },
+      {
+        domain: 'mgmt',
+        endpoint: 'dlp.dictionaries.list',
+        call: () => c.dlp.dictionaries.list({ size: 10 }),
+      },
     );
   });
 }

--- a/scripts/preflight-schemas.ts
+++ b/scripts/preflight-schemas.ts
@@ -33,13 +33,38 @@ interface ModelSchema {
   sourceFile: string;
 }
 
+/**
+ * DLP specs the SDK actually models. Other yaml files in `specs/dlp/` describe DLP endpoints
+ * we have not implemented yet — loading them creates name collisions (e.g. their `Policy`
+ * component differs from the mgmt `Policy`) and false drift against unrelated Zod schemas.
+ */
+const DLP_SPEC_WHITELIST = new Set([
+  'DataFilteringProfiles.yaml',
+  'DataPatterns.yaml',
+  'DataProfiles.yaml',
+  'Dictionaries.yaml',
+]);
+
+async function findSpecFiles(dir: string, parentName?: string): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await findSpecFiles(full, entry.name)));
+    } else if (entry.isFile() && (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml'))) {
+      if (parentName === 'dlp' && !DLP_SPEC_WHITELIST.has(entry.name)) continue;
+      out.push(full);
+    }
+  }
+  return out;
+}
+
 async function loadAllSpecs(): Promise<Map<string, OpenAPIV3.SchemaObject>> {
-  const entries = await readdir(SPECS_DIR);
+  const files = await findSpecFiles(SPECS_DIR);
   const merged = new Map<string, OpenAPIV3.SchemaObject>();
   const collisions: string[] = [];
-  for (const file of entries) {
-    if (!file.endsWith('.yaml') && !file.endsWith('.yml')) continue;
-    const path = join(SPECS_DIR, file);
+  for (const path of files) {
     const map = await loadSpec(path);
     for (const [name, schema] of map) {
       if (merged.has(name)) {

--- a/scripts/preflight/allowlist.ts
+++ b/scripts/preflight/allowlist.ts
@@ -270,6 +270,167 @@ export const PREFLIGHT_ALLOWLIST: AllowlistEntry[] = [
     kind: 'extra-field',
     reason: 'API returns `action` on URL filter entries; not in upstream OpenAPI.',
   },
+
+  // ── DLP Page<T> envelopes ────────────────────────────────────────────────────
+  // The Spring `Page<>` envelope marks `content` optional in the OpenAPI spec, but in practice
+  // every list response includes a (possibly empty) `content` array. Zod requires it so callers
+  // can iterate without first probing for the field.
+  {
+    schema: 'PageDataFilteringProfileResponse',
+    pathSubstring: '$',
+    kind: 'extra-required-field',
+    reason: 'pageSchema() requires `content`; API always returns it (possibly empty).',
+  },
+  {
+    schema: 'PageDataPatternResponse',
+    pathSubstring: '$',
+    kind: 'extra-required-field',
+    reason: 'pageSchema() requires `content`; API always returns it (possibly empty).',
+  },
+  {
+    schema: 'PageDataProfileResponse',
+    pathSubstring: '$',
+    kind: 'extra-required-field',
+    reason: 'pageSchema() requires `content`; API always returns it (possibly empty).',
+  },
+  {
+    schema: 'PageDictionaryResponse',
+    pathSubstring: '$',
+    kind: 'extra-required-field',
+    reason: 'pageSchema() requires `content`; API always returns it (possibly empty).',
+  },
+
+  // ── DLP JSON Merge Patch — jsonNullable() vs spec `nullable: true` ───────────
+  // RFC 7396 Merge Patch needs the explicit-null distinction. The `jsonNullable()` helper
+  // wraps each field in `nullable().optional()`, which zod-to-json-schema renders as a
+  // `{ anyOf | type: object }` shape that doesn't equal the spec's bare nullable string/array.
+  // The wire shape matches; only the JSON Schema rendering differs.
+  {
+    schema: 'DataPatternPatchRequest',
+    pathSubstring: '$.name',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() renders differently from spec `nullable: true`; wire shape matches.',
+  },
+  {
+    schema: 'DataPatternPatchRequest',
+    pathSubstring: '$.type',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+  {
+    schema: 'DataPatternPatchRequest',
+    pathSubstring: '$.description',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+  {
+    schema: 'DataPatternPatchRequest',
+    pathSubstring: '$.detection_config',
+    reason:
+      'Patch reuses create-side DataPatternDetectionConfigSchema with `technique` required; ' +
+      'spec leaves it optional. Sending `null` clears via RFC 7396 — required-ness only ' +
+      'applies when the field is present.',
+  },
+  {
+    schema: 'DataPatternPatchRequest',
+    pathSubstring: '$.matching_rules',
+    kind: 'extra-field',
+    reason: 'Patch reuses create-side DataPatternMatchingRulesSchema; spec uses a slimmer shape.',
+  },
+  {
+    schema: 'DataPatternPatchRequest',
+    pathSubstring: '$.tags',
+    kind: 'extra-field',
+    reason: 'Patch reuses create-side DataPatternTagsSchema; spec uses a slimmer shape.',
+  },
+  {
+    schema: 'DataProfilePatchRequest',
+    pathSubstring: '$.name',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+  {
+    schema: 'DataProfilePatchRequest',
+    pathSubstring: '$.profile_type',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+  {
+    schema: 'DataProfilePatchRequest',
+    pathSubstring: '$.description',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+  {
+    schema: 'DataProfilePatchRequest',
+    pathSubstring: '$.detection_rules',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable(array) rendering; wire shape matches.',
+  },
+  {
+    schema: 'DictionaryPatchRequest',
+    pathSubstring: '$.category',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+  {
+    schema: 'DictionaryPatchRequest',
+    pathSubstring: '$.name',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+  {
+    schema: 'DictionaryPatchRequest',
+    pathSubstring: '$.original_file_name',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+  {
+    schema: 'DictionaryPatchRequest',
+    pathSubstring: '$.description',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+  {
+    schema: 'DictionaryPatchRequest',
+    pathSubstring: '$.is_case_sensitive',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+  {
+    schema: 'DictionaryPatchRequest',
+    pathSubstring: '$.region_name',
+    kind: 'type-mismatch',
+    reason: 'jsonNullable() rendering; wire shape matches.',
+  },
+
+  // ── DLP DetectionRule discriminated-union literals ───────────────────────────
+  // The Zod `z.discriminatedUnion('rule_type', ...)` adds a required literal `rule_type` field
+  // to each arm. The OpenAPI spec uses a sibling `discriminator` block without redeclaring
+  // `rule_type` on the subtypes. The wire shape is identical; only the schema modeling differs.
+  {
+    schema: 'DefaultTreeDetectionRule',
+    pathSubstring: '$',
+    reason: 'Discriminator literal + branch field added in Zod for tagged-union narrowing.',
+  },
+  {
+    schema: 'MultiProfileDetectionRule',
+    pathSubstring: '$',
+    reason: 'Discriminator literal + branch field added in Zod for tagged-union narrowing.',
+  },
+
+  // ── DLP DetectionRuleItem — combined-passthrough union ───────────────────────
+  // The OpenAPI spec marks `detection_technique` as a discriminator across 4 subtypes
+  // (DataPattern, Dictionary, DocumentType, EDM) but every subtype's enum lists all 13
+  // technique values — there is no real partition. The Zod schema therefore unions all
+  // subtype fields onto one passthrough object. Field-level discrimination is left to callers
+  // who know which technique they configured.
+  {
+    schema: 'DetectionRuleItem',
+    pathSubstring: '$',
+    kind: 'extra-field',
+    reason: 'Combined passthrough union of all 4 OpenAPI subtypes — see schema JSDoc.',
+  },
 ];
 
 /**


### PR DESCRIPTION
Closes #147

## Summary

- 4 new mkdocs pages under `docs/services/dlp/` (data-filtering-profiles, data-patterns, data-profiles, dictionaries) wired into the Services nav
- 4 runnable `examples/mgmt-dlp-*.ts` walkthroughs + matching `example:dlp-*` npm scripts
- Recursive `specs/` traversal in `scripts/preflight-schemas.ts` with a whitelist that loads only the implemented DLP yaml files (prevents `Policy` collision with mgmt)
- ~24 allowlist entries in `scripts/preflight/allowlist.ts` for expected Zod-vs-OpenAPI divergences (pageSchema content required, jsonNullable merge-patch rendering, discriminator literals, combined passthrough unions)
- DLP list probes added to `scripts/live-audit.ts`
- README updated with the `client.dlp.*` namespace bullets
- Changeset: patch bump (`0028-dlp-docs-release.md`)

## Test plan

- [x] `pnpm format` clean
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1236/1236 pass
- [x] Preflight: 89 acknowledged drift, 0 unacknowledged
- [ ] `pnpm docs:build` (verified locally; rebuilds on merge)
- [ ] CI green