### PR TITLE
docs(dlp): expand DLP pages with worked use-case examples

### DIFF
--- a/.changeset/0029-dlp-docs-walkthroughs.md
+++ b/.changeset/0029-dlp-docs-walkthroughs.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Expand DLP documentation: each of the four `docs/services/dlp/` pages (`data-filtering-profiles`, `data-patterns`, `data-profiles`, `dictionaries`) now includes a required-fields reference table, two contrived but realistic use-case walkthroughs (scenario → input → expected JSON output → assertion-style validation), error-handling patterns, and cross-links between subclients.

--- a/docs/services/dlp/data-filtering-profiles.md
+++ b/docs/services/dlp/data-filtering-profiles.md
@@ -2,7 +2,7 @@
 
 Manage Data Filtering Profiles on the DLP service (`/v2/api/data-filtering-profiles`).
 
-Subclient lives at `client.dlp.dataFilteringProfiles`. Surface is read + full-replace only — the underlying API does not expose create or delete.
+Subclient lives at `client.dlp.dataFilteringProfiles`. Surface is **read + full-replace only** — the underlying API does not expose create or delete. To onboard a brand-new profile, provision it via the Strata Cloud Manager UI first, then manage it through this SDK.
 
 Spec source: [`specs/dlp/DataFilteringProfiles.yaml`](https://github.com/cdot65/prisma-airs-sdk/blob/main/specs/dlp/DataFilteringProfiles.yaml)
 
@@ -16,7 +16,23 @@ import { ManagementClient } from '@cdot65/prisma-airs-sdk';
 const client = new ManagementClient();
 ```
 
-## list
+## Required fields (PUT body)
+
+| Field             | Type                                                           | Required | Notes                                   |
+| ----------------- | -------------------------------------------------------------- | -------- | --------------------------------------- |
+| `file_based`      | `boolean`                                                      | ✅       | Enables file-content scanning           |
+| `non_file_based`  | `boolean`                                                      | ✅       | Enables non-file (chat/prompt) scanning |
+| `direction`       | `'BOTH' \| 'UPLOAD' \| 'DOWNLOAD'`                             | —        | Defaults server-side                    |
+| `log_severity`    | `'CRITICAL' \| 'HIGH' \| 'MEDIUM' \| 'LOW' \| 'INFORMATIONAL'` | —        | Log severity for matched events         |
+| `data_profile_id` | `number` (int64)                                               | —        | Links to the `dataProfiles` resource    |
+| `exception_rules` | `ExceptionRuleDTO[]`                                           | —        | Pre-filter ALLOW/ALERT/BLOCK overrides  |
+| `exclusions`      | `Exclusions`                                                   | —        | App / URL / keyword exclusion lists     |
+
+The full `DataFilteringProfileRequest` shape lives in [`src/models/dlp-data-filtering-profile.ts`](https://github.com/cdot65/prisma-airs-sdk/blob/main/src/models/dlp-data-filtering-profile.ts).
+
+## API reference
+
+### list
 
 Paginated `Page<DataFilteringProfileResponse>`. Optional filters: `status` (`enabled`/`disabled`), `name` (partial match). Sort entries emit one `sort=` query param each.
 
@@ -30,14 +46,14 @@ const page = await client.dlp.dataFilteringProfiles.list({
 console.log(page.totalElements, page.content.length);
 ```
 
-## get
+### get
 
 ```ts
 const profile = await client.dlp.dataFilteringProfiles.get('dfp-123');
 console.log(profile.name, profile.direction);
 ```
 
-## replace
+### replace
 
 Full PUT — body must satisfy `DataFilteringProfileRequest`. `file_based` and `non_file_based` are required. Returns the updated resource.
 
@@ -51,3 +67,212 @@ const updated = await client.dlp.dataFilteringProfiles.replace('dfp-123', {
   data_profile_id: 1001,
 });
 ```
+
+## Use cases
+
+### Use case 1 — Inspect every enabled profile and surface ones missing a data profile binding
+
+**Scenario.** Security ops wants a one-shot audit: list all `enabled` filtering profiles, then flag any that don't have a `data_profile_id` linked (these are misconfigured — they'd allow everything through). The output is a list of profile IDs to fix.
+
+**Input.**
+
+```ts
+import { ManagementClient, AISecSDKException } from '@cdot65/prisma-airs-sdk';
+
+const client = new ManagementClient();
+
+const page = await client.dlp.dataFilteringProfiles.list({
+  page: 0,
+  size: 100,
+  sort: ['name,asc'],
+  status: 'enabled',
+});
+```
+
+**Expected output** — `page` is a Spring `Page<>` envelope. A representative shape:
+
+```json
+{
+  "content": [
+    {
+      "id": "dfp-001",
+      "name": "Outbound-HR",
+      "direction": "UPLOAD",
+      "log_severity": "HIGH",
+      "file_based": true,
+      "non_file_based": true,
+      "data_profile_id": 1001,
+      "audit_metadata": {
+        "created_by": "ops@example.com",
+        "created_at": "2026-04-12T09:15:00Z",
+        "updated_at": "2026-05-01T14:22:00Z"
+      }
+    },
+    {
+      "id": "dfp-002",
+      "name": "Outbound-Eng",
+      "direction": "UPLOAD",
+      "log_severity": "MEDIUM",
+      "file_based": true,
+      "non_file_based": false
+    }
+  ],
+  "totalElements": 2,
+  "totalPages": 1,
+  "first": true,
+  "last": true,
+  "size": 100,
+  "number": 0,
+  "numberOfElements": 2
+}
+```
+
+**Validation.** Self-checking pattern — fails loudly if shape drifts or any enabled profile lacks a data profile binding:
+
+```ts
+const unlinked: string[] = [];
+
+if (!Array.isArray(page.content)) {
+  throw new Error(`list() did not return a Page<> envelope: ${JSON.stringify(page)}`);
+}
+
+for (const p of page.content) {
+  if (!p.id) throw new Error(`profile missing id: ${JSON.stringify(p)}`);
+  if (p.data_profile_id === undefined || p.data_profile_id === null) {
+    unlinked.push(p.id);
+  }
+}
+
+console.log(`enabled profiles: ${page.totalElements}`);
+console.log(`unlinked (need data_profile_id): ${unlinked.length}`, unlinked);
+
+if (unlinked.length > 0) {
+  process.exitCode = 1; // fail the audit job in CI
+}
+```
+
+### Use case 2 — Replace a profile to add a per-group exception rule
+
+**Scenario.** The "Outbound-HR" profile currently blocks all uploads. Legal needs the `legal-review` user group to BLOCK with elevated severity while everyone else stays on the current behavior. Use `replace()` to PUT the new shape — `replace` is a full PUT, so existing fields must be re-sent verbatim.
+
+**Input.**
+
+```ts
+const id = 'dfp-001';
+
+// 1. Fetch current state so we don't drop existing fields on the PUT.
+const current = await client.dlp.dataFilteringProfiles.get(id);
+
+// 2. Merge in the new exception rule.
+const updated = await client.dlp.dataFilteringProfiles.replace(id, {
+  file_based: current.file_based ?? true,
+  non_file_based: current.non_file_based ?? true,
+  description: current.description,
+  direction: current.direction as 'BOTH' | 'UPLOAD' | 'DOWNLOAD' | undefined,
+  log_severity: 'HIGH',
+  data_profile_id: current.data_profile_id,
+  exception_rules: [
+    {
+      action: 'BLOCK',
+      log_severity: 'CRITICAL',
+      data_profile_ids: current.data_profile_id ? [current.data_profile_id] : undefined,
+      source_attributes: {
+        match_any: false,
+        user_group_ids: ['legal-review'],
+      },
+    },
+  ],
+});
+```
+
+**Expected output.** PUT returns the updated `DataFilteringProfileResponse` — same shape as `get()`, with `version` bumped and `audit_metadata.updated_at` refreshed:
+
+```json
+{
+  "id": "dfp-001",
+  "name": "Outbound-HR",
+  "direction": "UPLOAD",
+  "log_severity": "HIGH",
+  "file_based": true,
+  "non_file_based": true,
+  "data_profile_id": 1001,
+  "version": 4,
+  "exception_rules": [
+    {
+      "id": "er-9c1a",
+      "action": "BLOCK",
+      "log_severity": "CRITICAL",
+      "data_profile_ids": [1001],
+      "source_attributes": {
+        "match_any": false,
+        "user_group_ids": ["legal-review"]
+      }
+    }
+  ],
+  "audit_metadata": {
+    "updated_at": "2026-05-23T17:04:11Z",
+    "updated_by": "ops@example.com"
+  }
+}
+```
+
+**Validation.** Confirm the new rule landed and the version advanced:
+
+```ts
+if (updated.id !== id) {
+  throw new Error(`returned id ${updated.id} does not match requested ${id}`);
+}
+if (current.version !== undefined && updated.version !== undefined) {
+  if (updated.version <= current.version) {
+    throw new Error(`version did not advance: ${current.version} → ${updated.version}`);
+  }
+}
+const rules = updated.exception_rules ?? [];
+const added = rules.find((r) => r.source_attributes?.user_group_ids?.includes('legal-review'));
+if (!added) {
+  throw new Error('legal-review exception rule was not persisted');
+}
+if (added.action !== 'BLOCK' || added.log_severity !== 'CRITICAL') {
+  throw new Error(`unexpected exception rule shape: ${JSON.stringify(added)}`);
+}
+console.log(`ok: rule ${added.id} active, version ${updated.version}`);
+```
+
+## Error handling
+
+Every method throws `AISecSDKException` on transport failure, OAuth issues, or response-validation errors. Classify with `errorType`:
+
+```ts
+import { AISecSDKException, ErrorType } from '@cdot65/prisma-airs-sdk';
+
+try {
+  await client.dlp.dataFilteringProfiles.replace('dfp-001', {
+    file_based: true,
+    non_file_based: true,
+  });
+} catch (err) {
+  if (err instanceof AISecSDKException) {
+    switch (err.errorType) {
+      case ErrorType.OAUTH_ERROR:
+        console.error('check PANW_MGMT_* env vars');
+        break;
+      case ErrorType.CLIENT_SIDE_ERROR:
+        console.error('4xx — id likely does not exist or body invalid:', err.message);
+        break;
+      case ErrorType.SERVER_SIDE_ERROR:
+        console.error('5xx — retried with backoff already:', err.message);
+        break;
+      default:
+        console.error('unexpected:', err.errorType, err.message);
+    }
+  } else {
+    throw err;
+  }
+}
+```
+
+## See also
+
+- [DLP — Data Profiles](data-profiles.md) — `data_profile_id` references resolve here
+- [DLP — Data Patterns](data-patterns.md) — patterns referenced inside detection rules on the linked data profile
+- Runnable walkthrough: [`examples/mgmt-dlp-data-filtering-profiles.ts`](https://github.com/cdot65/prisma-airs-sdk/blob/main/examples/mgmt-dlp-data-filtering-profiles.ts)

--- a/docs/services/dlp/data-patterns.md
+++ b/docs/services/dlp/data-patterns.md
@@ -2,7 +2,7 @@
 
 Manage Data Patterns on the DLP service (`/v2/api/data-patterns`).
 
-Subclient lives at `client.dlp.dataPatterns`. Full CRUD: list, create, get, replace (PUT), patch (RFC 7396 JSON Merge Patch), delete. DELETE soft-deletes (archives) server-side.
+Subclient lives at `client.dlp.dataPatterns`. **Full CRUD**: list, create, get, replace (PUT), patch (RFC 7396 JSON Merge Patch), delete. DELETE soft-deletes (archives) server-side — the pattern becomes invisible to list but its `id` still resolves on `get()` with `status: 'deleted'`.
 
 Spec source: [`specs/dlp/DataPatterns.yaml`](https://github.com/cdot65/prisma-airs-sdk/blob/main/specs/dlp/DataPatterns.yaml)
 
@@ -14,7 +14,24 @@ import { ManagementClient } from '@cdot65/prisma-airs-sdk';
 const client = new ManagementClient();
 ```
 
-## list
+## Required fields
+
+| Field              | Type                                          | Required on POST | Required on PATCH | Notes                                             |
+| ------------------ | --------------------------------------------- | ---------------- | ----------------- | ------------------------------------------------- |
+| `name`             | `string` (1..64)                              | ✅               | ✅                | Spec enforces length bounds                       |
+| `type`             | `'predefined' \| 'custom' \| 'file_property'` | ✅               | ✅                | `custom` for tenant-authored patterns             |
+| `detection_config` | `{ technique, supported_confidence_levels? }` | ✅               | ✅                | Required even on patch                            |
+| `matching_rules`   | `DataPatternMatchingRules`                    | —                | nullable          | `regexes`, proximity keywords, metadata criteria  |
+| `tags`             | `DataPatternTags`                             | —                | nullable          | `classification`, `compliance`, `geography`       |
+| `description`      | `string`                                      | —                | nullable          | Omit to leave unchanged on patch; `null` to clear |
+
+Detection techniques (the `detection_config.technique` enum): `edm`, `document_fingerprint`, `trainable_classifier`, `ml_document`, `regex`, `weighted_regex`, `ml`, `titus_tag`, `wildfire`, `file_property`, `dictionary`, `pab`, `document_classifier`.
+
+Schema source: [`src/models/dlp-data-pattern.ts`](https://github.com/cdot65/prisma-airs-sdk/blob/main/src/models/dlp-data-pattern.ts).
+
+## API reference
+
+### list
 
 ```ts
 const page = await client.dlp.dataPatterns.list({
@@ -25,7 +42,7 @@ const page = await client.dlp.dataPatterns.list({
 for (const p of page.content) console.log(p.id, p.name);
 ```
 
-## create
+### create
 
 `name`, `type`, and `detection_config` are required.
 
@@ -41,13 +58,13 @@ const created = await client.dlp.dataPatterns.create({
 console.log(created.id);
 ```
 
-## get
+### get
 
 ```ts
 const pattern = await client.dlp.dataPatterns.get('pat-001');
 ```
 
-## replace
+### replace
 
 Full PUT.
 
@@ -62,7 +79,7 @@ const replaced = await client.dlp.dataPatterns.replace('pat-001', {
 });
 ```
 
-## patch
+### patch
 
 JSON Merge Patch. `name`, `type`, and `detection_config` are required even on patch. Other fields use nullable semantics — omit to leave unchanged, send `null` to clear.
 
@@ -75,10 +92,232 @@ const patched = await client.dlp.dataPatterns.patch('pat-001', {
 });
 ```
 
-## delete
+### delete
 
-204 No Content. Returns `void`.
+204 No Content. Returns `void`. Soft-deletes server-side.
 
 ```ts
 await client.dlp.dataPatterns.delete('pat-001');
 ```
+
+## Use cases
+
+### Use case 1 — Create a weighted credit-card detector and validate its post-create state
+
+**Scenario.** Build a custom pattern that detects 15- or 16-digit credit-card-like sequences with proximity to keywords like "card", "visa", "mastercard". Weighted regexes let the engine score matches by confidence — a bare 16-digit run scores low, the same run within 30 chars of "card number" scores high.
+
+**Input.**
+
+```ts
+import { ManagementClient } from '@cdot65/prisma-airs-sdk';
+
+const client = new ManagementClient();
+
+const created = await client.dlp.dataPatterns.create({
+  name: 'cc-numbers-weighted',
+  type: 'custom',
+  description: 'Credit-card numbers, weighted by proximity to card-related keywords',
+  detection_config: {
+    technique: 'weighted_regex',
+    supported_confidence_levels: ['low', 'medium', 'high'],
+  },
+  matching_rules: {
+    proximity_distance: 30,
+    proximity_keywords: ['card', 'credit', 'visa', 'mastercard', 'amex'],
+    regexes: [
+      { regex: '\\b\\d{16}\\b', weight: 1.0 },
+      { regex: '\\b\\d{15}\\b', weight: 0.8 }, // amex is 15
+    ],
+  },
+  tags: {
+    classification: ['PCI'],
+    compliance: ['PCI-DSS-3.2.1'],
+    geography: ['US', 'EU'],
+  },
+});
+```
+
+**Expected output.** POST returns `DataPatternResponse` — the API generates `id`, `status`, `version`, and `audit_metadata`:
+
+```json
+{
+  "id": "pat-7c4a91",
+  "name": "cc-numbers-weighted",
+  "description": "Credit-card numbers, weighted by proximity to card-related keywords",
+  "tenant_id": "tnt-001",
+  "type": "custom",
+  "status": "active",
+  "license_type": "standard",
+  "version": 1,
+  "detection_config": {
+    "technique": "weighted_regex",
+    "supported_confidence_levels": ["low", "medium", "high"]
+  },
+  "matching_rules": {
+    "proximity_distance": 30,
+    "proximity_keywords": ["card", "credit", "visa", "mastercard", "amex"],
+    "regexes": [
+      { "regex": "\\b\\d{16}\\b", "weight": 1.0 },
+      { "regex": "\\b\\d{15}\\b", "weight": 0.8 }
+    ]
+  },
+  "tags": {
+    "classification": ["PCI"],
+    "compliance": ["PCI-DSS-3.2.1"],
+    "geography": ["US", "EU"]
+  },
+  "audit_metadata": {
+    "created_at": "2026-05-23T17:11:02Z",
+    "created_by": "ops@example.com"
+  }
+}
+```
+
+**Validation.** Assert the server preserved the input shape and stamped the lifecycle fields:
+
+```ts
+if (!created.id) throw new Error('create() did not return an id');
+if (created.status !== 'active') {
+  throw new Error(`new pattern not active: status=${created.status}`);
+}
+if (created.version !== 1) {
+  throw new Error(`expected version 1 for new pattern, got ${created.version}`);
+}
+if (created.detection_config?.technique !== 'weighted_regex') {
+  throw new Error(
+    `detection_config.technique not preserved: ${created.detection_config?.technique}`,
+  );
+}
+const regexCount = created.matching_rules?.regexes?.length ?? 0;
+if (regexCount !== 2) {
+  throw new Error(`expected 2 regexes round-tripped, got ${regexCount}`);
+}
+if (!created.tags?.compliance?.includes('PCI-DSS-3.2.1')) {
+  throw new Error('compliance tag not persisted');
+}
+console.log(`ok: pattern ${created.id} created (v${created.version})`);
+```
+
+### Use case 2 — Patch an existing pattern to widen its regex and clear its description
+
+**Scenario.** The above `cc-numbers-weighted` is too strict — it misses 13-digit cards. JSON Merge Patch lets us update only `matching_rules` (re-sending it in full, since arrays/objects are replaced not merged in JSON Merge Patch) and simultaneously clear the description by sending `description: null`.
+
+**Input.**
+
+```ts
+const id = 'pat-7c4a91';
+
+const patched = await client.dlp.dataPatterns.patch(id, {
+  // Required even on patch:
+  name: 'cc-numbers-weighted',
+  type: 'custom',
+  detection_config: {
+    technique: 'weighted_regex',
+    supported_confidence_levels: ['low', 'medium', 'high'],
+  },
+  // Replace matching_rules entirely (Merge Patch replaces arrays wholesale):
+  matching_rules: {
+    proximity_distance: 30,
+    proximity_keywords: ['card', 'credit', 'visa', 'mastercard', 'amex'],
+    regexes: [
+      { regex: '\\b\\d{16}\\b', weight: 1.0 },
+      { regex: '\\b\\d{15}\\b', weight: 0.8 },
+      { regex: '\\b\\d{13}\\b', weight: 0.6 },
+    ],
+  },
+  // Clear the description:
+  description: null,
+  // Omit `tags` entirely to leave them unchanged.
+});
+```
+
+**Expected output.** Same `DataPatternResponse` shape with `version` bumped, `description` absent (cleared), and the third regex present:
+
+```json
+{
+  "id": "pat-7c4a91",
+  "name": "cc-numbers-weighted",
+  "tenant_id": "tnt-001",
+  "type": "custom",
+  "status": "active",
+  "version": 2,
+  "detection_config": {
+    "technique": "weighted_regex",
+    "supported_confidence_levels": ["low", "medium", "high"]
+  },
+  "matching_rules": {
+    "proximity_distance": 30,
+    "proximity_keywords": ["card", "credit", "visa", "mastercard", "amex"],
+    "regexes": [
+      { "regex": "\\b\\d{16}\\b", "weight": 1.0 },
+      { "regex": "\\b\\d{15}\\b", "weight": 0.8 },
+      { "regex": "\\b\\d{13}\\b", "weight": 0.6 }
+    ]
+  },
+  "tags": {
+    "classification": ["PCI"],
+    "compliance": ["PCI-DSS-3.2.1"],
+    "geography": ["US", "EU"]
+  },
+  "audit_metadata": {
+    "created_at": "2026-05-23T17:11:02Z",
+    "created_by": "ops@example.com",
+    "updated_at": "2026-05-23T17:38:55Z",
+    "updated_by": "ops@example.com"
+  }
+}
+```
+
+**Validation.** Assert the new regex landed, description was cleared, tags were left alone:
+
+```ts
+if (patched.id !== id) throw new Error(`id changed unexpectedly: ${patched.id}`);
+if (patched.version === undefined || patched.version < 2) {
+  throw new Error(`version did not advance past 1: ${patched.version}`);
+}
+const regexes = patched.matching_rules?.regexes ?? [];
+const hasThirteen = regexes.some((r) => r.regex.includes('{13}'));
+if (!hasThirteen) {
+  throw new Error('13-digit regex was not persisted');
+}
+if (patched.description !== undefined && patched.description !== '') {
+  throw new Error(`description not cleared: ${JSON.stringify(patched.description)}`);
+}
+// Tags were omitted from the PATCH body — server should have left them intact.
+if (!patched.tags?.compliance?.includes('PCI-DSS-3.2.1')) {
+  throw new Error('tags were dropped — omitted fields should be preserved on Merge Patch');
+}
+console.log(`ok: patched to v${patched.version}, now matches ${regexes.length} regexes`);
+```
+
+## Error handling
+
+```ts
+import { AISecSDKException, ErrorType } from '@cdot65/prisma-airs-sdk';
+
+try {
+  await client.dlp.dataPatterns.create({
+    name: '', // violates min(1)
+    type: 'custom',
+    detection_config: { technique: 'regex' },
+  });
+} catch (err) {
+  if (err instanceof AISecSDKException) {
+    if (err.errorType === ErrorType.USER_REQUEST_PAYLOAD_ERROR) {
+      console.error('local validation rejected the body:', err.message);
+    } else if (err.errorType === ErrorType.CLIENT_SIDE_ERROR) {
+      console.error('API rejected (4xx):', err.message);
+    } else {
+      console.error(err.errorType, err.message);
+    }
+  } else {
+    throw err;
+  }
+}
+```
+
+## See also
+
+- [DLP — Data Profiles](data-profiles.md) — data profiles compose patterns via the `dictionary` technique on rule items (use the pattern's `id`)
+- [DLP — Dictionaries](dictionaries.md) — keyword-list-driven detection technique
+- Runnable walkthrough: [`examples/mgmt-dlp-data-patterns.ts`](https://github.com/cdot65/prisma-airs-sdk/blob/main/examples/mgmt-dlp-data-patterns.ts)

--- a/docs/services/dlp/data-profiles.md
+++ b/docs/services/dlp/data-profiles.md
@@ -2,7 +2,12 @@
 
 Manage Data Profiles on the DLP service (`/v2/api/data-profiles`).
 
-Subclient lives at `client.dlp.dataProfiles`. CRUD without DELETE — the spec does not expose a DELETE for data profiles. To remove a profile, patch its lifecycle state via the underlying API (typically `profile_status: 'deleted'`).
+Subclient lives at `client.dlp.dataProfiles`. **CRUD without DELETE** — the spec does not expose a DELETE for data profiles. To remove a profile, patch its lifecycle state via the underlying API (typically `profile_status: 'deleted'`).
+
+Two distinct rule shapes live under `detection_rules[].rule_type`:
+
+- `expression_tree` — recursive boolean tree of `DetectionRuleItem` leaves (the leaf carries the detection technique + thresholds)
+- `multi_profile` — composes other data profiles by id, joined by an operator (build "this OR that OR the other")
 
 Spec source: [`specs/dlp/DataProfiles.yaml`](https://github.com/cdot65/prisma-airs-sdk/blob/main/specs/dlp/DataProfiles.yaml)
 
@@ -14,7 +19,32 @@ import { ManagementClient } from '@cdot65/prisma-airs-sdk';
 const client = new ManagementClient();
 ```
 
-## list
+## Required fields
+
+| Field             | Type                    | Required on POST | Required on PATCH | Notes                                             |
+| ----------------- | ----------------------- | ---------------- | ----------------- | ------------------------------------------------- |
+| `name`            | `string` (1..64)        | ✅               | ✅                |                                                   |
+| `detection_rules` | `DetectionRule[]`       | ✅               | nullable          | Either `expression_tree` or `multi_profile` shape |
+| `profile_type`    | `'basic' \| 'advanced'` | —                | ✅                | PATCH requires it even when unchanged             |
+| `description`     | `string`                | —                | nullable          | Omit to leave unchanged on patch; `null` to clear |
+
+Schema source: [`src/models/dlp-data-profile.ts`](https://github.com/cdot65/prisma-airs-sdk/blob/main/src/models/dlp-data-profile.ts).
+
+### DetectionRuleItem (the leaf)
+
+Required: `detection_technique` (same vocabulary as data-patterns). Common optional fields per technique family:
+
+| Technique family           | Typical fields                                                       |
+| -------------------------- | -------------------------------------------------------------------- |
+| `regex`, `weighted_regex`  | `confidence_level`, `occurrence_operator_type`, `occurrence_count`   |
+| `dictionary`, `document_*` | `score`, `score_low`, `score_high`                                   |
+| `edm`                      | `edm_dataset_id`, `primary_fields`, `secondary_fields`, `*_criteria` |
+
+All combinations are valid Zod — set whatever the chosen technique requires.
+
+## API reference
+
+### list
 
 ```ts
 const page = await client.dlp.dataProfiles.list({
@@ -25,9 +55,7 @@ const page = await client.dlp.dataProfiles.list({
 for (const p of page.content) console.log(p.id, p.name, p.profile_type);
 ```
 
-## create
-
-Two rule shapes — `expression_tree` (recursive boolean tree of detection rule items) or `multi_profile` (composes other profiles by id).
+### create
 
 ```ts
 const created = await client.dlp.dataProfiles.create({
@@ -48,13 +76,13 @@ const created = await client.dlp.dataProfiles.create({
 console.log(created.id);
 ```
 
-## get
+### get
 
 ```ts
 const profile = await client.dlp.dataProfiles.get('prof-1');
 ```
 
-## replace
+### replace
 
 Full PUT.
 
@@ -73,7 +101,7 @@ const replaced = await client.dlp.dataProfiles.replace('prof-1', {
 });
 ```
 
-## patch
+### patch
 
 JSON Merge Patch. `name` and `profile_type` are required; other fields use nullable semantics — omit to leave unchanged, send `null` to clear.
 
@@ -85,3 +113,239 @@ const patched = await client.dlp.dataProfiles.patch('prof-1', {
   detection_rules: null,
 });
 ```
+
+## Use cases
+
+### Use case 1 — Build an `expression_tree` profile that requires SSN AND credit-card pattern hits
+
+**Scenario.** A "high-risk PII" profile should fire only when both an SSN-pattern leaf AND a credit-card-pattern leaf match (logical AND). Use an `expression_tree` rule with `operator_type: 'and'` joining two sub-expressions, each carrying a `rule_item` leaf.
+
+**Input.**
+
+```ts
+import { ManagementClient } from '@cdot65/prisma-airs-sdk';
+
+const client = new ManagementClient();
+
+const created = await client.dlp.dataProfiles.create({
+  name: 'High-risk PII (SSN AND CC)',
+  description: 'Fires only when both SSN and CC pattern leaves match',
+  detection_rules: [
+    {
+      rule_type: 'expression_tree',
+      expression_tree: {
+        operator_type: 'and',
+        sub_expressions: [
+          {
+            rule_item: {
+              detection_technique: 'regex',
+              match_type: 'include',
+              confidence_level: 'high',
+              occurrence_operator_type: 'more_than_equal_to',
+              occurrence_count: 1,
+            },
+          },
+          {
+            rule_item: {
+              detection_technique: 'weighted_regex',
+              match_type: 'include',
+              confidence_level: 'high',
+              occurrence_operator_type: 'more_than_equal_to',
+              occurrence_count: 1,
+            },
+          },
+        ],
+      },
+    },
+  ],
+});
+```
+
+**Expected output.**
+
+```json
+{
+  "id": "prof-3a91",
+  "name": "High-risk PII (SSN AND CC)",
+  "description": "Fires only when both SSN and CC pattern leaves match",
+  "tenant_id": "tnt-001",
+  "type": "custom",
+  "profile_status": "active",
+  "profile_type": "basic",
+  "version": 1,
+  "detection_rules": [
+    {
+      "rule_type": "expression_tree",
+      "expression_tree": {
+        "operator_type": "and",
+        "sub_expressions": [
+          {
+            "rule_item": {
+              "detection_technique": "regex",
+              "match_type": "include",
+              "confidence_level": "high",
+              "occurrence_operator_type": "more_than_equal_to",
+              "occurrence_count": 1
+            }
+          },
+          {
+            "rule_item": {
+              "detection_technique": "weighted_regex",
+              "match_type": "include",
+              "confidence_level": "high",
+              "occurrence_operator_type": "more_than_equal_to",
+              "occurrence_count": 1
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "audit_metadata": {
+    "created_at": "2026-05-23T17:55:14Z",
+    "created_by": "ops@example.com"
+  }
+}
+```
+
+**Validation.** Walk into the tree and assert structure:
+
+```ts
+if (!created.id) throw new Error('create() did not return an id');
+if (created.profile_status !== 'active') {
+  throw new Error(`new profile not active: ${created.profile_status}`);
+}
+
+const rule = created.detection_rules?.[0];
+if (!rule || rule.rule_type !== 'expression_tree') {
+  throw new Error(`expected expression_tree rule, got ${rule?.rule_type}`);
+}
+
+const tree = rule.expression_tree;
+if (tree?.operator_type !== 'and') {
+  throw new Error(`root operator not 'and': ${tree?.operator_type}`);
+}
+
+const leaves = tree?.sub_expressions ?? [];
+if (leaves.length !== 2) {
+  throw new Error(`expected 2 sub-expressions, got ${leaves.length}`);
+}
+
+const techniques = leaves.map((s) => s.rule_item?.detection_technique);
+if (!techniques.includes('regex') || !techniques.includes('weighted_regex')) {
+  throw new Error(`leaves missing expected techniques: ${techniques.join(',')}`);
+}
+
+console.log(`ok: ${created.id} created (v${created.version}) with ${leaves.length} leaves`);
+```
+
+### Use case 2 — Compose a `multi_profile` umbrella profile that ORs two existing profiles
+
+**Scenario.** Compliance wants a single "EU-Regulated" profile that fires when **either** an existing `GDPR-PII` (id `1001`) **or** `EU-Healthcare` (id `1002`) profile matches. Use `multi_profile` to OR them together; the new profile becomes the single binding target for filtering profiles.
+
+**Input.**
+
+```ts
+const created = await client.dlp.dataProfiles.create({
+  name: 'EU-Regulated (umbrella)',
+  description: 'GDPR-PII OR EU-Healthcare',
+  detection_rules: [
+    {
+      rule_type: 'multi_profile',
+      multi_profile: {
+        operator_type: 'or',
+        data_profile_ids: [1001, 1002],
+      },
+    },
+  ],
+});
+```
+
+**Expected output.**
+
+```json
+{
+  "id": "prof-eu-001",
+  "name": "EU-Regulated (umbrella)",
+  "description": "GDPR-PII OR EU-Healthcare",
+  "tenant_id": "tnt-001",
+  "type": "custom",
+  "profile_status": "active",
+  "profile_type": "advanced",
+  "version": 1,
+  "detection_rules": [
+    {
+      "rule_type": "multi_profile",
+      "multi_profile": {
+        "operator_type": "or",
+        "data_profile_ids": [1001, 1002]
+      }
+    }
+  ],
+  "audit_metadata": {
+    "created_at": "2026-05-23T18:02:08Z",
+    "created_by": "ops@example.com"
+  }
+}
+```
+
+Note: composing other profiles auto-promotes `profile_type` to `'advanced'` server-side — even though we didn't ask for it.
+
+**Validation.** Confirm the discriminator survived round-trip, the ids landed in order, and the server upgraded the profile_type:
+
+```ts
+if (created.profile_type !== 'advanced') {
+  throw new Error(
+    `multi_profile composition should auto-promote to advanced, got ${created.profile_type}`,
+  );
+}
+
+const rule = created.detection_rules?.[0];
+if (rule?.rule_type !== 'multi_profile') {
+  throw new Error(`expected multi_profile rule, got ${rule?.rule_type}`);
+}
+
+const ids = rule.multi_profile?.data_profile_ids ?? [];
+if (ids.length !== 2 || ids[0] !== 1001 || ids[1] !== 1002) {
+  throw new Error(`data_profile_ids did not round-trip: ${JSON.stringify(ids)}`);
+}
+
+if (rule.multi_profile?.operator_type !== 'or') {
+  throw new Error(`operator not 'or': ${rule.multi_profile?.operator_type}`);
+}
+
+console.log(`ok: umbrella ${created.id} bundles ${ids.length} child profiles`);
+```
+
+## Error handling
+
+```ts
+import { AISecSDKException, ErrorType } from '@cdot65/prisma-airs-sdk';
+
+try {
+  await client.dlp.dataProfiles.create({
+    name: 'bad',
+    detection_rules: [
+      // discriminator missing the matching payload key
+      { rule_type: 'expression_tree' },
+    ],
+  });
+} catch (err) {
+  if (err instanceof AISecSDKException) {
+    if (err.errorType === ErrorType.CLIENT_SIDE_ERROR) {
+      console.error('400 — likely a malformed detection rule:', err.message);
+    } else {
+      console.error(err.errorType, err.message);
+    }
+  } else {
+    throw err;
+  }
+}
+```
+
+## See also
+
+- [DLP — Data Filtering Profiles](data-filtering-profiles.md) — binds a data profile via `data_profile_id`
+- [DLP — Data Patterns](data-patterns.md) — pattern ids referenced inside `DetectionRuleItem` leaves
+- [DLP — Dictionaries](dictionaries.md) — `detection_technique: 'dictionary'` references dictionary ids
+- Runnable walkthrough: [`examples/mgmt-dlp-data-profiles.ts`](https://github.com/cdot65/prisma-airs-sdk/blob/main/examples/mgmt-dlp-data-profiles.ts)

--- a/docs/services/dlp/dictionaries.md
+++ b/docs/services/dlp/dictionaries.md
@@ -2,7 +2,9 @@
 
 Manage Dictionaries on the DLP service (`/v2/api/dictionaries`).
 
-Subclient lives at `client.dlp.dictionaries`. Full CRUD with a multipart upload twist: `create` and `replace` take a metadata object + keyword file. PATCH uses JSON Merge Patch. PUT can return 200+body or 204+empty — `replace()` returns `DictionaryResponse | undefined`.
+Subclient lives at `client.dlp.dictionaries`. **Full CRUD with a multipart twist**: `create` and `replace` take a metadata object + a keyword file (newline-delimited). PATCH uses JSON Merge Patch. PUT can return 200+body **or** 204+empty — `replace()` returns `DictionaryResponse | undefined`.
+
+Accepted file shapes: `Blob`, `ArrayBuffer`, `Uint8Array`, `string`. The SDK builds the multipart boundary; **do not set `Content-Type` manually**.
 
 Spec source: [`specs/dlp/Dictionaries.yaml`](https://github.com/cdot65/prisma-airs-sdk/blob/main/specs/dlp/Dictionaries.yaml)
 
@@ -14,7 +16,25 @@ import { ManagementClient } from '@cdot65/prisma-airs-sdk';
 const client = new ManagementClient();
 ```
 
-## list
+## Required fields
+
+| Field                | Type                       | Required on POST/PUT | Required on PATCH | Notes                                                  |
+| -------------------- | -------------------------- | -------------------- | ----------------- | ------------------------------------------------------ |
+| `category`           | `DictionaryCategory` enum  | ✅                   | ✅                | `'Academic' \| 'Confidential' \| 'Source Code' \| ...` |
+| `name`               | `string`                   | ✅                   | ✅                |                                                        |
+| `original_file_name` | `string`                   | ✅                   | ✅                | Used as the multipart filename and the keyword source  |
+| `region_name`        | `string`                   | ✅                   | nullable          |                                                        |
+| `description`        | `string`                   | —                    | nullable          | Omit to leave unchanged; `null` to clear               |
+| `is_case_sensitive`  | `boolean`                  | —                    | nullable          |                                                        |
+| `type`               | `'predefined' \| 'custom'` | —                    | —                 | Defaults server-side to `custom` for user uploads      |
+
+Valid `category` values (spec enum, verbatim — note the space in `'Source Code'`): `Academic`, `Confidential`, `Employment`, `Financial`, `Government`, `Healthcare`, `Legal`, `Marketing`, `Source Code`.
+
+Schema source: [`src/models/dlp-dictionary.ts`](https://github.com/cdot65/prisma-airs-sdk/blob/main/src/models/dlp-dictionary.ts).
+
+## API reference
+
+### list
 
 `keywords: true` includes the keyword array in each response entry.
 
@@ -27,9 +47,9 @@ const page = await client.dlp.dictionaries.list({
 for (const d of page.content) console.log(d.id, d.name);
 ```
 
-## create
+### create
 
-Multipart upload — `file` accepts `Blob | ArrayBuffer | Uint8Array | string`. The SDK builds the multipart boundary; do not set Content-Type manually. `category`, `name`, `original_file_name`, and `region_name` are required on the metadata.
+Multipart upload — `file` accepts `Blob | ArrayBuffer | Uint8Array | string`. `category`, `name`, `original_file_name`, and `region_name` are required on the metadata.
 
 ```ts
 const created = await client.dlp.dictionaries.create({
@@ -46,13 +66,13 @@ const created = await client.dlp.dictionaries.create({
 console.log(created.id);
 ```
 
-## get
+### get
 
 ```ts
 const dict = await client.dlp.dictionaries.get('dict-1', { includeKeywords: true });
 ```
 
-## replace
+### replace
 
 Full multipart replace. Returns `DictionaryResponse | undefined` since the API may answer 200 with body or 204 with no body.
 
@@ -71,7 +91,7 @@ if (replaced) console.log('200:', replaced.id);
 else console.log('204 — empty body');
 ```
 
-## patch
+### patch
 
 JSON Merge Patch. `category`, `name`, and `original_file_name` are required even on patch. Other fields are nullable — omit to leave unchanged, send `null` to clear.
 
@@ -84,8 +104,227 @@ const patched = await client.dlp.dictionaries.patch('dict-1', {
 });
 ```
 
-## delete
+### delete
 
 ```ts
 await client.dlp.dictionaries.delete('dict-1');
 ```
+
+## Use cases
+
+### Use case 1 — Upload a codenames dictionary from a string, then read keywords back
+
+**Scenario.** A new "Confidential" dictionary holds internal project codenames. Build the keyword list as a string in-process, POST as multipart, and immediately GET back with `includeKeywords: true` to confirm the server parsed every line.
+
+**Input.**
+
+```ts
+import { ManagementClient } from '@cdot65/prisma-airs-sdk';
+
+const client = new ManagementClient();
+
+const keywords = ['alpha', 'bravo', 'charlie', 'delta', 'echo'];
+const file = keywords.join('\n') + '\n'; // newline-delimited, trailing \n
+
+const created = await client.dlp.dictionaries.create({
+  metadata: {
+    category: 'Confidential',
+    name: 'project-codenames',
+    original_file_name: 'codenames.txt',
+    region_name: 'us-west-2',
+    description: 'Internal project codenames — phonetic alphabet',
+    is_case_sensitive: false,
+    type: 'custom',
+  },
+  file,
+  includeKeywords: true,
+});
+```
+
+**Expected output.** POST returns `DictionaryResponse`. With `includeKeywords: true`, `keywords[]` is populated:
+
+```json
+{
+  "id": "dict-7f30c2",
+  "name": "project-codenames",
+  "description": "Internal project codenames — phonetic alphabet",
+  "category": "Confidential",
+  "region_name": "us-west-2",
+  "type": "custom",
+  "is_case_sensitive": false,
+  "is_parent_managed": false,
+  "detection_technique": "dictionary",
+  "dictionary_metadata": {
+    "number_of_keywords": 5,
+    "original_file_name": "codenames.txt",
+    "original_file_size_in_byte": 30
+  },
+  "keywords": ["alpha", "bravo", "charlie", "delta", "echo"],
+  "audit_metadata": {
+    "created_at": "2026-05-23T18:20:41Z",
+    "created_by": "ops@example.com"
+  }
+}
+```
+
+**Validation.** Make the example self-checking — verify the metadata counter, the keyword round-trip, and the lifecycle stamps:
+
+```ts
+if (!created.id) throw new Error('create() did not return an id');
+if (created.category !== 'Confidential') {
+  throw new Error(`category not preserved: ${created.category}`);
+}
+if (created.dictionary_metadata?.number_of_keywords !== keywords.length) {
+  throw new Error(
+    `server counted ${created.dictionary_metadata?.number_of_keywords} keywords, expected ${keywords.length}`,
+  );
+}
+if (created.dictionary_metadata?.original_file_name !== 'codenames.txt') {
+  throw new Error(`filename not preserved: ${created.dictionary_metadata?.original_file_name}`);
+}
+
+const returned = created.keywords ?? [];
+if (returned.length !== keywords.length) {
+  throw new Error(`got ${returned.length} keywords back, expected ${keywords.length}`);
+}
+const missing = keywords.filter((k) => !returned.includes(k));
+if (missing.length > 0) {
+  throw new Error(`keywords lost in round-trip: ${missing.join(', ')}`);
+}
+
+console.log(`ok: dictionary ${created.id} contains ${returned.length} keywords`);
+```
+
+### Use case 2 — Replace a dictionary's keyword file and tolerate 200-or-204 response
+
+**Scenario.** Add a new codename ("foxtrot") to an existing dictionary. PUT can answer 200+body (some regions) or 204+empty (others) — handle both. After the replace, re-fetch with `includeKeywords: true` to verify the new keyword stuck.
+
+**Input.**
+
+```ts
+const id = 'dict-7f30c2';
+const updatedKeywords = ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot'];
+
+const result = await client.dlp.dictionaries.replace(id, {
+  metadata: {
+    category: 'Confidential',
+    name: 'project-codenames',
+    original_file_name: 'codenames.txt',
+    region_name: 'us-west-2',
+    type: 'custom',
+  },
+  file: updatedKeywords.join('\n') + '\n',
+  includeKeywords: false, // don't bother with body if region returns 200
+});
+
+// Always re-fetch to canonically observe state, regardless of 200/204:
+const reread = await client.dlp.dictionaries.get(id, { includeKeywords: true });
+```
+
+**Expected output.** Two possibilities for `result`:
+
+- **200 path** — `result` is a full `DictionaryResponse`
+- **204 path** — `result` is `undefined`
+
+```json
+// reread (always present, definitive)
+{
+  "id": "dict-7f30c2",
+  "name": "project-codenames",
+  "category": "Confidential",
+  "region_name": "us-west-2",
+  "type": "custom",
+  "dictionary_metadata": {
+    "number_of_keywords": 6,
+    "original_file_name": "codenames.txt",
+    "original_file_size_in_byte": 38
+  },
+  "keywords": ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"],
+  "audit_metadata": {
+    "created_at": "2026-05-23T18:20:41Z",
+    "created_by": "ops@example.com",
+    "updated_at": "2026-05-23T18:45:09Z",
+    "updated_by": "ops@example.com"
+  }
+}
+```
+
+**Validation.** Branch on 200-vs-204 then assert against the re-read:
+
+```ts
+if (result === undefined) {
+  console.log('replace() returned 204 — empty body (expected in some regions)');
+} else {
+  console.log(`replace() returned 200 — body for ${result.id}`);
+  if (result.id !== id) throw new Error(`id mismatch in 200 path: ${result.id}`);
+}
+
+// Definitive checks against the re-read:
+if (reread.dictionary_metadata?.number_of_keywords !== updatedKeywords.length) {
+  throw new Error(
+    `expected ${updatedKeywords.length} keywords post-replace, got ${reread.dictionary_metadata?.number_of_keywords}`,
+  );
+}
+if (!reread.keywords?.includes('foxtrot')) {
+  throw new Error('foxtrot was not added — replace did not persist');
+}
+if (!reread.audit_metadata?.updated_at) {
+  throw new Error('audit_metadata.updated_at missing — replace did not stamp lifecycle');
+}
+console.log(`ok: dictionary ${id} now holds ${reread.keywords?.length} keywords`);
+```
+
+## Notes on the multipart body
+
+The SDK encodes the metadata as a JSON part named `json` (with `Content-Type: application/json` and filename `metadata.json`) and the keyword file as a part named `file` (with the filename you put in `metadata.original_file_name`). Don't try to override the multipart boundary — the runtime needs to write it.
+
+For an `ArrayBuffer` or `Uint8Array` source — e.g. when reading from disk in Node:
+
+```ts
+import { readFile } from 'node:fs/promises';
+
+const buf = await readFile('./codenames.txt');
+await client.dlp.dictionaries.create({
+  metadata: {
+    category: 'Confidential',
+    name: 'codenames',
+    original_file_name: 'codenames.txt',
+    region_name: 'us-west-2',
+  },
+  file: buf,
+});
+```
+
+## Error handling
+
+```ts
+import { AISecSDKException, ErrorType } from '@cdot65/prisma-airs-sdk';
+
+try {
+  await client.dlp.dictionaries.create({
+    metadata: {
+      // Missing required region_name — Zod will catch it before the request.
+      category: 'Confidential',
+      name: 'broken',
+      original_file_name: 'broken.txt',
+    } as any,
+    file: 'foo\n',
+  });
+} catch (err) {
+  if (err instanceof AISecSDKException) {
+    if (err.errorType === ErrorType.USER_REQUEST_PAYLOAD_ERROR) {
+      console.error('local validation rejected the metadata:', err.message);
+    } else {
+      console.error(err.errorType, err.message);
+    }
+  } else {
+    throw err;
+  }
+}
+```
+
+## See also
+
+- [DLP — Data Profiles](data-profiles.md) — `DetectionRuleItem` with `detection_technique: 'dictionary'` references dictionary ids
+- [DLP — Data Patterns](data-patterns.md) — alternative detection surface (regex / weighted_regex)
+- Runnable walkthrough: [`examples/mgmt-dlp-dictionaries.ts`](https://github.com/cdot65/prisma-airs-sdk/blob/main/examples/mgmt-dlp-dictionaries.ts)


### PR DESCRIPTION
Closes #154

## Summary

Each of the 4 DLP service docs pages (`data-filtering-profiles`, `data-patterns`, `data-profiles`, `dictionaries`) now has:

- **Required-fields reference table** with POST vs PATCH requirement and JSON Merge Patch nullability columns
- **2 contrived use-case walkthroughs** per page, each structured as **scenario → input (TS code) → expected output (JSON) → validation (assertion-style TS)**
- **Error handling** block with `AISecSDKException` + `ErrorType` switch tailored to that endpoint
- **Cross-links** to related subclients ("See also")

8 use cases total. Examples include: enabled-profile audit script, per-group exception rule, weighted credit-card pattern + Merge Patch widening, expression_tree AND composition, multi_profile umbrella, dictionary keyword round-trip, and 200/204 tolerant replace.

## Test plan

- [x] `pnpm format` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1236/1236
- [x] `mkdocs build --strict` — clean (only pre-existing unrelated INFO)
- [ ] CI green