### PR TITLE
fix(red-team): tolerate empty 2xx response bodies on delete/create

### DIFF
--- a/.changeset/0000-redteam-empty-body-tolerance.md
+++ b/.changeset/0000-redteam-empty-body-tolerance.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Accept empty response bodies on red-team `targets.delete`, `customAttacks.deletePrompt`, and `customAttacks.createPropertyName`. AIRS red-team API returns 2xx with an empty body on these mutations; SDK now tolerates that via `allowEmptyBody: true` (same precedent as DLP `dictionaries.replace`) instead of throwing `AISEC_RESPONSE_VALIDATION`. Return types widened to `BaseResponse | undefined` to reflect the empty-body case. Closes #168.

--- a/src/red-team/custom-attacks-client.ts
+++ b/src/red-team/custom-attacks-client.ts
@@ -565,14 +565,15 @@ export class RedTeamCustomAttacksClient {
    * // { message: 'ok', status: 200 }
    * ```
    */
-  async deletePrompt(promptSetUuid: string, promptUuid: string): Promise<BaseResponse> {
+  async deletePrompt(promptSetUuid: string, promptUuid: string): Promise<BaseResponse | undefined> {
     assertUuid(promptSetUuid, 'prompt set uuid');
     assertUuid(promptUuid, 'prompt uuid');
-    return request({
+    return request<BaseResponse | undefined>({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/custom-prompt-set/${promptSetUuid}/custom-prompt/${promptUuid}`,
-      responseSchema: BaseResponseSchema,
+      responseSchema: BaseResponseSchema.optional(),
+      allowEmptyBody: true,
       auth: this.auth,
       numRetries: this.numRetries,
     });
@@ -620,13 +621,14 @@ export class RedTeamCustomAttacksClient {
    * // { message: 'ok', status: 200 }
    * ```
    */
-  async createPropertyName(body: PropertyNameCreateRequest): Promise<BaseResponse> {
-    return request({
+  async createPropertyName(body: PropertyNameCreateRequest): Promise<BaseResponse | undefined> {
+    return request<BaseResponse | undefined>({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: `${RED_TEAM_CUSTOM_ATTACK_PATH}/property-names`,
       body,
-      responseSchema: BaseResponseSchema,
+      responseSchema: BaseResponseSchema.optional(),
+      allowEmptyBody: true,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/red-team/targets-client.ts
+++ b/src/red-team/targets-client.ts
@@ -212,13 +212,14 @@ export class RedTeamTargetsClient {
    * // { message: 'ok', status: 200 }
    * ```
    */
-  async delete(uuid: string): Promise<BaseResponse> {
+  async delete(uuid: string): Promise<BaseResponse | undefined> {
     assertUuid(uuid, 'target uuid');
-    return request({
+    return request<BaseResponse | undefined>({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: `${RED_TEAM_TARGET_PATH}/${uuid}`,
-      responseSchema: BaseResponseSchema,
+      responseSchema: BaseResponseSchema.optional(),
+      allowEmptyBody: true,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/test/red-team/custom-attacks-client.spec.ts
+++ b/test/red-team/custom-attacks-client.spec.ts
@@ -328,12 +328,22 @@ describe('RedTeamCustomAttacksClient', () => {
       mockFetch(baseResponseMock());
       const result = await client.deletePrompt(validUuid, validUuid2);
 
-      expect(result.message).toBe('ok');
+      expect(result?.message).toBe('ok');
       const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain(
         `/v1/custom-attack/custom-prompt-set/${validUuid}/custom-prompt/${validUuid2}`,
       );
       expect(init.method).toBe('DELETE');
+    });
+
+    it('tolerates empty 2xx body without throwing (issue #168)', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
+      const result = await client.deletePrompt(validUuid, validUuid2);
+      expect(result).toBeUndefined();
     });
 
     it('rejects invalid prompt set UUID', async () => {
@@ -361,10 +371,20 @@ describe('RedTeamCustomAttacksClient', () => {
       mockFetch(baseResponseMock());
       const result = await client.createPropertyName({ name: 'severity' });
 
-      expect(result.message).toBe('ok');
+      expect(result?.message).toBe('ok');
       const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('/v1/custom-attack/property-names');
       expect(init.method).toBe('POST');
+    });
+
+    it('tolerates empty 2xx body without throwing (issue #168)', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
+      const result = await client.createPropertyName({ name: 'severity' });
+      expect(result).toBeUndefined();
     });
   });
 

--- a/test/red-team/targets-client.spec.ts
+++ b/test/red-team/targets-client.spec.ts
@@ -210,10 +210,20 @@ describe('RedTeamTargetsClient', () => {
       mockFetch(baseResponseMock());
       const result = await client.delete(validUuid);
 
-      expect(result.message).toBe('ok');
+      expect(result?.message).toBe('ok');
       const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain(`/v1/target/${validUuid}`);
       expect(init.method).toBe('DELETE');
+    });
+
+    it('tolerates empty 2xx body without throwing (issue #168)', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
+      const result = await client.delete(validUuid);
+      expect(result).toBeUndefined();
     });
 
     it('rejects invalid UUID', async () => {


### PR DESCRIPTION
## Summary

3 red-team mutation endpoints return 2xx with an **empty body**. SDK schema expected `{ message: string, status: number }` (`BaseResponseSchema`), so every call threw `AISEC_RESPONSE_VALIDATION` despite server-side success.

## Affected call sites

| Method | File:line | Verb / Path |
|---|---|---|
| `RedTeamTargetsClient.delete` | `src/red-team/targets-client.ts:215` | `DELETE /red-team/mgmt/v1/targets/{id}` |
| `RedTeamCustomAttacksClient.deletePrompt` | `src/red-team/custom-attacks-client.ts:568` | `DELETE /red-team/mgmt/v1/prompts/...` |
| `RedTeamCustomAttacksClient.createPropertyName` | `src/red-team/custom-attacks-client.ts:623` | `POST /red-team/mgmt/v1/properties/names` |

## Fix

Opted in to `allowEmptyBody: true` + `responseSchema: BaseResponseSchema.optional()` on each spec. Same precedent as `src/management/dlp/dictionaries.ts:223` (closed #136). Return types widened to `BaseResponse | undefined` to reflect the empty-body runtime case.

## TDD

3 new RED tests (one per site) mock 200 + empty body. RED confirmed with exact zod error from #168 (`Required` on `message` and `status`). GREEN after fix.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` (1262/1262 pass)
- [x] `npm run preflight` (no unacknowledged drift)

Closes #168.