### PR TITLE
feat(management): add DashboardClient for per-app token consumption + violations

### DIFF
--- a/.changeset/0032-mgmt-dashboard-client.md
+++ b/.changeset/0032-mgmt-dashboard-client.md
@@ -1,0 +1,10 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Add `ManagementClient.dashboard` (new `DashboardClient`) covering the SCM "AI Security > Runtime > API Applications" detail panel:
+
+- `mgmt.dashboard.application({ appId, appName })` returns the per-app overview - `token_stats` (average daily + monthly total, paired with K/M scale qualifiers), `session_stats`, attached `profiles[]`, `cloud`/`source`/`created_at`. Together these power per-app token consumption / chargeback reporting that previously required the SCM UI.
+- `mgmt.dashboard.applicationViolationBreakdown({ appId, appName })` returns per-detector severity counts (one entry per `detection_type`: `agent_security`, `dlp`, `malicious_code`, `pi`, `tc`, `topic_guardrails`, `uf`) plus `total_violating`.
+
+Both endpoints require `appId` AND `appName` - omitting `appname` returns an all-null body (silent failure mode), so the parameter is non-optional in the TypeScript signature. History window max is 30 days (the API's hard cap); `timeInterval`/`timeUnit` default to `30`/`days`. Response schemas use `.passthrough()` + `nullable().optional()` for forward compatibility with future API fields.

--- a/.changeset/0032-mgmt-dashboard-client.md
+++ b/.changeset/0032-mgmt-dashboard-client.md
@@ -5,6 +5,14 @@
 Add `ManagementClient.dashboard` (new `DashboardClient`) covering the SCM "AI Security > Runtime > API Applications" detail panel:
 
 - `mgmt.dashboard.application({ appId, appName })` returns the per-app overview - `token_stats` (average daily + monthly total, paired with K/M scale qualifiers), `session_stats`, attached `profiles[]`, `cloud`/`source`/`created_at`. Together these power per-app token consumption / chargeback reporting that previously required the SCM UI.
-- `mgmt.dashboard.applicationViolationBreakdown({ appId, appName })` returns per-detector severity counts (one entry per `detection_type`: `agent_security`, `dlp`, `malicious_code`, `pi`, `tc`, `topic_guardrails`, `uf`) plus `total_violating`.
+- `mgmt.dashboard.applicationViolationBreakdown({ appId, appName })` returns per-detector severity counts (one entry per `detection_type`; 10 observed live as of 2026-05-28: `agent_security`, `contextual_grounding`, `dbs` (database security), `dlp`, `malicious_code`, `pi`, `source_code`, `tc`, `topic_guardrails`, `uf`) plus `total_violating`.
 
-Both endpoints require `appId` AND `appName` - omitting `appname` returns an all-null body (silent failure mode), so the parameter is non-optional in the TypeScript signature. History window max is 30 days (the API's hard cap); `timeInterval`/`timeUnit` default to `30`/`days`. Response schemas use `.passthrough()` + `nullable().optional()` for forward compatibility with future API fields.
+Both endpoints require `appId` and a non-empty `appName`. Empty `appname` returns HTTP 400; omitting it entirely (different code path) returns an all-null body. The SDK requires both, keeping both failure modes off the happy path.
+
+API behavior verified live on 2026-05-28 and reflected in the type signature:
+
+- `timeUnit` is narrowed to `'days'` only - `'hours'` / `'minutes'` return HTTP 400.
+- `timeInterval` is narrowed to `7 | 30 | 60` (the only values that returned 200; `1, 3, 14, 21, 28, 90` all returned 400).
+- Default is `30` / `'days'` to match the SCM UI's "30 days" claim.
+
+Response schemas use `.passthrough()` + `nullable().optional()` for forward compatibility with future API fields and detector types.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## v0.11.0 (unreleased)
+
+### New Features — Dashboard Client (per-app token consumption + violations)
+
+Adds `ManagementClient.dashboard` (new `DashboardClient`) covering the SCM **AI Security > Runtime > API Applications** detail panel — and unlocks per-app token chargeback reporting that previously required the SCM UI.
+
+**New methods (both on `client.dashboard`):**
+
+- **`application({ appId, appName, timeInterval?, timeUnit? })`** — per-app overview. Returns `token_stats` (average daily + monthly total, each paired with a `K`/`M` scale qualifier), `session_stats`, attached `profiles[]`, `cloud`, `source`, `created_at`.
+- **`applicationViolationBreakdown({ appId, appName, timeInterval?, timeUnit? })`** — per-detector severity counts. Returns one entry per `detection_type` in `detection_type_violation_breakdown[]` plus the rolled-up `total_violating`. 10 detectors observed live as of 2026-05-28: `agent_security`, `contextual_grounding`, `dbs` (database security), `dlp`, `malicious_code`, `pi` (prompt injection), `source_code`, `tc` (toxic content), `topic_guardrails`, `uf` (URL filtering).
+
+**Type signature reflects verified live behavior (2026-05-28):**
+
+- `appId` and a non-empty `appName` are both required. Empty `appname` → HTTP 400; omitting it (different code path) returns an all-null body. The SDK keeps both failure modes off the happy path.
+- `timeInterval?: 7 | 30 | 60` (default `30`). Values `1, 3, 14, 21, 28, 90` all returned HTTP 400.
+- `timeUnit?: 'days'` only (default `'days'`). `'hours'` / `'minutes'` return HTTP 400.
+
+Response schemas use `.passthrough()` + `.nullable().optional()` for forward compatibility — new detectors and new response fields parse cleanly without an SDK bump.
+
+**Files:** `src/management/dashboard.ts`, `src/models/mgmt-dashboard.ts`, `examples/mgmt-dashboard.ts`. New `MGMT_DASHBOARD_APPLICATION_PATH` / `_VIOLATION_BREAKDOWN_PATH` constants. Guide section added under [Management API → Dashboard](../guides/management-api.md#dashboard) including the per-app chargeback pattern.
+
 ## v0.10.0
 
 ### New Default — `service-name: api` Header on Every Request

--- a/docs/guides/management-api.md
+++ b/docs/guides/management-api.md
@@ -14,6 +14,7 @@ The thing you'll touch most is the **security profile**: a named ruleset that tu
 | `client.topics`             | Custom detection topics (your own patterns) referenced inside profiles. |
 | `client.apiKeys`            | AIRS scan API keys for your tenant — create, rotate, revoke.            |
 | `client.customerApps`       | Customer application registrations.                                     |
+| `client.dashboard`          | Per-app token consumption + violation breakdown (SCM detail panel).     |
 | `client.dlpProfiles`        | Data-loss-prevention data profiles (list).                              |
 | `client.deploymentProfiles` | Deployment profiles for the tenant (list).                              |
 | `client.scanLogs`           | Query historical scan activity by time range.                           |
@@ -360,6 +361,83 @@ const updated = await client.customerApps.update('customer-app-uuid', {
 ```ts
 const result = await client.customerApps.delete('my-app', 'user@example.com');
 ```
+
+## Dashboard
+
+Per-application token consumption and per-detector violation counts — the same data SCM renders in the **AI Security > Runtime > API Applications** detail panel. Pair with `customerApps.list()` to iterate every app in the tenant for chargeback or risk reporting.
+
+Both methods require `appId` and a non-empty `appName`. Sending an empty `appname` returns HTTP 400; omitting it entirely returns an all-null body — the SDK requires both to keep those failure modes off the happy path. `timeInterval` is `7 | 30 | 60` (default `30`), `timeUnit` is `'days'` only (default `'days'`); other values return HTTP 400.
+
+### Application overview
+
+`dashboard.application()` returns token stats, session stats, attached profiles, and cloud/source metadata for one app.
+
+```ts
+const overview = await client.dashboard.application({
+  appId: 'd8dc4033-593b-45e7-9633-e0dfc130cc82',
+  appName: 'chatbot',
+});
+
+const { average_daily_tokens, average_daily_tokens_scale, monthly_total_tokens, monthly_total_tokens_scale } =
+  overview.token_stats ?? {};
+// each numeric value is paired with a scale qualifier — 'K' (thousands) or 'M' (millions) —
+// both are needed to reconstruct the SCM panel's display value
+```
+
+Narrow the window:
+
+```ts
+const lastWeek = await client.dashboard.application({
+  appId: 'd8dc4033-593b-45e7-9633-e0dfc130cc82',
+  appName: 'chatbot',
+  timeInterval: 7,
+  timeUnit: 'days',
+});
+```
+
+### Violation breakdown
+
+`dashboard.applicationViolationBreakdown()` returns one entry per detector in `detection_type_violation_breakdown[]`, each with critical/high/medium/low/total severity counts, plus the rolled-up `total_violating`.
+
+```ts
+const breakdown = await client.dashboard.applicationViolationBreakdown({
+  appId: 'd8dc4033-593b-45e7-9633-e0dfc130cc82',
+  appName: 'chatbot',
+});
+
+for (const entry of breakdown.detection_type_violation_breakdown ?? []) {
+  if ((entry.violation_breakdown?.total ?? 0) === 0) continue;
+  console.log(entry.detection_type, entry.violation_breakdown);
+}
+// breakdown.total_violating // rolled-up count across all detectors
+```
+
+Detector codes observed live (10 as of 2026-05-28): `agent_security`, `contextual_grounding`, `dbs` (database security), `dlp`, `malicious_code`, `pi` (prompt injection), `source_code`, `tc` (toxic content), `topic_guardrails`, `uf` (URL filtering). Schemas use `.passthrough()`, so new detectors parse cleanly without an SDK bump.
+
+### Per-app chargeback pattern
+
+Combine `customerApps.list()` with `dashboard.application()` to attribute token spend across every app in the tenant:
+
+```ts
+const { customer_apps = [] } = await client.customerApps.list({ offset: 0, limit: 100 });
+const scale = (n?: number | null, s?: string | null) =>
+  (n ?? 0) * (s === 'M' ? 1_000_000 : s === 'K' ? 1_000 : 1);
+
+for (const app of customer_apps) {
+  if (!app.customer_appId) continue;
+  const overview = await client.dashboard.application({
+    appId: app.customer_appId,
+    appName: app.app_name,
+  });
+  const tokens = scale(
+    overview.token_stats?.monthly_total_tokens,
+    overview.token_stats?.monthly_total_tokens_scale,
+  );
+  console.log(`${app.app_name}: ${tokens.toLocaleString()} tokens this month`);
+}
+```
+
+See `examples/mgmt-dashboard.ts` for a runnable version that also surfaces firing detectors per app.
 
 ## DLP Profiles
 

--- a/examples/mgmt-dashboard.ts
+++ b/examples/mgmt-dashboard.ts
@@ -1,0 +1,73 @@
+import { ManagementClient, AISecSDKException } from '@cdot65/prisma-airs-sdk';
+
+/**
+ * Pull per-application token consumption and violation breakdown from the SCM AIRS
+ * "AI Security > Runtime > API Applications" panel.
+ *
+ * Requires: PANW_MGMT_CLIENT_ID, PANW_MGMT_CLIENT_SECRET, PANW_MGMT_TSG_ID.
+ */
+async function main() {
+  const mgmt = new ManagementClient();
+
+  try {
+    const apps = await mgmt.customerApps.list({ offset: 0, limit: 100 });
+    const customerApps = apps.customer_apps ?? [];
+    if (customerApps.length === 0) {
+      console.log('No applications found in tenant.');
+      return;
+    }
+
+    for (const app of customerApps) {
+      if (!app.customer_appId) continue;
+      console.log(`\n=== ${app.app_name} (${app.customer_appId}) ===`);
+
+      const overview = await mgmt.dashboard.application({
+        appId: app.customer_appId,
+        appName: app.app_name,
+      });
+
+      const ts = overview.token_stats;
+      if (ts?.average_daily_tokens != null) {
+        console.log(
+          `  daily avg: ${ts.average_daily_tokens}${ts.average_daily_tokens_scale ?? ''}, ` +
+            `monthly: ${ts.monthly_total_tokens}${ts.monthly_total_tokens_scale ?? ''}`,
+        );
+      } else {
+        console.log('  no token activity in window');
+      }
+
+      const ss = overview.session_stats;
+      if (ss) {
+        console.log(`  sessions: ${ss.total ?? 0} total, ${ss.violating ?? 0} violating`);
+      }
+
+      const breakdown = await mgmt.dashboard.applicationViolationBreakdown({
+        appId: app.customer_appId,
+        appName: app.app_name,
+      });
+      const detectors = breakdown.detection_type_violation_breakdown ?? [];
+      const firing = detectors.filter((d) => (d.violation_breakdown?.total ?? 0) > 0);
+      if (firing.length > 0) {
+        console.log(`  detectors firing (${breakdown.total_violating ?? 0} total violating):`);
+        for (const d of firing) {
+          console.log(
+            `    - ${d.detection_type}: ${d.violation_breakdown?.total} ` +
+              `(c=${d.violation_breakdown?.critical ?? 0} h=${d.violation_breakdown?.high ?? 0} ` +
+              `m=${d.violation_breakdown?.medium ?? 0} l=${d.violation_breakdown?.low ?? 0})`,
+          );
+        }
+      } else {
+        console.log('  no detector violations in window');
+      }
+    }
+  } catch (error) {
+    if (error instanceof AISecSDKException) {
+      console.error('Error:', error.message);
+      console.error('Type:', error.errorType);
+    } else {
+      throw error;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,6 +83,11 @@ export const MGMT_CUSTOMER_APPS_TSG_PATH = '/v1/mgmt/customerapp/tsg';
 export const MGMT_OAUTH_INVALIDATE_PATH = '/v1/mgmt/oauth/invalidateToken';
 export const MGMT_OAUTH_TOKEN_PATH = '/v1/mgmt/oauth/client_credential/accesstoken';
 
+// API paths — management dashboard (SCM AI Security > Runtime > API Applications panel)
+export const MGMT_DASHBOARD_APPLICATION_PATH = '/v1/mgmt/dashboard/v2/apps/application';
+export const MGMT_DASHBOARD_APPLICATION_VIOLATION_BREAKDOWN_PATH =
+  '/v1/mgmt/dashboard/v2/apps/applicationviolationbreakdown';
+
 // DLP (Data Loss Prevention) API defaults
 export const DEFAULT_DLP_ENDPOINT = 'https://api.dlp.paloaltonetworks.com';
 

--- a/src/management/client.ts
+++ b/src/management/client.ts
@@ -9,6 +9,7 @@ import { DlpProfilesClient } from './dlp-profiles.js';
 import { DeploymentProfilesClient } from './deployment-profiles.js';
 import { ScanLogsClient } from './scan-logs.js';
 import { OAuthManagementClient } from './oauth-management.js';
+import { DashboardClient } from './dashboard.js';
 import { DlpNamespace } from './dlp/index.js';
 
 /** Options for constructing a {@link ManagementClient}. */
@@ -63,6 +64,7 @@ export class ManagementClient {
   public readonly deploymentProfiles: DeploymentProfilesClient;
   public readonly scanLogs: ScanLogsClient;
   public readonly oauth: OAuthManagementClient;
+  public readonly dashboard: DashboardClient;
   public readonly dlp: DlpNamespace;
 
   constructor(opts: ManagementClientOptions = {}) {
@@ -89,6 +91,7 @@ export class ManagementClient {
     this.deploymentProfiles = new DeploymentProfilesClient({ baseUrl, auth, numRetries });
     this.scanLogs = new ScanLogsClient({ baseUrl, auth, numRetries });
     this.oauth = new OAuthManagementClient({ baseUrl, auth, numRetries });
+    this.dashboard = new DashboardClient({ baseUrl, auth, numRetries });
     this.dlp = new DlpNamespace({ baseUrl: dlpEndpoint, auth, numRetries });
   }
 }

--- a/src/management/dashboard.ts
+++ b/src/management/dashboard.ts
@@ -21,8 +21,10 @@ export interface DashboardClientOptions {
 /**
  * Query parameters shared by both dashboard application endpoints.
  *
- * Both `appId` AND `appName` are REQUIRED by the API; omitting `appname` returns an all-null
- * response rather than 4xx, which is the most common gotcha when integrating these endpoints.
+ * Both `appId` and a non-empty `appName` are required by the API. Sending an empty `appname`
+ * returns HTTP 400; omitting the parameter entirely (different code path) returns an all-null
+ * body. The SDK signature requires a non-empty `appName` to keep both failure modes off the
+ * happy path.
  */
 export interface DashboardAppQuery {
   /**
@@ -30,12 +32,20 @@ export interface DashboardAppQuery {
    * {@link import('./customer-apps.js').CustomerAppsClient.list}'s `customer_appId` field.
    */
   appId: string;
-  /** Application display name. Required. URL encoding is handled internally. */
+  /** Application display name. Required, non-empty. URL encoding is handled internally. */
   appName: string;
-  /** Look-back window length. Defaults to 30. */
-  timeInterval?: number;
-  /** Look-back window unit. Defaults to 'days'. History max is 30 days. */
-  timeUnit?: 'days' | 'hours' | 'minutes';
+  /**
+   * Look-back window length, in days. Defaults to 30 (matches the SCM UI's "30 days" claim).
+   * The API accepts an enum-like set rather than an arbitrary integer; values verified
+   * accepted on 2026-05-28 are `7`, `30`, and `60`. Other values (1, 3, 14, 21, 28, 90) all
+   * returned HTTP 400. Widen this union if the API later accepts more.
+   */
+  timeInterval?: 7 | 30 | 60;
+  /**
+   * Look-back window unit. Only `'days'` is supported by the API as of verification
+   * (2026-05-28); `'hours'` / `'minutes'` return HTTP 400.
+   */
+  timeUnit?: 'days';
 }
 
 /**
@@ -123,8 +133,11 @@ export class DashboardClient {
    * Get per-detector violation severity counts for the application over the requested window.
    *
    * @param query - App identity and time window. `appId` and `appName` are both required.
-   * @returns The detection-type breakdown (one entry per detector: agent_security, dlp,
-   *   malicious_code, pi, tc, topic_guardrails, uf) plus `total_violating`.
+   * @returns The detection-type breakdown (one entry per detector observed live:
+   *   `agent_security`, `contextual_grounding`, `dbs` (database security), `dlp`,
+   *   `malicious_code`, `pi` (prompt injection), `source_code`, `tc` (toxic content),
+   *   `topic_guardrails`, `uf` (URL filtering)) plus `total_violating`. Detector set may
+   *   evolve; `.passthrough()` schemas accept additions.
    * @example
    * ```ts
    * import { ManagementClient } from '@cdot65/prisma-airs-sdk';

--- a/src/management/dashboard.ts
+++ b/src/management/dashboard.ts
@@ -1,0 +1,165 @@
+import {
+  MGMT_DASHBOARD_APPLICATION_PATH,
+  MGMT_DASHBOARD_APPLICATION_VIOLATION_BREAKDOWN_PATH,
+} from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import {
+  DashboardApplicationSchema,
+  DashboardApplicationViolationBreakdownSchema,
+  type DashboardApplication,
+  type DashboardApplicationViolationBreakdown,
+} from '../models/mgmt-dashboard.js';
+
+/** @internal */
+export interface DashboardClientOptions {
+  baseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+}
+
+/**
+ * Query parameters shared by both dashboard application endpoints.
+ *
+ * Both `appId` AND `appName` are REQUIRED by the API; omitting `appname` returns an all-null
+ * response rather than 4xx, which is the most common gotcha when integrating these endpoints.
+ */
+export interface DashboardAppQuery {
+  /**
+   * Customer application UUID. Source it from
+   * {@link import('./customer-apps.js').CustomerAppsClient.list}'s `customer_appId` field.
+   */
+  appId: string;
+  /** Application display name. Required. URL encoding is handled internally. */
+  appName: string;
+  /** Look-back window length. Defaults to 30. */
+  timeInterval?: number;
+  /** Look-back window unit. Defaults to 'days'. History max is 30 days. */
+  timeUnit?: 'days' | 'hours' | 'minutes';
+}
+
+/**
+ * Client for AIRS SCM dashboard endpoints that power the
+ * "AI Security > Runtime > API Applications" detail panel.
+ *
+ * Together, {@link application} (overview + token consumption + session activity) and
+ * {@link applicationViolationBreakdown} (per-detector violations) reproduce the full panel and
+ * unlock per-app token chargeback reporting.
+ *
+ * @example
+ * ```ts
+ * import { ManagementClient } from '@cdot65/prisma-airs-sdk';
+ * const mgmt = new ManagementClient();
+ *
+ * const apps = await mgmt.customerApps.list();
+ * const first = apps.customer_apps?.[0];
+ * if (!first?.customer_appId) return;
+ *
+ * const overview = await mgmt.dashboard.application({
+ *   appId: first.customer_appId,
+ *   appName: first.app_name,
+ * });
+ * // overview.token_stats?.monthly_total_tokens + scale ("K" | "M") = current month consumption
+ *
+ * const violations = await mgmt.dashboard.applicationViolationBreakdown({
+ *   appId: first.customer_appId,
+ *   appName: first.app_name,
+ * });
+ * // violations.detection_type_violation_breakdown -> per-detector severity counts
+ * ```
+ */
+export class DashboardClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: DashboardClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * Get per-application token consumption and session activity over the requested window.
+   *
+   * @param query - App identity and time window. `appId` and `appName` are both required.
+   * @returns The application overview with `token_stats`, `session_stats`, attached profiles,
+   *   and monitoring metadata.
+   * @example
+   * ```ts
+   * import { ManagementClient } from '@cdot65/prisma-airs-sdk';
+   * const mgmt = new ManagementClient(); // reads PANW_MGMT_* env vars
+   *
+   * const overview = await mgmt.dashboard.application({
+   *   appId: 'd8dc4033-593b-45e7-9633-e0dfc130cc82',
+   *   appName: 'chatbot',
+   * });
+   * // overview =>
+   * // { name: 'chatbot', cloud: 'other', source: 'api',
+   * //   token_stats: { average_daily_tokens: 744.233, average_daily_tokens_scale: 'K',
+   * //                  monthly_total_tokens: 17.71, monthly_total_tokens_scale: 'M' },
+   * //   session_stats: { total: 56935, violating: 31136, ... },
+   * //   profiles: ['ms-tuned', 'golden-v2'] }
+   * ```
+   */
+  async application(query: DashboardAppQuery): Promise<DashboardApplication> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: MGMT_DASHBOARD_APPLICATION_PATH,
+      params: {
+        appid: query.appId,
+        appname: query.appName,
+        time_interval: String(query.timeInterval ?? 30),
+        time_unit: query.timeUnit ?? 'days',
+      },
+      responseSchema: DashboardApplicationSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Get per-detector violation severity counts for the application over the requested window.
+   *
+   * @param query - App identity and time window. `appId` and `appName` are both required.
+   * @returns The detection-type breakdown (one entry per detector: agent_security, dlp,
+   *   malicious_code, pi, tc, topic_guardrails, uf) plus `total_violating`.
+   * @example
+   * ```ts
+   * import { ManagementClient } from '@cdot65/prisma-airs-sdk';
+   * const mgmt = new ManagementClient(); // reads PANW_MGMT_* env vars
+   *
+   * const breakdown = await mgmt.dashboard.applicationViolationBreakdown({
+   *   appId: 'd8dc4033-593b-45e7-9633-e0dfc130cc82',
+   *   appName: 'chatbot',
+   * });
+   * // breakdown =>
+   * // { detection_type_violation_breakdown: [
+   * //     { detection_type: 'topic_guardrails',
+   * //       violation_breakdown: { critical: 0, high: 0, medium: 3, low: 0, total: 3 } },
+   * //     { detection_type: 'dlp',
+   * //       violation_breakdown: { critical: 0, high: 0, medium: 0, low: 0, total: 0 } },
+   * //     ... ],
+   * //   total_violating: 3 }
+   * ```
+   */
+  async applicationViolationBreakdown(
+    query: DashboardAppQuery,
+  ): Promise<DashboardApplicationViolationBreakdown> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: MGMT_DASHBOARD_APPLICATION_VIOLATION_BREAKDOWN_PATH,
+      params: {
+        appid: query.appId,
+        appname: query.appName,
+        time_interval: String(query.timeInterval ?? 30),
+        time_unit: query.timeUnit ?? 'days',
+      },
+      responseSchema: DashboardApplicationViolationBreakdownSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/management/index.ts
+++ b/src/management/index.ts
@@ -20,6 +20,11 @@ export {
   type OAuthManagementClientOptions,
   type GetTokenOptions,
 } from './oauth-management.js';
+export {
+  DashboardClient,
+  type DashboardClientOptions,
+  type DashboardAppQuery,
+} from './dashboard.js';
 export { DlpNamespace, type DlpNamespaceOptions } from './dlp/index.js';
 export {
   DataFilteringProfilesClient,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -190,6 +190,20 @@ export {
   type CustomerAppListResponse,
 } from './mgmt-customer-app.js';
 export {
+  TokenStatsSchema,
+  type TokenStats,
+  ViolationSeverityCountsSchema,
+  type ViolationSeverityCounts,
+  DashboardSessionStatsSchema,
+  type DashboardSessionStats,
+  DashboardApplicationSchema,
+  type DashboardApplication,
+  DetectorViolationBreakdownEntrySchema,
+  type DetectorViolationBreakdownEntry,
+  DashboardApplicationViolationBreakdownSchema,
+  type DashboardApplicationViolationBreakdown,
+} from './mgmt-dashboard.js';
+export {
   DeploymentProfileEntrySchema,
   type DeploymentProfileEntry,
   DeploymentProfilesResponseSchema,

--- a/src/models/mgmt-dashboard.ts
+++ b/src/models/mgmt-dashboard.ts
@@ -73,8 +73,10 @@ export type DashboardApplication = z.infer<typeof DashboardApplicationSchema>;
 /**
  * One entry in `detection_type_violation_breakdown[]` - severity counts for a single detector.
  *
- * `detection_type` values observed live: `agent_security`, `dlp`, `malicious_code`, `pi`
- * (prompt injection), `tc` (toxic content), `topic_guardrails`, `uf` (URL filtering).
+ * `detection_type` values observed live (2026-05-28): `agent_security`, `contextual_grounding`,
+ * `dbs` (database security), `dlp`, `malicious_code`, `pi` (prompt injection), `source_code`,
+ * `tc` (toxic content), `topic_guardrails`, `uf` (URL filtering). Detector set may evolve;
+ * the field uses a plain `z.string()` so additions parse without changes.
  */
 export const DetectorViolationBreakdownEntrySchema = z
   .object({

--- a/src/models/mgmt-dashboard.ts
+++ b/src/models/mgmt-dashboard.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+
+/**
+ * Token consumption stats for an application over the requested window.
+ *
+ * The API returns a numeric value paired with a scale qualifier ('K' for thousands, 'M' for
+ * millions, etc.) - both are needed to reconstruct the SCM panel's display value.
+ */
+export const TokenStatsSchema = z
+  .object({
+    average_daily_tokens: z.number().nullable().optional(),
+    average_daily_tokens_scale: z.string().nullable().optional(),
+    monthly_total_tokens: z.number().nullable().optional(),
+    monthly_total_tokens_scale: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+/** Per-application token consumption stats. */
+export type TokenStats = z.infer<typeof TokenStatsSchema>;
+
+/** Severity-bucketed counts used by both session stats and per-detector breakdowns. */
+export const ViolationSeverityCountsSchema = z
+  .object({
+    critical: z.number().optional(),
+    high: z.number().optional(),
+    medium: z.number().optional(),
+    low: z.number().optional(),
+    total: z.number().optional(),
+  })
+  .passthrough();
+
+/** Critical/high/medium/low/total severity counts. */
+export type ViolationSeverityCounts = z.infer<typeof ViolationSeverityCountsSchema>;
+
+/** Session-level activity stats for an application over the requested window. */
+export const DashboardSessionStatsSchema = z
+  .object({
+    total: z.number().optional(),
+    violating: z.number().optional(),
+    violation_breakdown: ViolationSeverityCountsSchema.optional(),
+    last_session_id: z.string().nullable().optional(),
+    most_recent_session_time: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+/** Per-application session activity stats. */
+export type DashboardSessionStats = z.infer<typeof DashboardSessionStatsSchema>;
+
+/**
+ * Per-application overview - powers SCM's "API Applications" detail panel (token consumption,
+ * sessions, monitoring metadata, attached profiles).
+ *
+ * History window is 30 days (the API's max). `appname` is REQUIRED on the request; omitting it
+ * returns an all-null body.
+ */
+export const DashboardApplicationSchema = z
+  .object({
+    id: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    cloud: z.string().nullable().optional(),
+    source: z.string().nullable().optional(),
+    created_at: z.string().nullable().optional(),
+    updated_at: z.string().nullable().optional(),
+    profiles: z.array(z.string()).nullable().optional(),
+    token_stats: TokenStatsSchema.nullable().optional(),
+    session_stats: DashboardSessionStatsSchema.nullable().optional(),
+  })
+  .passthrough();
+
+/** Per-application dashboard overview response. */
+export type DashboardApplication = z.infer<typeof DashboardApplicationSchema>;
+
+/**
+ * One entry in `detection_type_violation_breakdown[]` - severity counts for a single detector.
+ *
+ * `detection_type` values observed live: `agent_security`, `dlp`, `malicious_code`, `pi`
+ * (prompt injection), `tc` (toxic content), `topic_guardrails`, `uf` (URL filtering).
+ */
+export const DetectorViolationBreakdownEntrySchema = z
+  .object({
+    detection_type: z.string().optional(),
+    violation_breakdown: ViolationSeverityCountsSchema.optional(),
+  })
+  .passthrough();
+
+/** Per-detector violation severity counts entry. */
+export type DetectorViolationBreakdownEntry = z.infer<typeof DetectorViolationBreakdownEntrySchema>;
+
+/** Per-application violation breakdown response - detector by detector. */
+export const DashboardApplicationViolationBreakdownSchema = z
+  .object({
+    detection_type_violation_breakdown: z.array(DetectorViolationBreakdownEntrySchema).optional(),
+    total_violating: z.number().optional(),
+  })
+  .passthrough();
+
+/** Per-application detector violation breakdown. */
+export type DashboardApplicationViolationBreakdown = z.infer<
+  typeof DashboardApplicationViolationBreakdownSchema
+>;

--- a/test/management/dashboard.spec.ts
+++ b/test/management/dashboard.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DashboardClient } from '../../src/management/dashboard.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+const APPLICATION_RESPONSE = {
+  id: '5e16929a-1234-4567-89ab-cdef01234567',
+  name: 'chatbot',
+  cloud: 'other',
+  source: 'api',
+  created_at: '2026-04-29T17:04:52Z',
+  updated_at: '2026-05-27T14:53:33Z',
+  profiles: ['ms-tuned', 'claude-code', 'golden-v2'],
+  token_stats: {
+    average_daily_tokens: 744.233,
+    average_daily_tokens_scale: 'K',
+    monthly_total_tokens: 17.713747,
+    monthly_total_tokens_scale: 'M',
+  },
+  session_stats: {
+    total: 56935,
+    violating: 31136,
+    violation_breakdown: { critical: 0, high: 11, low: 4664, medium: 55282, total: 59957 },
+    last_session_id: 'session-abc',
+    most_recent_session_time: '2026-05-27T14:53:33Z',
+  },
+};
+
+const BREAKDOWN_RESPONSE = {
+  detection_type_violation_breakdown: [
+    {
+      detection_type: 'agent_security',
+      violation_breakdown: { critical: 0, high: 0, low: 0, medium: 0, total: 0 },
+    },
+    {
+      detection_type: 'dlp',
+      violation_breakdown: { critical: 0, high: 0, low: 0, medium: 0, total: 0 },
+    },
+    {
+      detection_type: 'topic_guardrails',
+      violation_breakdown: { critical: 0, high: 0, low: 0, medium: 3, total: 3 },
+    },
+  ],
+  total_violating: 3,
+};
+
+describe('DashboardClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: DashboardClient;
+
+  beforeEach(() => {
+    client = new DashboardClient({
+      baseUrl: 'https://api.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('application', () => {
+    it('GETs /v1/mgmt/dashboard/v2/apps/application with appid + appname', async () => {
+      mockFetch(APPLICATION_RESPONSE);
+      const result = await client.application({ appId: 'uuid-1', appName: 'chatbot' });
+
+      expect(result.name).toBe('chatbot');
+      expect(result.token_stats?.average_daily_tokens).toBe(744.233);
+      expect(result.token_stats?.average_daily_tokens_scale).toBe('K');
+      expect(result.token_stats?.monthly_total_tokens_scale).toBe('M');
+      expect(result.session_stats?.total).toBe(56935);
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/dashboard/v2/apps/application');
+      expect(url).toContain('appid=uuid-1');
+      expect(url).toContain('appname=chatbot');
+      expect(url).toContain('time_interval=30');
+      expect(url).toContain('time_unit=days');
+    });
+
+    it('URL-encodes appname with spaces', async () => {
+      mockFetch(APPLICATION_RESPONSE);
+      await client.application({ appId: 'uuid-1', appName: 'Claude Code' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toMatch(/appname=Claude(\+|%20)Code/);
+    });
+
+    it('uses caller-supplied timeInterval + timeUnit', async () => {
+      mockFetch(APPLICATION_RESPONSE);
+      await client.application({
+        appId: 'uuid-1',
+        appName: 'chatbot',
+        timeInterval: 7,
+        timeUnit: 'days',
+      });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('time_interval=7');
+      expect(url).toContain('time_unit=days');
+    });
+
+    it('tolerates all-null body when appname omitted server-side', async () => {
+      mockFetch({
+        id: null,
+        name: null,
+        token_stats: null,
+        session_stats: null,
+      });
+      const result = await client.application({ appId: 'uuid-1', appName: 'chatbot' });
+      expect(result.token_stats).toBeNull();
+      expect(result.session_stats).toBeNull();
+    });
+  });
+
+  describe('applicationViolationBreakdown', () => {
+    it('GETs /v1/mgmt/dashboard/v2/apps/applicationviolationbreakdown', async () => {
+      mockFetch(BREAKDOWN_RESPONSE);
+      const result = await client.applicationViolationBreakdown({
+        appId: 'uuid-1',
+        appName: 'chatbot',
+      });
+
+      expect(result.total_violating).toBe(3);
+      expect(result.detection_type_violation_breakdown).toHaveLength(3);
+      const tg = result.detection_type_violation_breakdown?.find(
+        (e) => e.detection_type === 'topic_guardrails',
+      );
+      expect(tg?.violation_breakdown?.medium).toBe(3);
+      expect(tg?.violation_breakdown?.total).toBe(3);
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toContain('/v1/mgmt/dashboard/v2/apps/applicationviolationbreakdown');
+      expect(url).toContain('appid=uuid-1');
+      expect(url).toContain('appname=chatbot');
+    });
+  });
+});


### PR DESCRIPTION
Adds `mgmt.dashboard` covering the SCM "AI Security > Runtime > API Applications" detail panel endpoints. Unblocks per-app token chargeback / consumption reporting from the SDK without scraping the UI.

Companion to cdot65/prisma-airs-cli#222 — the CLI consumer PR will open as a draft alongside this one.

## What's new

```ts
import { ManagementClient } from '@cdot65/prisma-airs-sdk';
const mgmt = new ManagementClient();

const overview = await mgmt.dashboard.application({
  appId: 'd8dc4033-593b-45e7-9633-e0dfc130cc82',
  appName: 'chatbot',
});
// overview.token_stats -> { average_daily_tokens: 744.233, average_daily_tokens_scale: 'K',
//                           monthly_total_tokens: 17.71, monthly_total_tokens_scale: 'M' }
// overview.session_stats -> { total, violating, violation_breakdown, ... }
// overview.profiles -> ['ms-tuned', 'golden-v2', ...]

const breakdown = await mgmt.dashboard.applicationViolationBreakdown({
  appId: 'd8dc4033-593b-45e7-9633-e0dfc130cc82',
  appName: 'chatbot',
});
// breakdown.detection_type_violation_breakdown -> per-detector severity counts
// breakdown.total_violating -> total
```

## Endpoints

| Method | Path |
|---|---|
| GET | \`/v1/mgmt/dashboard/v2/apps/application\` |
| GET | \`/v1/mgmt/dashboard/v2/apps/applicationviolationbreakdown\` |

## Type contract decisions, from live API behavior (verified 2026-05-28)

- \`appName\` is **non-optional and non-empty**. Sending an empty \`appname\` returns HTTP 400; omitting it entirely (different code path) returns an all-null body. The signature keeps both failure modes off the happy path.
- \`timeUnit?: 'days'\` only — \`'hours'\` and \`'minutes'\` return HTTP 400.
- \`timeInterval?: 7 | 30 | 60\` — enum-like enforcement on the server. Probed values:

  | interval | result |
  |---:|:---|
  | 1 | 400 |
  | 3 | 400 |
  | 7 | 200 |
  | 14 | 400 |
  | 21 | 400 |
  | 28 | 400 |
  | 30 | 200 |
  | 60 | 200 |
  | 90 | 400 |

- \`detection_type\` set has **10 detectors** (not 7 as the runbook docs claimed):
  \`agent_security\`, \`contextual_grounding\`, \`dbs\` (database security), \`dlp\`, \`malicious_code\`, \`pi\`, \`source_code\`, \`tc\`, \`topic_guardrails\`, \`uf\`. The field uses a plain \`z.string()\` so future additions parse cleanly.
- Response schemas use \`.passthrough()\` + \`.nullable().optional()\` throughout for forward compat — matches existing convention for SCM-side responses where the API gains fields ahead of the OpenAPI spec.

## Notes for reviewers

- Endpoints aren't in any OpenAPI spec, so they land under \"Unmatched Zod schemas (no OpenAPI counterpart)\" in preflight — **0 unacknowledged drift**, CI gate passes strict.
- Picked up a stale \`package-lock.json\` version sync (0.9.2 → 0.10.0) to keep \`npm ci\` happy.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run format:check\`
- [x] \`npm run test\` (1264/1264 with clean env; pre-commit hook gate passes)
- [x] \`npm run preflight\` (strict; 0 unacknowledged drift)
- [x] \`npm run build\` (CJS + ESM + DTS)
- [x] Live integration test against real tenant (TSG 1016244978): 5/5 apps round-trip cleanly through Zod across both endpoints; empty appname throws \`CLIENT_SIDE_ERROR\` as designed; \`timeInterval: 7\` and \`60\` both round-trip 200
- [x] Dogfooded via \`pnpm link\` into the CLI fork; full end-to-end (CLI → SDK → API) verified against real tenant