### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## v0.12.0
+
+### New Features — Dashboard Apps Enumeration
+
+Adds `mgmt.dashboard.applicationsOverview(opts?)` — the canonical apps-list source backing the SCM **AI Security > Runtime > API Applications** view (endpoint `/v1/mgmt/dashboard/v2/apps/applicationsoverview`).
+
+The dashboard buckets traffic by the literal `metadata.app_name` value scan payloads send, so a single registered `customer_appId` can surface here as multiple items — one per distinct scan-payload name (e.g. LiteLLM's `panw_prisma_airs` guardrail overrides `app_name` by default). Enumerate from `applicationsOverview` rather than `customerApps.list` to see every dashboard bucket: the `id` field is the registered `customer_appId` UUID and `name` is the scan-payload value. Pair with `dashboard.application(...)` and `dashboard.applicationViolationBreakdown(...)` to drill into a bucket.
+
+**Verified live behavior (2026-05-29), reflected in the types:**
+
+- `timeInterval?: 1 | 7 | 30 | 60` — other values return HTTP 400.
+- `timeUnit?: 'days' | 'day' | 'hour'` — wider than the per-app `application` endpoint (which accepts only `'days'`). Live-tested combinations: `(7, days)`, `(30, days)`, `(60, days)`, `(1, day)`, `(1, hour)`. Defaults to `(30, days)` to match existing dashboard methods.
+- `limit` / `offset` provide offset-based pagination (SCM UI uses `limit=25`).
+
+Response shapes use `z.passthrough()` + `nullable().optional()` for forward compatibility. **New exports:** `DashboardApplicationsOverviewQuery`, `DashboardApplicationsOverview`, `DashboardApplicationsOverviewItem`, `DashboardApplicationSessionsBucket`, `DashboardPagination`, and their schemas. Also clarifies `DashboardAppQuery.appName` JSDoc to point at `applicationsOverview` as the canonical source of valid `(appId, appName)` pairs.
+
 ## v0.11.0
 
 ### New Features — Dashboard Client (per-app token consumption + violations)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.11.0';
+export const SDK_VERSION = '0.12.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
Release v0.12.0.

- feat(management): `dashboard.applicationsOverview` for dashboard apps enumeration (#177)

Manual version bump (package.json + lockfile + `SDK_VERSION` + release-notes). Merging this then publishing the GitHub Release fires `publish.yml` → npm.