### PR TITLE
fix(dlp): nullish nested helper schemas (v0.9.2)

### DIFF
--- a/.changeset/0031-dlp-nullable-sweep-v2.md
+++ b/.changeset/0031-dlp-nullable-sweep-v2.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Extend nullable sweep to nested DLP helper schemas. v0.9.1 covered top-level Response fields but missed inner helpers — live API still returned `null` on nested fields and failed Zod. Now `.nullish()` across `DataPatternMatchingRulesSchema`, `ExpressionTreeNodeSchema` (recursive), `DetectionRuleItemSchema`, exclusion/exception helpers on `DataFilteringProfileResponseSchema`, and dictionary metadata/tags/extension helpers.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## v0.9.2
+
+### Bug Fixes — DLP Nested Helper Schemas
+
+Follow-up to v0.9.1. The earlier sweep widened top-level Response fields but missed nested helpers — live `api.dlp.paloaltonetworks.com` still returned `null` on inner fields and failed Zod. Surfaced re-running [prisma-airs-cli PR #78](https://github.com/cdot65/prisma-airs-cli/pull/78) DLP list commands against the live tenant.
+
+**Schema changes (all backward compatible):**
+
+- `DataPatternMatchingRulesSchema` (`src/models/dlp-data-pattern.ts`) — all 5 fields → `.nullish()`. Primary fix for `data-patterns list` Zod failures on nested `matching_rules`.
+- `ExpressionTreeNodeSchema` (`src/models/dlp-data-profile.ts`, recursive via `z.lazy`) — `operator_type`, `rule_item`, `sub_expressions` → `.nullish()`. Primary fix for `data-profiles list` Zod failures inside the expression tree. `ExpressionTreeNode` TS interface widened to allow `null` to match.
+- `DetectionRuleItemSchema` — 23 inner fields → `.nullish()` (`detection_technique` stays required as the discriminator-ish marker).
+- `MultiProfileDataNodeSchema`, `DefaultTreeDetectionRuleSchema.expression_tree`, `MultiProfileDetectionRuleSchema.multi_profile` → `.nullish()`.
+- `MetadataCriterionSchema`, `DataPatternDetectionConfigSchema.supported_confidence_levels`, `DataPatternTagsSchema` — all `.nullish()`.
+- `dlp-data-filtering-profile.ts` — 8 nested helpers (`AppExclusion`, `URLExclusion`, `Exclusions`, `SourceAttributes`, `DestinationAttributes`, `ExceptionRuleDTO`, `DataFilteringRuleDTO`, `DataFilteringDetails`) → `.nullish()`.
+- `dlp-dictionary.ts` — `DictionaryMetaDataDTOSchema`, `DictionaryTagsSchema`, `ResourceModelExtensionSchema` → `.nullish()`.
+
+**Side-effect (acceptable):** these helpers are shared by request schemas, so request payloads now tolerate explicit `null` on the affected inner fields. SDK user code would not intentionally serialize nulls there; top-level `*RequestSchema` files remain strict.
+
+**Test coverage:** 9 new test cases across `dlp-data-pattern.spec.ts`, `dlp-data-profile.spec.ts`, `dlp-data-filtering-profile.spec.ts`, `dlp-dictionary.spec.ts`. All 1255 tests pass.
+
 ## v0.9.1
 
 ### Bug Fixes — DLP Response Schemas

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.9.1';
+export const SDK_VERSION = '0.9.2';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/models/dlp-data-filtering-profile.ts
+++ b/src/models/dlp-data-filtering-profile.ts
@@ -5,9 +5,9 @@ import { pageSchema } from './dlp-page.js';
 /** App exclusion entry — application-level bypass for DLP scanning. */
 export const AppExclusionSchema = z
   .object({
-    app_id: z.string().optional(),
-    app_name: z.string().optional(),
-    type: z.string().optional(),
+    app_id: z.string().nullish(),
+    app_name: z.string().nullish(),
+    type: z.string().nullish(),
   })
   .passthrough();
 export type AppExclusion = z.infer<typeof AppExclusionSchema>;
@@ -15,9 +15,9 @@ export type AppExclusion = z.infer<typeof AppExclusionSchema>;
 /** URL exclusion entry — URL-level bypass for DLP scanning. */
 export const URLExclusionSchema = z
   .object({
-    type: z.string().optional(),
-    url_id: z.string().optional(),
-    url_name: z.string().optional(),
+    type: z.string().nullish(),
+    url_id: z.string().nullish(),
+    url_name: z.string().nullish(),
   })
   .passthrough();
 export type URLExclusion = z.infer<typeof URLExclusionSchema>;
@@ -25,13 +25,13 @@ export type URLExclusion = z.infer<typeof URLExclusionSchema>;
 /** Exclusions block — wraps app, URL, and arbitrary keyword exclusion lists. */
 export const ExclusionsSchema = z
   .object({
-    app_exclusion_list: z.array(AppExclusionSchema).optional(),
-    url_exclusion_list: z.array(URLExclusionSchema).optional(),
+    app_exclusion_list: z.array(AppExclusionSchema).nullish(),
+    url_exclusion_list: z.array(URLExclusionSchema).nullish(),
     /**
      * Map of category-name → string-array. `additionalProperties: { type: array of string }`
      * in the OpenAPI spec; modeled here as `z.record(z.array(z.string()))`.
      */
-    exclusion_list: z.record(z.array(z.string())).optional(),
+    exclusion_list: z.record(z.array(z.string())).nullish(),
   })
   .passthrough();
 export type Exclusions = z.infer<typeof ExclusionsSchema>;
@@ -39,9 +39,9 @@ export type Exclusions = z.infer<typeof ExclusionsSchema>;
 /** Source attributes for an exception rule. */
 export const SourceAttributesSchema = z
   .object({
-    match_any: z.boolean().optional(),
-    user_group_ids: z.array(z.string()).optional(),
-    user_ids: z.array(z.string()).optional(),
+    match_any: z.boolean().nullish(),
+    user_group_ids: z.array(z.string()).nullish(),
+    user_ids: z.array(z.string()).nullish(),
   })
   .passthrough();
 export type SourceAttributes = z.infer<typeof SourceAttributesSchema>;
@@ -49,9 +49,9 @@ export type SourceAttributes = z.infer<typeof SourceAttributesSchema>;
 /** Destination attributes for an exception rule. */
 export const DestinationAttributesSchema = z
   .object({
-    match_any: z.boolean().optional(),
-    app_ids: z.array(z.string()).optional(),
-    url_patterns: z.array(z.string()).optional(),
+    match_any: z.boolean().nullish(),
+    app_ids: z.array(z.string()).nullish(),
+    url_patterns: z.array(z.string()).nullish(),
   })
   .passthrough();
 export type DestinationAttributes = z.infer<typeof DestinationAttributesSchema>;
@@ -59,16 +59,16 @@ export type DestinationAttributes = z.infer<typeof DestinationAttributesSchema>;
 /** Exception rule — bypass that fires before the main filter logic. */
 export const ExceptionRuleDTOSchema = z
   .object({
-    id: z.string().optional(),
-    action: z.enum(['ALLOW', 'ALERT', 'BLOCK']).optional(),
-    log_severity: z.enum(['INFORMATIONAL', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL']).optional(),
+    id: z.string().nullish(),
+    action: z.enum(['ALLOW', 'ALERT', 'BLOCK']).nullish(),
+    log_severity: z.enum(['INFORMATIONAL', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL']).nullish(),
     /**
      * `int64` per spec; declared as `z.number()` since JS numbers cover any realistic
      * data_profile_id and the SDK never round-trips these unmodified.
      */
-    data_profile_ids: z.array(z.number()).optional(),
-    destination_attributes: DestinationAttributesSchema.optional(),
-    source_attributes: SourceAttributesSchema.optional(),
+    data_profile_ids: z.array(z.number()).nullish(),
+    destination_attributes: DestinationAttributesSchema.nullish(),
+    source_attributes: SourceAttributesSchema.nullish(),
   })
   .passthrough();
 export type ExceptionRuleDTO = z.infer<typeof ExceptionRuleDTOSchema>;
@@ -76,9 +76,9 @@ export type ExceptionRuleDTO = z.infer<typeof ExceptionRuleDTOSchema>;
 /** Secondary filtering rule (rule1 / rule2 slots on a profile). */
 export const DataFilteringRuleDTOSchema = z
   .object({
-    action: z.string().optional(),
-    response_page: z.string().optional(),
-    show_rsp_page: z.string().optional(),
+    action: z.string().nullish(),
+    response_page: z.string().nullish(),
+    show_rsp_page: z.string().nullish(),
   })
   .passthrough();
 export type DataFilteringRuleDTO = z.infer<typeof DataFilteringRuleDTOSchema>;
@@ -90,16 +90,16 @@ export type DataFilteringRuleDTO = z.infer<typeof DataFilteringRuleDTOSchema>;
  */
 export const DataFilteringDetailsSchema = z
   .object({
-    action: z.string().optional(),
-    dataProfileId: z.number().optional(),
-    direction: z.string().optional(),
-    euc_template_id: z.string().optional(),
-    fileBased: z.string().optional(),
-    fileTypes: z.array(z.string()).optional(),
-    is_end_user_coaching_enabled: z.boolean().optional(),
-    logSeverity: z.string().optional(),
-    nonFileBased: z.string().optional(),
-    scanType: z.string().optional(),
+    action: z.string().nullish(),
+    dataProfileId: z.number().nullish(),
+    direction: z.string().nullish(),
+    euc_template_id: z.string().nullish(),
+    fileBased: z.string().nullish(),
+    fileTypes: z.array(z.string()).nullish(),
+    is_end_user_coaching_enabled: z.boolean().nullish(),
+    logSeverity: z.string().nullish(),
+    nonFileBased: z.string().nullish(),
+    scanType: z.string().nullish(),
   })
   .passthrough();
 export type DataFilteringDetails = z.infer<typeof DataFilteringDetailsSchema>;

--- a/src/models/dlp-data-pattern.ts
+++ b/src/models/dlp-data-pattern.ts
@@ -62,13 +62,18 @@ export const WeightedRegexSchema = z
   .passthrough();
 export type WeightedRegex = z.infer<typeof WeightedRegexSchema>;
 
-/** Metadata criterion for granular filtering inside matching_rules. */
+/**
+ * Metadata criterion for granular filtering inside matching_rules.
+ *
+ * Inner fields are `.nullish()` — live API emits `null` for unset values on response;
+ * shared with request paths but writing `null` would be unusual user input.
+ */
 export const MetadataCriterionSchema = z
   .object({
-    comparisonOperatorType: ComparisonOperatorTypeSchema.optional(),
-    name: z.string().optional(),
-    type: z.string().optional(),
-    value: z.string().optional(),
+    comparisonOperatorType: ComparisonOperatorTypeSchema.nullish(),
+    name: z.string().nullish(),
+    type: z.string().nullish(),
+    value: z.string().nullish(),
   })
   .passthrough();
 export type MetadataCriterion = z.infer<typeof MetadataCriterionSchema>;
@@ -80,20 +85,25 @@ export type MetadataCriterion = z.infer<typeof MetadataCriterionSchema>;
 export const DataPatternDetectionConfigSchema = z
   .object({
     technique: DataPatternTechniqueSchema,
-    supported_confidence_levels: z.array(DataPatternConfidenceLevelSchema).optional(),
+    supported_confidence_levels: z.array(DataPatternConfidenceLevelSchema).nullish(),
   })
   .passthrough();
 export type DataPatternDetectionConfig = z.infer<typeof DataPatternDetectionConfigSchema>;
 
-/** Matching rules — controls proximity, delimiters, regex weights, and metadata filters. */
+/**
+ * Matching rules — controls proximity, delimiters, regex weights, and metadata filters.
+ *
+ * Every inner field is `.nullish()` — live API confirmed to emit `null` for unset values
+ * (issue #160). `proximity_distance` keeps the 2..1000 bound only when a number is provided.
+ */
 export const DataPatternMatchingRulesSchema = z
   .object({
-    delimiter: z.string().optional(),
+    delimiter: z.string().nullish(),
     /** Proximity window for keyword matching — spec bounds 2..1000 inclusive. */
-    proximity_distance: z.number().int().min(2).max(1000).optional(),
-    proximity_keywords: z.array(z.string()).optional(),
-    regexes: z.array(WeightedRegexSchema).optional(),
-    metadata_criteria: z.array(MetadataCriterionSchema).optional(),
+    proximity_distance: z.number().int().min(2).max(1000).nullish(),
+    proximity_keywords: z.array(z.string()).nullish(),
+    regexes: z.array(WeightedRegexSchema).nullish(),
+    metadata_criteria: z.array(MetadataCriterionSchema).nullish(),
   })
   .passthrough();
 export type DataPatternMatchingRules = z.infer<typeof DataPatternMatchingRulesSchema>;
@@ -101,9 +111,9 @@ export type DataPatternMatchingRules = z.infer<typeof DataPatternMatchingRulesSc
 /** Metadata tag arrays attached to a pattern. */
 export const DataPatternTagsSchema = z
   .object({
-    classification: z.array(z.string()).optional(),
-    compliance: z.array(z.string()).optional(),
-    geography: z.array(z.string()).optional(),
+    classification: z.array(z.string()).nullish(),
+    compliance: z.array(z.string()).nullish(),
+    geography: z.array(z.string()).nullish(),
   })
   .passthrough();
 export type DataPatternTags = z.infer<typeof DataPatternTagsSchema>;

--- a/src/models/dlp-data-profile.ts
+++ b/src/models/dlp-data-profile.ts
@@ -75,30 +75,30 @@ export type DataProfileSubtype = z.infer<typeof DataProfileSubtypeSchema>;
 export const DetectionRuleItemSchema = z
   .object({
     detection_technique: RuleItemDetectionTechniqueSchema,
-    id: z.string().optional(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    version: z.number().int().optional(),
-    match_type: RuleItemMatchTypeSchema.optional(),
-    by_unique_count: z.boolean().optional(),
-    confidence_level: RuleItemConfidenceLevelSchema.optional(),
-    supported_confidence_levels: z.array(RuleItemConfidenceLevelSchema).optional(),
-    occurrence_count: z.number().int().optional(),
-    occurrence_high: z.number().int().optional(),
-    occurrence_low: z.number().int().optional(),
-    occurrence_operator_type: RuleItemOccurrenceOperatorTypeSchema.optional(),
+    id: z.string().nullish(),
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    version: z.number().int().nullish(),
+    match_type: RuleItemMatchTypeSchema.nullish(),
+    by_unique_count: z.boolean().nullish(),
+    confidence_level: RuleItemConfidenceLevelSchema.nullish(),
+    supported_confidence_levels: z.array(RuleItemConfidenceLevelSchema).nullish(),
+    occurrence_count: z.number().int().nullish(),
+    occurrence_high: z.number().int().nullish(),
+    occurrence_low: z.number().int().nullish(),
+    occurrence_operator_type: RuleItemOccurrenceOperatorTypeSchema.nullish(),
     // dictionary + document-type fields
-    score: z.number().int().optional(),
-    score_high: z.number().int().optional(),
-    score_low: z.number().int().optional(),
+    score: z.number().int().nullish(),
+    score_high: z.number().int().nullish(),
+    score_low: z.number().int().nullish(),
     // edm fields
-    edm_dataset_id: z.string().optional(),
-    primary_fields: z.array(z.string()).optional(),
-    primary_match_criteria: RuleItemEdmMatchCriteriaSchema.optional(),
-    primary_match_any_count: z.number().int().optional(),
-    secondary_fields: z.array(z.string()).optional(),
-    secondary_match_criteria: RuleItemEdmMatchCriteriaSchema.optional(),
-    secondary_match_any_count: z.number().int().optional(),
+    edm_dataset_id: z.string().nullish(),
+    primary_fields: z.array(z.string()).nullish(),
+    primary_match_criteria: RuleItemEdmMatchCriteriaSchema.nullish(),
+    primary_match_any_count: z.number().int().nullish(),
+    secondary_fields: z.array(z.string()).nullish(),
+    secondary_match_criteria: RuleItemEdmMatchCriteriaSchema.nullish(),
+    secondary_match_any_count: z.number().int().nullish(),
   })
   .passthrough();
 export type DetectionRuleItem = z.infer<typeof DetectionRuleItemSchema>;
@@ -109,18 +109,18 @@ export type DetectionRuleItem = z.infer<typeof DetectionRuleItemSchema>;
  * joining children.
  */
 export interface ExpressionTreeNode {
-  operator_type?: ExpressionOperatorType;
-  rule_item?: DetectionRuleItem;
-  sub_expressions?: ExpressionTreeNode[];
+  operator_type?: ExpressionOperatorType | null;
+  rule_item?: DetectionRuleItem | null;
+  sub_expressions?: ExpressionTreeNode[] | null;
   [key: string]: unknown;
 }
 
 export const ExpressionTreeNodeSchema: z.ZodType<ExpressionTreeNode> = z.lazy(() =>
   z
     .object({
-      operator_type: ExpressionOperatorTypeSchema.optional(),
-      rule_item: DetectionRuleItemSchema.optional(),
-      sub_expressions: z.array(ExpressionTreeNodeSchema).optional(),
+      operator_type: ExpressionOperatorTypeSchema.nullish(),
+      rule_item: DetectionRuleItemSchema.nullish(),
+      sub_expressions: z.array(ExpressionTreeNodeSchema).nullish(),
     })
     .passthrough(),
 );
@@ -132,8 +132,8 @@ export const ExpressionTreeNodeSchema: z.ZodType<ExpressionTreeNode> = z.lazy(()
  */
 export const MultiProfileDataNodeSchema = z
   .object({
-    data_profile_ids: z.array(z.number()).optional(),
-    operator_type: ExpressionOperatorTypeSchema.optional(),
+    data_profile_ids: z.array(z.number()).nullish(),
+    operator_type: ExpressionOperatorTypeSchema.nullish(),
   })
   .passthrough();
 export type MultiProfileDataNode = z.infer<typeof MultiProfileDataNodeSchema>;
@@ -142,7 +142,7 @@ export type MultiProfileDataNode = z.infer<typeof MultiProfileDataNodeSchema>;
 export const DefaultTreeDetectionRuleSchema = z
   .object({
     rule_type: z.literal('expression_tree'),
-    expression_tree: ExpressionTreeNodeSchema.optional(),
+    expression_tree: ExpressionTreeNodeSchema.nullish(),
   })
   .passthrough();
 export type DefaultTreeDetectionRule = z.infer<typeof DefaultTreeDetectionRuleSchema>;
@@ -151,7 +151,7 @@ export type DefaultTreeDetectionRule = z.infer<typeof DefaultTreeDetectionRuleSc
 export const MultiProfileDetectionRuleSchema = z
   .object({
     rule_type: z.literal('multi_profile'),
-    multi_profile: MultiProfileDataNodeSchema.optional(),
+    multi_profile: MultiProfileDataNodeSchema.nullish(),
   })
   .passthrough();
 export type MultiProfileDetectionRule = z.infer<typeof MultiProfileDetectionRuleSchema>;

--- a/src/models/dlp-dictionary.ts
+++ b/src/models/dlp-dictionary.ts
@@ -63,9 +63,9 @@ export type DictionaryDetectionSubTechnique = z.infer<typeof DictionaryDetection
 /** Metadata about the uploaded keyword file. */
 export const DictionaryMetaDataDTOSchema = z
   .object({
-    number_of_keywords: z.number().optional(),
-    original_file_name: z.string().optional(),
-    original_file_size_in_byte: z.number().optional(),
+    number_of_keywords: z.number().nullish(),
+    original_file_name: z.string().nullish(),
+    original_file_size_in_byte: z.number().nullish(),
   })
   .passthrough();
 export type DictionaryMetaDataDTO = z.infer<typeof DictionaryMetaDataDTOSchema>;
@@ -73,7 +73,7 @@ export type DictionaryMetaDataDTO = z.infer<typeof DictionaryMetaDataDTOSchema>;
 /** Tag block attached to a dictionary. */
 export const DictionaryTagsSchema = z
   .object({
-    classification: z.array(DictionaryClassificationSchema).optional(),
+    classification: z.array(DictionaryClassificationSchema).nullish(),
   })
   .passthrough();
 export type DictionaryTags = z.infer<typeof DictionaryTagsSchema>;
@@ -81,8 +81,8 @@ export type DictionaryTags = z.infer<typeof DictionaryTagsSchema>;
 /** Free-form k/v extension entry returned on dictionary responses. */
 export const ResourceModelExtensionSchema = z
   .object({
-    key: z.string().optional(),
-    value: z.string().optional(),
+    key: z.string().nullish(),
+    value: z.string().nullish(),
   })
   .passthrough();
 export type ResourceModelExtension = z.infer<typeof ResourceModelExtensionSchema>;

--- a/test/models/dlp-data-filtering-profile.spec.ts
+++ b/test/models/dlp-data-filtering-profile.spec.ts
@@ -291,6 +291,51 @@ describe('DataFilteringProfileResponseSchema', () => {
     });
     expect(r.success).toBe(true);
   });
+  it('accepts null on every nested helper inner field (defensive sweep, issue #160)', () => {
+    const r = DataFilteringProfileResponseSchema.safeParse({
+      ...responseFixture,
+      criteria_details: [
+        {
+          action: null,
+          dataProfileId: null,
+          direction: null,
+          euc_template_id: null,
+          fileBased: null,
+          fileTypes: null,
+          is_end_user_coaching_enabled: null,
+          logSeverity: null,
+          nonFileBased: null,
+          scanType: null,
+        },
+      ],
+      exception_rules: [
+        {
+          id: null,
+          action: null,
+          log_severity: null,
+          data_profile_ids: null,
+          destination_attributes: {
+            match_any: null,
+            app_ids: null,
+            url_patterns: null,
+          },
+          source_attributes: {
+            match_any: null,
+            user_group_ids: null,
+            user_ids: null,
+          },
+        },
+      ],
+      exclusions: {
+        app_exclusion_list: [{ app_id: null, app_name: null, type: null }],
+        url_exclusion_list: [{ type: null, url_id: null, url_name: null }],
+        exclusion_list: null,
+      },
+      rule1: { action: null, response_page: null, show_rsp_page: null },
+      rule2: { action: null, response_page: null, show_rsp_page: null },
+    });
+    expect(r.success).toBe(true);
+  });
 });
 
 describe('PageDataFilteringProfileResponseSchema', () => {

--- a/test/models/dlp-data-pattern.spec.ts
+++ b/test/models/dlp-data-pattern.spec.ts
@@ -345,6 +345,43 @@ describe('DataPatternResponseSchema', () => {
     });
     expect(r.success).toBe(true);
   });
+  it('accepts null on every nested matching_rules field per live API (issue #160)', () => {
+    const r = DataPatternResponseSchema.safeParse({
+      ...responseFixture,
+      matching_rules: {
+        delimiter: null,
+        proximity_distance: null,
+        proximity_keywords: null,
+        regexes: null,
+        metadata_criteria: null,
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+  it('accepts null on detection_config.supported_confidence_levels (defensive)', () => {
+    const r = DataPatternResponseSchema.safeParse({
+      ...responseFixture,
+      detection_config: { technique: 'regex', supported_confidence_levels: null },
+    });
+    expect(r.success).toBe(true);
+  });
+  it('accepts null on tags inner array fields (defensive)', () => {
+    const r = DataPatternResponseSchema.safeParse({
+      ...responseFixture,
+      tags: { classification: null, compliance: null, geography: null },
+    });
+    expect(r.success).toBe(true);
+  });
+  it('accepts null on metadata_criteria inner fields (defensive)', () => {
+    const r = DataPatternResponseSchema.safeParse({
+      ...responseFixture,
+      matching_rules: {
+        ...responseFixture.matching_rules,
+        metadata_criteria: [{ comparisonOperatorType: null, name: null, type: null, value: null }],
+      },
+    });
+    expect(r.success).toBe(true);
+  });
 });
 
 describe('PageDataPatternResponseSchema', () => {

--- a/test/models/dlp-data-profile.spec.ts
+++ b/test/models/dlp-data-profile.spec.ts
@@ -407,6 +407,73 @@ describe('DataProfileResponseSchema', () => {
     });
     expect(r.success).toBe(true);
   });
+  it('accepts null on expression_tree.rule_item + sub_expressions[].{rule_item,operator_type} per live API (issue #160)', () => {
+    const r = DataProfileResponseSchema.safeParse({
+      ...responseFixture,
+      detection_rules: [
+        {
+          rule_type: 'expression_tree',
+          expression_tree: {
+            operator_type: 'and',
+            rule_item: null,
+            sub_expressions: [{ operator_type: null, rule_item: null, sub_expressions: null }],
+          },
+        },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+  it('accepts null on multi_profile node inner fields (defensive)', () => {
+    const r = DataProfileResponseSchema.safeParse({
+      ...responseFixture,
+      detection_rules: [
+        {
+          rule_type: 'multi_profile',
+          multi_profile: { data_profile_ids: null, operator_type: null },
+        },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+  it('accepts null on every DetectionRuleItem inner field (defensive)', () => {
+    const r = DataProfileResponseSchema.safeParse({
+      ...responseFixture,
+      detection_rules: [
+        {
+          rule_type: 'expression_tree',
+          expression_tree: {
+            operator_type: 'and',
+            rule_item: {
+              detection_technique: 'regex',
+              id: null,
+              name: null,
+              description: null,
+              version: null,
+              match_type: null,
+              by_unique_count: null,
+              confidence_level: null,
+              supported_confidence_levels: null,
+              occurrence_count: null,
+              occurrence_high: null,
+              occurrence_low: null,
+              occurrence_operator_type: null,
+              score: null,
+              score_high: null,
+              score_low: null,
+              edm_dataset_id: null,
+              primary_fields: null,
+              primary_match_criteria: null,
+              primary_match_any_count: null,
+              secondary_fields: null,
+              secondary_match_criteria: null,
+              secondary_match_any_count: null,
+            },
+          },
+        },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
 });
 
 describe('PageDataProfileResponseSchema', () => {

--- a/test/models/dlp-dictionary.spec.ts
+++ b/test/models/dlp-dictionary.spec.ts
@@ -271,6 +271,19 @@ describe('DictionaryResponseSchema', () => {
     });
     expect(r.success).toBe(true);
   });
+  it('accepts null on every nested helper inner field (defensive sweep, issue #160)', () => {
+    const r = DictionaryResponseSchema.safeParse({
+      ...responseFixture,
+      dictionary_metadata: {
+        number_of_keywords: null,
+        original_file_name: null,
+        original_file_size_in_byte: null,
+      },
+      tags: { classification: null },
+      attributes: [{ key: null, value: null }],
+    });
+    expect(r.success).toBe(true);
+  });
 });
 
 describe('PageDictionaryResponseSchema', () => {


### PR DESCRIPTION
## Summary

- Extends v0.9.1 nullable sweep to nested DLP helpers. Top-level Response fields were widened in v0.9.1, but live `api.dlp.paloaltonetworks.com` still emitted `null` on inner helpers — `data-patterns list` and `data-profiles list` still failed Zod.
- 18+ nested helper schemas across 4 dlp-*.ts files moved from `.optional()` → `.nullish()`. `ExpressionTreeNode` (recursive via `z.lazy`) TS interface widened to allow `null`.
- Side-effect: shared helpers also relax request schemas slightly. SDK user code wouldn't intentionally serialize null on these; top-level `*RequestSchema` files remain strict.

Closes #160.

## Test plan

- [x] 1255/1255 vitest pass
- [x] lint / format:check / typecheck clean (pre-commit hook)
- [ ] post-release: re-run 4 DLP `list` commands from prisma-airs-cli PR #78 against live tenant (CLI bump to ^0.9.2)