### PR TITLE
fix(management): tolerate plain-string DELETE response bodies

### DIFF
--- a/.changeset/0000-delete-string-body-tolerance.md
+++ b/.changeset/0000-delete-string-body-tolerance.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Accept plain-string response bodies on management `.delete()` methods. AIRS API returns `Content-Type: application/json` with a JSON-encoded plain-string body (e.g. `"successfully deleted ..."`) for DELETE on profiles, topics, api-keys, customer-apps; SDK now normalizes that to `{ message: <string> }` instead of throwing `AISEC_RESPONSE_VALIDATION`. `customerApps.delete` return type changes from `CustomerApp` to a new `CustomerAppDeleteResponse` (`{ message: string }`) — the prior signature was a fiction since the server never returned a `CustomerApp` on delete. Closes #164, #165, #166, #167.

--- a/src/management/customer-apps.ts
+++ b/src/management/customer-apps.ts
@@ -4,8 +4,10 @@ import type { AuthAdapter } from '../http/types.js';
 import type { PaginationOptions } from './profiles.js';
 import {
   CustomerAppSchema,
+  CustomerAppDeleteResponseSchema,
   CustomerAppListResponseSchema,
   type CustomerApp,
+  type CustomerAppDeleteResponse,
   type CustomerAppListResponse,
 } from '../models/mgmt-customer-app.js';
 
@@ -126,24 +128,23 @@ export class CustomerAppsClient {
    * Delete a customer app.
    * @param appName - Name of the customer app to delete.
    * @param updatedBy - Email of user performing the deletion.
-   * @returns The deleted customer app.
+   * @returns Deletion confirmation message.
    * @example
    * ```ts
    * import { ManagementClient } from '@cdot65/prisma-airs-sdk';
    * const mgmt = new ManagementClient(); // reads PANW_MGMT_* env vars
    *
-   * const app = await mgmt.customerApps.delete('myapp', 'user@example.com');
-   * // app =>
-   * // { tsg_id: '1234567890', app_name: 'myapp', cloud_provider: 'aws', environment: 'prod' }
+   * const result = await mgmt.customerApps.delete('myapp', 'user@example.com');
+   * // result => { message: 'customer app and associated keys successfully deleted' }
    * ```
    */
-  async delete(appName: string, updatedBy: string): Promise<CustomerApp> {
+  async delete(appName: string, updatedBy: string): Promise<CustomerAppDeleteResponse> {
     return request({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: MGMT_CUSTOMER_APP_PATH,
       params: { app_name: appName, updated_by: updatedBy },
-      responseSchema: CustomerAppSchema,
+      responseSchema: CustomerAppDeleteResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -188,6 +188,8 @@ export {
   type CustomerAppWithKeys,
   CustomerAppListResponseSchema,
   type CustomerAppListResponse,
+  CustomerAppDeleteResponseSchema,
+  type CustomerAppDeleteResponse,
 } from './mgmt-customer-app.js';
 export {
   DeploymentProfileEntrySchema,

--- a/src/models/mgmt-api-key.ts
+++ b/src/models/mgmt-api-key.ts
@@ -77,12 +77,15 @@ export const ApiKeyListResponseSchema = z
 /** Paginated API key list response. */
 export type ApiKeyListResponse = z.infer<typeof ApiKeyListResponseSchema>;
 
+// AIRS management returns a JSON-encoded plain string (e.g.
+// `"successfully deleted apiKeyName: <name>"`) on a successful DELETE despite
+// Content-Type: application/json. Accept both shapes and normalize the string
+// form to { message } so consumers see a stable object. See issue #166.
 /** Zod schema for API key delete response. */
-export const ApiKeyDeleteResponseSchema = z
-  .object({
-    message: z.string().optional(),
-  })
-  .passthrough();
+export const ApiKeyDeleteResponseSchema = z.union([
+  z.string().transform((message) => ({ message })),
+  z.object({ message: z.string().optional() }).passthrough(),
+]);
 
 /** API key delete response. */
 export type ApiKeyDeleteResponse = z.infer<typeof ApiKeyDeleteResponseSchema>;

--- a/src/models/mgmt-custom-topic.ts
+++ b/src/models/mgmt-custom-topic.ts
@@ -49,12 +49,15 @@ export const CustomTopicListResponseSchema = z
 /** Paginated list of custom topics. */
 export type CustomTopicListResponse = z.infer<typeof CustomTopicListResponseSchema>;
 
+// AIRS management returns a JSON-encoded plain string (e.g.
+// `"successfully deleted topicId: <id>"`) on a successful DELETE despite
+// Content-Type: application/json. Accept both shapes and normalize the string
+// form to { message } so consumers see a stable object. See issue #165.
 /** Zod schema for a topic deletion response. */
-export const DeleteTopicResponseSchema = z
-  .object({
-    message: z.string(),
-  })
-  .passthrough();
+export const DeleteTopicResponseSchema = z.union([
+  z.string().transform((message) => ({ message })),
+  z.object({ message: z.string() }).passthrough(),
+]);
 
 /** Response from deleting a custom topic. */
 export type DeleteTopicResponse = z.infer<typeof DeleteTopicResponseSchema>;

--- a/src/models/mgmt-customer-app.ts
+++ b/src/models/mgmt-customer-app.ts
@@ -58,3 +58,17 @@ export const CustomerAppListResponseSchema = z
 
 /** Paginated customer app list response. */
 export type CustomerAppListResponse = z.infer<typeof CustomerAppListResponseSchema>;
+
+// AIRS management returns a JSON-encoded plain string (e.g.
+// `"customer app and associated keys successfully deleted"`) on a successful
+// DELETE despite Content-Type: application/json. The previous schema reused
+// CustomerAppSchema, which never matched the real wire body, so every delete
+// threw RESPONSE_VALIDATION even though the resource was gone. See issue #167.
+/** Zod schema for a customer app deletion response. */
+export const CustomerAppDeleteResponseSchema = z.union([
+  z.string().transform((message) => ({ message })),
+  z.object({ message: z.string() }).passthrough(),
+]);
+
+/** Response from deleting a customer app. */
+export type CustomerAppDeleteResponse = z.infer<typeof CustomerAppDeleteResponseSchema>;

--- a/src/models/mgmt-security-profile.ts
+++ b/src/models/mgmt-security-profile.ts
@@ -297,12 +297,15 @@ export const SecurityProfileListResponseSchema: z.ZodType<SecurityProfileListRes
   })
   .passthrough();
 
+// AIRS management returns a JSON-encoded plain string (e.g.
+// `"successfully deleted profileId: <id>"`) on a successful DELETE despite
+// Content-Type: application/json. Accept both shapes and normalize the string
+// form to { message } so consumers see a stable object. See issue #164.
 /** Zod schema for a profile deletion response. */
-export const DeleteProfileResponseSchema = z
-  .object({
-    message: z.string(),
-  })
-  .passthrough();
+export const DeleteProfileResponseSchema = z.union([
+  z.string().transform((message) => ({ message })),
+  z.object({ message: z.string() }).passthrough(),
+]);
 
 /** Response from deleting a security profile. */
 export type DeleteProfileResponse = z.infer<typeof DeleteProfileResponseSchema>;

--- a/test/management/api-keys.spec.ts
+++ b/test/management/api-keys.spec.ts
@@ -89,6 +89,13 @@ describe('ApiKeysClient', () => {
       expect(url).toContain('updated_by=user');
       expect(init.method).toBe('DELETE');
     });
+
+    // Regression for #166 — see profiles.spec.ts for shared context.
+    it('tolerates plain-string body and normalizes to { message }', async () => {
+      mockFetch('successfully deleted apiKeyName: my-key');
+      const result = await client.delete('my-key', 'user@test.com');
+      expect(result.message).toBe('successfully deleted apiKeyName: my-key');
+    });
   });
 
   describe('regenerate', () => {

--- a/test/management/customer-apps.spec.ts
+++ b/test/management/customer-apps.spec.ts
@@ -70,14 +70,23 @@ describe('CustomerAppsClient', () => {
 
   describe('delete', () => {
     it('DELETEs /v1/mgmt/customerapp with app_name and updated_by', async () => {
-      const app = { tsg_id: '123', app_name: 'myapp', cloud_provider: 'aws', environment: 'prod' };
-      mockFetch(app);
+      mockFetch({ message: 'deleted' });
       await client.delete('myapp', 'user@test.com');
 
       const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('app_name=myapp');
       expect(url).toContain('updated_by=user');
       expect(init.method).toBe('DELETE');
+    });
+
+    // Regression for #167 — see profiles.spec.ts for shared context.
+    // Server returns a JSON-encoded plain string ("customer app and associated
+    // keys successfully deleted") on a successful DELETE; SDK must normalize
+    // it to { message } instead of throwing RESPONSE_VALIDATION.
+    it('tolerates plain-string body and normalizes to { message }', async () => {
+      mockFetch('customer app and associated keys successfully deleted');
+      const result = await client.delete('myapp', 'user@test.com');
+      expect(result.message).toBe('customer app and associated keys successfully deleted');
     });
   });
 });

--- a/test/management/profiles.spec.ts
+++ b/test/management/profiles.spec.ts
@@ -91,6 +91,27 @@ describe('ProfilesClient', () => {
     });
   });
 
+  // Regression for #164: AIRS management API returns a JSON-encoded plain
+  // string (e.g. `"successfully deleted profileId: <id>"`) on DELETE — the
+  // SDK schema previously expected an object and threw RESPONSE_VALIDATION
+  // even though the resource was gone server-side.
+  describe('delete — plain-string response body (regression #164)', () => {
+    it('normalizes a JSON-encoded string body to { message }', async () => {
+      mockFetch('successfully deleted profileId: 550e8400');
+      const result = await client.delete('550e8400-e29b-41d4-a716-446655440000');
+      expect(result.message).toBe('successfully deleted profileId: 550e8400');
+    });
+
+    it('forceDelete also tolerates plain-string body', async () => {
+      mockFetch('successfully force deleted profileId: 550e8400');
+      const result = await client.forceDelete(
+        '550e8400-e29b-41d4-a716-446655440000',
+        'admin@test.com',
+      );
+      expect(result.message).toBe('successfully force deleted profileId: 550e8400');
+    });
+  });
+
   describe('delete', () => {
     it('DELETEs profile by id', async () => {
       mockFetch({ message: 'deleted' });

--- a/test/management/topics.spec.ts
+++ b/test/management/topics.spec.ts
@@ -91,6 +91,24 @@ describe('TopicsClient', () => {
     });
   });
 
+  // Regression for #165 — see profiles.spec.ts for shared context.
+  describe('delete — plain-string response body (regression #165)', () => {
+    it('normalizes a JSON-encoded string body to { message }', async () => {
+      mockFetch('successfully deleted topicId: 550e8400');
+      const result = await client.delete('550e8400-e29b-41d4-a716-446655440000');
+      expect(result.message).toBe('successfully deleted topicId: 550e8400');
+    });
+
+    it('forceDelete also tolerates plain-string body', async () => {
+      mockFetch('successfully force deleted topicId: 550e8400');
+      const result = await client.forceDelete(
+        '550e8400-e29b-41d4-a716-446655440000',
+        'admin@test.com',
+      );
+      expect(result.message).toBe('successfully force deleted topicId: 550e8400');
+    });
+  });
+
   describe('delete', () => {
     it('DELETEs topic by id', async () => {
       mockFetch({ message: 'deleted' });


### PR DESCRIPTION
## Summary

Closes #164, #165, #166, #167.

AIRS management API returns `Content-Type: application/json` with a **JSON-encoded plain-string body** on a successful DELETE (e.g. `"successfully deleted profileId: <id>"`). The SDK schemas expected an object, so every `.delete()` threw `AISEC_RESPONSE_VALIDATION` even though the resource was gone server-side. Same family as the closed empty-body issue #136.

## Approach

Widen each delete-response Zod schema to a `z.union` that accepts either the plain-string body (normalized to `{ message }` via `.transform`) or the existing object shape. Consumers continue to read `result.message`.

```ts
// before
export const DeleteProfileResponseSchema = z.object({ message: z.string() }).passthrough();

// after
export const DeleteProfileResponseSchema = z.union([
  z.string().transform((message) => ({ message })),
  z.object({ message: z.string() }).passthrough(),
]);
```

## Affected call sites

| Issue | Method | Schema | Endpoint |
|---|---|---|---|
| #164 | `profiles.delete` | `DeleteProfileResponseSchema` | `DELETE /v1/mgmt/profile/{id}` |
| #164 | `profiles.forceDelete` | `DeleteProfileResponseSchema` | `DELETE /v1/mgmt/profile/{id}/force` |
| #165 | `topics.delete` | `DeleteTopicResponseSchema` | `DELETE /v1/mgmt/topic/{id}` |
| #165 | `topics.forceDelete` | `DeleteTopicResponseSchema` | `DELETE /v1/mgmt/topic/{id}/force` |
| #166 | `apiKeys.delete` | `ApiKeyDeleteResponseSchema` | `DELETE /v1/mgmt/apikey/delete/{name}` |
| #167 | `customerApps.delete` | **new** `CustomerAppDeleteResponseSchema` | `DELETE /v1/mgmt/customerapp?app_name=…` |

`customerApps.delete` previously declared its response as `CustomerAppSchema`, which the server has never actually returned for a delete. Introduced `CustomerAppDeleteResponseSchema` instead of widening `CustomerAppSchema` so the get/update return type stays correct. Return type changes from `CustomerApp` to `CustomerAppDeleteResponse` — a TS-level signature change, but no real consumer could have ever received a valid `CustomerApp` here, since the call always threw.

## DLP delete endpoints checked

`dlp.dataPatterns.delete`, `dlp.dictionaries.delete`, etc. all return `Promise<void>` with no `responseSchema`, so `src/http/request.ts` short-circuits before JSON parsing — they are already immune to this bug. Left alone.

## Test plan

- [x] TDD: 6 new tests written first (2 per spec across 3 specs + 1 in customer-apps), watched RED with the exact `AISEC_RESPONSE_VALIDATION` "Expected object, received string" error from the issues, then GREEN after schema widening
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 1265/1265 passing
- [x] `npm run preflight` (schema drift) clean
- [ ] Live tenant validation post-merge (re-run the CLI delete flow on each resource type)