### PR TITLE
fix(dlp): accept null + numeric timestamps in response schemas (#158)

### DIFF
--- a/.changeset/0030-dlp-nullable-sweep.md
+++ b/.changeset/0030-dlp-nullable-sweep.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Fix DLP response schemas rejecting `null` and numeric epoch timestamps from the live API (issue #158). Convert every top-level `.optional()` on `DataFilteringProfileResponseSchema`, `DataPatternResponseSchema`, `DataProfileResponseSchema`, `DictionaryResponseSchema`, `DlpReportSchema`, and `AuditResponseSchema` to `.nullish()` so unset values arriving as `null` parse cleanly. Widen `AuditResponseSchema.created_at` and `updated_at` to `z.union([z.string(), z.number()]).nullish()` — the API has been observed emitting epoch-ms integers, not just ISO strings. Request schemas remain strict (no nulls on write).

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,27 @@
 # Release Notes
 
+## v0.9.1
+
+### Bug Fixes — DLP Response Schemas
+
+Hotfix for [issue #158](https://github.com/cdot65/prisma-airs-sdk/issues/158): live `api.dlp.paloaltonetworks.com` responses fail Zod validation because `.optional()` rejects `null` and the API emits `null` (not `undefined`) for unset fields. Surfaced during smoke-testing of [prisma-airs-cli PR #78](https://github.com/cdot65/prisma-airs-cli/pull/78).
+
+**Schema changes (all backward compatible):**
+
+- `AuditResponseSchema` (`src/models/dlp-audit.ts`) — `created_by` / `updated_by` → `.nullish()`. `created_at` / `updated_at` widened to `z.union([z.string(), z.number()]).nullish()` because the API has been observed returning epoch-ms integers, not just ISO strings.
+- `DataFilteringProfileResponseSchema` — every top-level `.optional()` → `.nullish()`. Specifically resolves rejection of `description`, `is_end_user_coaching_enabled`, `euc_template_id`, `rule1`, `rule2` when those fields arrive as `null`.
+- `DataPatternResponseSchema` — every top-level `.optional()` → `.nullish()`.
+- `DataProfileResponseSchema` — every top-level `.optional()` → `.nullish()`.
+- `DictionaryResponseSchema` — every top-level `.optional()` → `.nullish()`.
+- `DlpReportSchema` (`src/models/dlp-report.ts`) — every field `.nullish()` for consistency.
+
+**Out of scope:**
+
+- `*RequestSchema` files stay strict (`.optional()`) — the API tolerates omission on write but the SDK should not emit explicit `null`s on PUT/POST bodies.
+- Patch request schemas (`*PatchRequestSchema`) unchanged — `jsonNullable()` already handles JSON Merge Patch null semantics correctly.
+
+**Test coverage:** added null-acceptance and numeric-timestamp acceptance cases to `test/models/dlp-audit.spec.ts`, `dlp-data-filtering-profile.spec.ts`, `dlp-data-pattern.spec.ts`, `dlp-data-profile.spec.ts`, `dlp-dictionary.spec.ts` (10 new tests). All 1246 tests pass.
+
 ## v0.9.0
 
 ### New Features — DLP Service Coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.9.0';
+export const SDK_VERSION = '0.9.1';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/models/dlp-audit.ts
+++ b/src/models/dlp-audit.ts
@@ -4,15 +4,16 @@ import { z } from 'zod';
  * Audit metadata block shared by every DLP resource response. Tracks who created
  * and last updated the resource.
  *
- * All fields are optional; the DLP API may omit some on partially-managed records
- * (e.g. system-seeded predefined patterns).
+ * All fields are nullish (the live API emits `null` for unset values, not `undefined`).
+ * Timestamps accept either ISO string or numeric epoch (ms) — the API has been
+ * observed to emit both shapes across different records.
  */
 export const AuditResponseSchema = z
   .object({
-    created_at: z.string().optional(),
-    created_by: z.string().optional(),
-    updated_at: z.string().optional(),
-    updated_by: z.string().optional(),
+    created_at: z.union([z.string(), z.number()]).nullish(),
+    created_by: z.string().nullish(),
+    updated_at: z.union([z.string(), z.number()]).nullish(),
+    updated_by: z.string().nullish(),
   })
   .passthrough();
 

--- a/src/models/dlp-data-filtering-profile.ts
+++ b/src/models/dlp-data-filtering-profile.ts
@@ -131,32 +131,37 @@ export const DataFilteringProfileRequestSchema = z
   .passthrough();
 export type DataFilteringProfileRequest = z.infer<typeof DataFilteringProfileRequestSchema>;
 
-/** Response payload returned by GET / PUT on a Data Filtering Profile. */
+/**
+ * Response payload returned by GET / PUT on a Data Filtering Profile.
+ *
+ * Every optional field is `.nullish()` — the live API emits `null` (not `undefined`)
+ * for unset values across the entire resource family.
+ */
 export const DataFilteringProfileResponseSchema = z
   .object({
-    id: z.string().optional(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    tenant_id: z.string().optional(),
-    type: z.string().optional(),
-    data_profile_id: z.number().optional(),
-    direction: z.string().optional(),
-    file_based: z.boolean().optional(),
-    non_file_based: z.boolean().optional(),
-    log_severity: z.string().optional(),
-    scan_type: z.enum(['include', 'exclude']).optional(),
-    is_end_user_coaching_enabled: z.boolean().optional(),
-    is_granular_profile: z.boolean().optional(),
-    is_parent_managed: z.boolean().optional(),
-    euc_template_id: z.string().optional(),
-    version: z.number().optional(),
-    file_type: z.array(z.string()).optional(),
-    audit_metadata: AuditResponseSchema.optional(),
-    criteria_details: z.array(DataFilteringDetailsSchema).optional(),
-    exception_rules: z.array(ExceptionRuleDTOSchema).optional(),
-    exclusions: ExclusionsSchema.optional(),
-    rule1: DataFilteringRuleDTOSchema.optional(),
-    rule2: DataFilteringRuleDTOSchema.optional(),
+    id: z.string().nullish(),
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    tenant_id: z.string().nullish(),
+    type: z.string().nullish(),
+    data_profile_id: z.number().nullish(),
+    direction: z.string().nullish(),
+    file_based: z.boolean().nullish(),
+    non_file_based: z.boolean().nullish(),
+    log_severity: z.string().nullish(),
+    scan_type: z.enum(['include', 'exclude']).nullish(),
+    is_end_user_coaching_enabled: z.boolean().nullish(),
+    is_granular_profile: z.boolean().nullish(),
+    is_parent_managed: z.boolean().nullish(),
+    euc_template_id: z.string().nullish(),
+    version: z.number().nullish(),
+    file_type: z.array(z.string()).nullish(),
+    audit_metadata: AuditResponseSchema.nullish(),
+    criteria_details: z.array(DataFilteringDetailsSchema).nullish(),
+    exception_rules: z.array(ExceptionRuleDTOSchema).nullish(),
+    exclusions: ExclusionsSchema.nullish(),
+    rule1: DataFilteringRuleDTOSchema.nullish(),
+    rule2: DataFilteringRuleDTOSchema.nullish(),
   })
   .passthrough();
 export type DataFilteringProfileResponse = z.infer<typeof DataFilteringProfileResponseSchema>;

--- a/src/models/dlp-data-pattern.ts
+++ b/src/models/dlp-data-pattern.ts
@@ -139,22 +139,27 @@ export const DataPatternPatchRequestSchema = z
   .passthrough();
 export type DataPatternPatchRequest = z.infer<typeof DataPatternPatchRequestSchema>;
 
-/** Response payload returned by GET / POST / PUT / PATCH on a data pattern. */
+/**
+ * Response payload returned by GET / POST / PUT / PATCH on a data pattern.
+ *
+ * Every optional field is `.nullish()` — the live API emits `null` (not `undefined`)
+ * for unset values.
+ */
 export const DataPatternResponseSchema = z
   .object({
-    id: z.string().optional(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    tenant_id: z.string().optional(),
-    type: DataPatternTypeSchema.optional(),
-    status: DataPatternStatusSchema.optional(),
-    license_type: DataPatternLicenseTypeSchema.optional(),
-    is_parent_managed: z.boolean().optional(),
-    version: z.number().optional(),
-    detection_config: DataPatternDetectionConfigSchema.optional(),
-    matching_rules: DataPatternMatchingRulesSchema.optional(),
-    tags: DataPatternTagsSchema.optional(),
-    audit_metadata: AuditResponseSchema.optional(),
+    id: z.string().nullish(),
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    tenant_id: z.string().nullish(),
+    type: DataPatternTypeSchema.nullish(),
+    status: DataPatternStatusSchema.nullish(),
+    license_type: DataPatternLicenseTypeSchema.nullish(),
+    is_parent_managed: z.boolean().nullish(),
+    version: z.number().nullish(),
+    detection_config: DataPatternDetectionConfigSchema.nullish(),
+    matching_rules: DataPatternMatchingRulesSchema.nullish(),
+    tags: DataPatternTagsSchema.nullish(),
+    audit_metadata: AuditResponseSchema.nullish(),
   })
   .passthrough();
 export type DataPatternResponse = z.infer<typeof DataPatternResponseSchema>;

--- a/src/models/dlp-data-profile.ts
+++ b/src/models/dlp-data-profile.ts
@@ -194,22 +194,27 @@ export const DataProfilePatchRequestSchema = z
   .passthrough();
 export type DataProfilePatchRequest = z.infer<typeof DataProfilePatchRequestSchema>;
 
-/** Response payload returned by GET / POST / PUT / PATCH on a data profile. */
+/**
+ * Response payload returned by GET / POST / PUT / PATCH on a data profile.
+ *
+ * Every optional field is `.nullish()` — the live API emits `null` (not `undefined`)
+ * for unset values.
+ */
 export const DataProfileResponseSchema = z
   .object({
-    id: z.string().optional(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    tenant_id: z.string().optional(),
-    type: DataProfileSubtypeSchema.optional(),
-    profile_status: DataProfileStatusSchema.optional(),
-    profile_type: DataProfileTypeSchema.optional(),
-    is_granular_data_profile: z.boolean().optional(),
-    is_parent_managed: z.boolean().optional(),
-    version: z.number().int().optional(),
-    advance_data_patterns_rule_request: z.array(z.string()).optional(),
-    detection_rules: z.array(DetectionRuleSchema).optional(),
-    audit_metadata: AuditResponseSchema.optional(),
+    id: z.string().nullish(),
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    tenant_id: z.string().nullish(),
+    type: DataProfileSubtypeSchema.nullish(),
+    profile_status: DataProfileStatusSchema.nullish(),
+    profile_type: DataProfileTypeSchema.nullish(),
+    is_granular_data_profile: z.boolean().nullish(),
+    is_parent_managed: z.boolean().nullish(),
+    version: z.number().int().nullish(),
+    advance_data_patterns_rule_request: z.array(z.string()).nullish(),
+    detection_rules: z.array(DetectionRuleSchema).nullish(),
+    audit_metadata: AuditResponseSchema.nullish(),
   })
   .passthrough();
 export type DataProfileResponse = z.infer<typeof DataProfileResponseSchema>;

--- a/src/models/dlp-dictionary.ts
+++ b/src/models/dlp-dictionary.ts
@@ -121,25 +121,30 @@ export const DictionaryPatchRequestSchema = z
   .passthrough();
 export type DictionaryPatchRequest = z.infer<typeof DictionaryPatchRequestSchema>;
 
-/** Response payload returned by GET / POST / PUT / PATCH on a dictionary. */
+/**
+ * Response payload returned by GET / POST / PUT / PATCH on a dictionary.
+ *
+ * Every optional field is `.nullish()` — the live API emits `null` (not `undefined`)
+ * for unset values.
+ */
 export const DictionaryResponseSchema = z
   .object({
-    id: z.string().optional(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    category: z.string().optional(),
-    region_name: z.string().optional(),
-    type: DictionaryTypeSchema.optional(),
-    is_case_sensitive: z.boolean().optional(),
-    is_parent_managed: z.boolean().optional(),
-    detection_technique: DictionaryDetectionTechniqueSchema.optional(),
-    detection_sub_technique: DictionaryDetectionSubTechniqueSchema.optional(),
-    dictionary_metadata: DictionaryMetaDataDTOSchema.optional(),
+    id: z.string().nullish(),
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    category: z.string().nullish(),
+    region_name: z.string().nullish(),
+    type: DictionaryTypeSchema.nullish(),
+    is_case_sensitive: z.boolean().nullish(),
+    is_parent_managed: z.boolean().nullish(),
+    detection_technique: DictionaryDetectionTechniqueSchema.nullish(),
+    detection_sub_technique: DictionaryDetectionSubTechniqueSchema.nullish(),
+    dictionary_metadata: DictionaryMetaDataDTOSchema.nullish(),
     /** Keyword list — populated only when `keywords=true` is passed as a query parameter. */
-    keywords: z.array(z.string()).optional(),
-    tags: DictionaryTagsSchema.optional(),
-    attributes: z.array(ResourceModelExtensionSchema).optional(),
-    audit_metadata: AuditResponseSchema.optional(),
+    keywords: z.array(z.string()).nullish(),
+    tags: DictionaryTagsSchema.nullish(),
+    attributes: z.array(ResourceModelExtensionSchema).nullish(),
+    audit_metadata: AuditResponseSchema.nullish(),
   })
   .passthrough();
 export type DictionaryResponse = z.infer<typeof DictionaryResponseSchema>;

--- a/src/models/dlp-report.ts
+++ b/src/models/dlp-report.ts
@@ -1,16 +1,21 @@
 import { z } from 'zod';
 import { DlpPatternDetectionSchema } from './detection-reports.js';
 
-/** Zod schema for a DLP (Data Loss Prevention) report. */
+/**
+ * Zod schema for a DLP (Data Loss Prevention) report.
+ *
+ * Every field is `.nullish()` — the live API emits `null` (not `undefined`) for
+ * unset values across all DLP responses.
+ */
 export const DlpReportSchema = z
   .object({
-    dlp_report_id: z.string().optional(),
-    dlp_profile_name: z.string().optional(),
-    dlp_profile_id: z.string().optional(),
-    dlp_profile_version: z.number().optional(),
-    data_pattern_rule1_verdict: z.string().optional(),
-    data_pattern_rule2_verdict: z.string().optional(),
-    data_pattern_detection_offsets: z.array(DlpPatternDetectionSchema).optional(),
+    dlp_report_id: z.string().nullish(),
+    dlp_profile_name: z.string().nullish(),
+    dlp_profile_id: z.string().nullish(),
+    dlp_profile_version: z.number().nullish(),
+    data_pattern_rule1_verdict: z.string().nullish(),
+    data_pattern_rule2_verdict: z.string().nullish(),
+    data_pattern_detection_offsets: z.array(DlpPatternDetectionSchema).nullish(),
   })
   .passthrough();
 

--- a/test/models/dlp-audit.spec.ts
+++ b/test/models/dlp-audit.spec.ts
@@ -29,4 +29,22 @@ describe('AuditResponseSchema', () => {
     });
     expect(r.success).toBe(true);
   });
+
+  it('accepts null for all four fields (live API emits null on unset)', () => {
+    const r = AuditResponseSchema.safeParse({
+      created_at: null,
+      created_by: null,
+      updated_at: null,
+      updated_by: null,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts numeric epoch (ms) for created_at and updated_at', () => {
+    const r = AuditResponseSchema.safeParse({
+      created_at: 1779560642845,
+      updated_at: 1779560642999,
+    });
+    expect(r.success).toBe(true);
+  });
 });

--- a/test/models/dlp-data-filtering-profile.spec.ts
+++ b/test/models/dlp-data-filtering-profile.spec.ts
@@ -268,6 +268,29 @@ describe('DataFilteringProfileResponseSchema', () => {
   it('parses an empty response', () => {
     expect(DataFilteringProfileResponseSchema.safeParse({}).success).toBe(true);
   });
+  it('accepts null for nullable string/boolean/object fields per live API (issue #158)', () => {
+    const r = DataFilteringProfileResponseSchema.safeParse({
+      ...responseFixture,
+      description: null,
+      is_end_user_coaching_enabled: null,
+      euc_template_id: null,
+      rule1: null,
+      rule2: null,
+    });
+    expect(r.success).toBe(true);
+  });
+  it('accepts null audit_metadata fields (live API emits null on unset)', () => {
+    const r = DataFilteringProfileResponseSchema.safeParse({
+      ...responseFixture,
+      audit_metadata: {
+        created_at: null,
+        created_by: null,
+        updated_at: 1779560642845,
+        updated_by: null,
+      },
+    });
+    expect(r.success).toBe(true);
+  });
 });
 
 describe('PageDataFilteringProfileResponseSchema', () => {

--- a/test/models/dlp-data-pattern.spec.ts
+++ b/test/models/dlp-data-pattern.spec.ts
@@ -324,6 +324,27 @@ describe('DataPatternResponseSchema', () => {
       DataPatternResponseSchema.safeParse({ ...responseFixture, future_field: 'ok' }).success,
     ).toBe(true);
   });
+  it('accepts null for nullable string/boolean/object fields per live API (issue #158)', () => {
+    const r = DataPatternResponseSchema.safeParse({
+      ...responseFixture,
+      description: null,
+      matching_rules: null,
+      tags: null,
+    });
+    expect(r.success).toBe(true);
+  });
+  it('accepts null audit_metadata fields (live API emits null on unset)', () => {
+    const r = DataPatternResponseSchema.safeParse({
+      ...responseFixture,
+      audit_metadata: {
+        created_at: null,
+        created_by: null,
+        updated_at: 1779560642845,
+        updated_by: null,
+      },
+    });
+    expect(r.success).toBe(true);
+  });
 });
 
 describe('PageDataPatternResponseSchema', () => {

--- a/test/models/dlp-data-profile.spec.ts
+++ b/test/models/dlp-data-profile.spec.ts
@@ -386,6 +386,27 @@ describe('DataProfileResponseSchema', () => {
       DataProfileResponseSchema.safeParse({ ...responseFixture, future_field: 'ok' }).success,
     ).toBe(true);
   });
+  it('accepts null for nullable string/object fields per live API (issue #158)', () => {
+    const r = DataProfileResponseSchema.safeParse({
+      ...responseFixture,
+      description: null,
+      detection_rules: null,
+      advance_data_patterns_rule_request: null,
+    });
+    expect(r.success).toBe(true);
+  });
+  it('accepts null audit_metadata fields (live API emits null on unset)', () => {
+    const r = DataProfileResponseSchema.safeParse({
+      ...responseFixture,
+      audit_metadata: {
+        created_at: null,
+        created_by: null,
+        updated_at: 1779560642845,
+        updated_by: null,
+      },
+    });
+    expect(r.success).toBe(true);
+  });
 });
 
 describe('PageDataProfileResponseSchema', () => {

--- a/test/models/dlp-dictionary.spec.ts
+++ b/test/models/dlp-dictionary.spec.ts
@@ -248,6 +248,29 @@ describe('DictionaryResponseSchema', () => {
       DictionaryResponseSchema.safeParse({ ...responseFixture, future_field: 'ok' }).success,
     ).toBe(true);
   });
+  it('accepts null for nullable string/boolean/object fields per live API (issue #158)', () => {
+    const r = DictionaryResponseSchema.safeParse({
+      ...responseFixture,
+      description: null,
+      is_case_sensitive: null,
+      region_name: null,
+      tags: null,
+      keywords: null,
+    });
+    expect(r.success).toBe(true);
+  });
+  it('accepts null audit_metadata fields (live API emits null on unset)', () => {
+    const r = DictionaryResponseSchema.safeParse({
+      ...responseFixture,
+      audit_metadata: {
+        created_at: null,
+        created_by: null,
+        updated_at: 1779560642845,
+        updated_by: null,
+      },
+    });
+    expect(r.success).toBe(true);
+  });
 });
 
 describe('PageDictionaryResponseSchema', () => {


### PR DESCRIPTION
## Summary

Closes #158. Hotfix for live `api.dlp.paloaltonetworks.com` responses failing Zod validation. Surfaced during smoke-test of [prisma-airs-cli PR #78](https://github.com/cdot65/prisma-airs-cli/pull/78).

**Root cause:** Zod `.optional()` permits `undefined` but rejects `null`. The live API emits `null` for unset object/string/boolean fields and emits numeric epoch (ms) for `updated_at`/`created_at` on some records.

**Scope:**

- `AuditResponseSchema` — all 4 fields `.nullish()`; timestamps widened to `z.union([z.string(), z.number()]).nullish()`.
- `DataFilteringProfileResponseSchema`, `DataPatternResponseSchema`, `DataProfileResponseSchema`, `DictionaryResponseSchema`, `DlpReportSchema` — every top-level `.optional()` → `.nullish()`.
- Request schemas left strict (API tolerates omit on write, SDK shouldn't emit nulls on PUT/POST).
- Patch request schemas unchanged (`jsonNullable()` already handles merge-patch null semantics).

**Tests:** 10 new cases covering null acceptance + numeric-timestamp acceptance across all 5 DLP response specs. RED → GREEN. Full suite: 1246 / 1246 pass.

**Release:** SDK_VERSION bumped to 0.9.1, changeset added (patch), release notes prepended.

## Test plan

- [x] Pre-commit: lint / format:check / typecheck / vitest all green locally
- [x] `mkdocs build --strict` succeeds (orphan plan file pre-existing, unrelated)
- [ ] CI green
- [ ] Post-merge: tag `v0.9.1`, GitHub release triggers npm publish
- [ ] Re-pin `@cdot65/prisma-airs-sdk` to `^0.9.1` in prisma-airs-cli and re-run smoke test