### PR TITLE
test(red-team): lock getPropertyNames data shape as string[]

### DIFF
--- a/test/red-team/custom-attacks-client.spec.ts
+++ b/test/red-team/custom-attacks-client.spec.ts
@@ -354,6 +354,17 @@ describe('RedTeamCustomAttacksClient', () => {
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('/v1/custom-attack/property-names');
     });
+
+    it('decodes data as string[] per documented server contract (issue #169)', async () => {
+      mockFetch({ data: ['property-docs-test'] });
+      const result = await client.getPropertyNames();
+
+      expect(Array.isArray(result.data)).toBe(true);
+      expect(result.data).toEqual(['property-docs-test']);
+      for (const item of result.data ?? []) {
+        expect(typeof item).toBe('string');
+      }
+    });
   });
 
   describe('createPropertyName', () => {


### PR DESCRIPTION
## Summary

Regression-only test for #169.

Issue body claimed the SDK schema decoded `getPropertyNames` `data` as `Array<{name:string}>`, but `src/models/red-team.ts:1394` has always been `z.array(z.string())`. The `• undefined` symptom comes from the CLI renderer (`cdot65/prisma-airs-cli`) dereferencing `.name` on plain strings — that's where the fix belongs.

This PR adds a regression test that mocks the documented server body `{"data":["property-docs-test"]}` and asserts string-typed items, so the SDK contract cannot silently regress.

Closes via issue close (not planned) — fix tracked in `cdot65/prisma-airs-cli`.

## Test plan

- [x] `npm test` — new test passes alongside existing 1262
- [x] `npm run typecheck` / `lint` / `format:check`

Refs #169.