### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## v0.10.0
+
+### New Default — `service-name: api` Header on Every Request
+
+The SDK now sends `service-name: api` on every outbound HTTP request. Fixes [issue #162](https://github.com/cdot65/prisma-airs-sdk/issues/162): on tenants whose downstream services require the header, DLP `GET /v2/api/data-patterns/{id}` and `GET /v2/api/data-profiles/{id}` returned HTTP 400 for every id. Verified live (tenant 6198141467535401984, 2026-05-27): adding `service-name: api` alone flips both endpoints from 400 → 200. The header is optional in the spec but defensive on the client per AIRS API team guidance.
+
+**Surface:**
+
+- `src/http/request.ts` — header added to the default headers map, so every request through `request()` (Runtime, Management, DLP, Red-Team, Model Security) carries it.
+- `test/http/request.spec.ts` — regression test asserts the header is present on every fetch.
+- `test/management/dlp/data-patterns.spec.ts`, `test/management/dlp/data-profiles.spec.ts` — `get(id)` call-path regressions.
+
+**Not in this release (deferred):** `POST /v2/api/data-profiles` and `PUT/PATCH` on DLP profiles/patterns continue to return 400 with `"Invalid Request Body"` — a separate server-side validation surface, independent of the `service-name` header. Tracking separately.
+
+Minor bump (not patch) to flag the new default request header as behavior-affecting for proxies/log scrapers parsing SDK traffic.
+
 ## v0.9.2
 
 ### Bug Fixes — DLP Nested Helper Schemas

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.9.2';
+export const SDK_VERSION = '0.10.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
## Summary
- Bump version 0.9.2 → 0.10.0 (minor; service-name header is a default-behavior change)
- Adds release notes entry for the `service-name: api` default header (issue #162)

## Test plan
- [x] `npm run preflight` clean (1259/1259 tests)
- [ ] CI green