### PR TITLE
fix(http): send service-name: api on every request

### DIFF
--- a/.changeset/0000-dlp-service-name-header.md
+++ b/.changeset/0000-dlp-service-name-header.md
@@ -1,5 +1,5 @@
 ---
-'@cdot65/prisma-airs-sdk': patch
+'@cdot65/prisma-airs-sdk': minor
 ---
 
 Send `service-name: api` on every request. Fixes DLP `GET /v2/api/{data-patterns,data-profiles}/{id}` returning HTTP 400 on tenants whose downstream services require this header. Per AIRS API team guidance — header is optional in the spec but defensive on the client.

--- a/.changeset/0000-dlp-service-name-header.md
+++ b/.changeset/0000-dlp-service-name-header.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Send `service-name: api` on every request. Fixes DLP `GET /v2/api/{data-patterns,data-profiles}/{id}` returning HTTP 400 on tenants whose downstream services require this header. Per AIRS API team guidance — header is optional in the spec but defensive on the client.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -90,10 +90,13 @@ Walking it explicitly:
 
 1. **Build URL.** The base URL is right-trimmed of trailing slashes, then joined with `path`. Query
    `params` are appended; array values append once per element (`?id=a&id=b`).
-2. **Build headers + body.** A `User-Agent` of `PAN-AIRS/<version>-typescript-sdk` is always set.
-   If `formData` is present it is sent as-is (the runtime writes the multipart boundary). Otherwise
-   a `body` is JSON-stringified with `Content-Type: application/json` — overridable via
-   `contentType` (DLP endpoints use `application/merge-patch+json`).
+2. **Build headers + body.** A `User-Agent` of `PAN-AIRS/<version>-typescript-sdk` is always set,
+   along with `service-name: api` on every outgoing request — the header is optional in the AIRS
+   spec but required by some tenants' downstream services (notably DLP `GET /v2/api/data-patterns/{id}`
+   and `/v2/api/data-profiles/{id}`, which 400 without it). Sending it unconditionally avoids a
+   per-endpoint workaround. If `formData` is present it is sent as-is (the runtime writes the
+   multipart boundary). Otherwise a `body` is JSON-stringified with `Content-Type: application/json`
+   — overridable via `contentType` (DLP endpoints use `application/merge-patch+json`).
 3. **Auth.** The `auth.prepare()` adapter mutates the prepared headers (see below).
 4. **Fetch with retry.** The whole attempt runs inside `executeWithRetry` (`src/http-retry.ts`).
 5. **Validate.** On success, the body text is read once. If no `responseSchema` was declared,

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -33,7 +33,10 @@ export async function request<TResponse = void>(spec: RequestSpec<TResponse>): P
         }
       }
 
-      const headers: Record<string, string> = { 'User-Agent': USER_AGENT };
+      const headers: Record<string, string> = {
+        'User-Agent': USER_AGENT,
+        'service-name': 'api',
+      };
       let bodyText: string | undefined;
       let bodyForFetch: FormData | string | undefined;
       if (spec.formData !== undefined) {

--- a/test/http/request.spec.ts
+++ b/test/http/request.spec.ts
@@ -167,6 +167,26 @@ describe('request — body handling', () => {
     const [, init] = fetchSpy.mock.calls[0];
     expect((init.headers as Record<string, string>)['User-Agent']).toMatch(/PAN-AIRS/);
   });
+
+  // Regression for #162: AIRS DLP GET-by-id endpoints return 400 on tenants
+  // whose downstream services require the `service-name: api` header. The
+  // header is optional in the spec but defensive on the client per the AIRS
+  // API team's guidance.
+  it('sets service-name: api on every request', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse({}));
+    globalThis.fetch = fetchSpy;
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      auth: passthroughAuth,
+      numRetries: 0,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Record<string, string>)['service-name']).toBe('api');
+  });
 });
 
 describe('request — content type override', () => {

--- a/test/management/dlp/data-patterns.spec.ts
+++ b/test/management/dlp/data-patterns.spec.ts
@@ -134,6 +134,17 @@ describe('DataPatternsClient', () => {
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('weird%20id%2Fslash');
     });
+
+    // Regression for #162: tenants whose downstream services require the
+    // `service-name: api` header returned 400 for every valid id. The fix
+    // sets the header globally in src/http/request.ts; this asserts it
+    // reaches the DLP get-by-id call path.
+    it('sends service-name: api header', async () => {
+      mockFetch(patternFixture);
+      await client.get('dp-1');
+      const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect((init.headers as Record<string, string>)['service-name']).toBe('api');
+    });
   });
 
   describe('replace', () => {

--- a/test/management/dlp/data-profiles.spec.ts
+++ b/test/management/dlp/data-profiles.spec.ts
@@ -129,6 +129,14 @@ describe('DataProfilesClient', () => {
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('weird%20id%2Fslash');
     });
+
+    // Regression for #162 — see data-patterns.spec.ts for context.
+    it('sends service-name: api header', async () => {
+      mockFetch(profileFixture);
+      await client.get('prof-1');
+      const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect((init.headers as Record<string, string>)['service-name']).toBe('api');
+    });
   });
 
   describe('replace', () => {


### PR DESCRIPTION
## Summary

Adds the `service-name: api` request header globally in `src/http/request.ts` so every SDK call (Runtime API, Management API, DLP, Red-Team) sends it. Resolves DLP GET-by-id 400s reported in #162.

Per the AIRS API team's guidance on that issue:

> please add to your request `-H 'service-name: api'` — it's not mentioned in the spec since it's an optional header and for most apis it's not required. but some downstream services could still produce 400, so right now for the safety reason and to avoid this error I advise you to add to your requests. I'll make sure it's implicit one down the line.

## Verified live (2026-05-27, tenant `6198141467535401984`)

| Endpoint | Without header | With `service-name: api` |
|---|---|---|
| `GET /v2/api/data-patterns/{id}` | 400 Bad Request | **200 OK** |
| `GET /v2/api/data-profiles/{id}` | 400 Bad Request | **200 OK** |
| `GET /v2/api/data-patterns` (list) | 200 OK | 200 OK |
| `POST /v2/api/data-profiles` | 400 ("Invalid Request Body") | 400 ("Invalid Request Body") — **separate validation bug** |

POST/PATCH/PUT 400s on `data-profiles` are a distinct server-side validation issue and out of scope here — needs its own ticket once a valid request body is determined.

## Changes

- `src/http/request.ts` — one-line addition to the default headers map.
- `test/http/request.spec.ts` — new assertion mirroring the existing User-Agent test.
- `test/management/dlp/data-patterns.spec.ts` + `data-profiles.spec.ts` — regression tests asserting the header reaches the DLP `get(id)` call path.
- `.changeset/0000-dlp-service-name-header.md` — patch bump.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 1259/1259 passing
- [x] `npm run preflight` (schema drift) clean
- [x] TDD: tests written first, watched RED, then GREEN after the one-line src change
- [ ] Live tenant validation post-merge (re-run the `curl` matrix above)

Closes #162.