### PR TITLE
feat(http): env-gated debug logging with hashed access tokens

### DIFF
--- a/.changeset/0034-debug-logging.md
+++ b/.changeset/0034-debug-logging.md
@@ -1,0 +1,7 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Add opt-in debug logging of API calls. Set `PANW_AI_SEC_DEBUG=1` (or `true`/`yes`/`on`) to log every HTTP request (method, URL, headers, body) and response (status, duration, body) to `stderr`, across every domain (scan, management, model security, red teaming). Logs once per attempt, so retries and token refreshes are visible.
+
+Access-token header values (`Authorization`, `x-pan-token`) are replaced with a non-reversible `sha256:<prefix>` hash — the raw token is never written, so logs are safe to share while still revealing token rotation. Zero output and zero overhead when the variable is unset.

--- a/docs/getting-started/environment-variables.md
+++ b/docs/getting-started/environment-variables.md
@@ -46,6 +46,35 @@ All fall back to the corresponding `PANW_MGMT_*` variable if not set.
 | `PANW_RED_TEAM_MGMT_ENDPOINT`  | —                          | `https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane` | Management plane base URL |
 | `PANW_RED_TEAM_TOKEN_ENDPOINT` | `PANW_MGMT_TOKEN_ENDPOINT` | —                                                                 | OAuth2 token endpoint     |
 
+## Debugging
+
+| Variable             | Required | Default | Description                                                     |
+| -------------------- | -------- | ------- | --------------------------------------------------------------- |
+| `PANW_AI_SEC_DEBUG`  | No       | —       | Set to `1`/`true`/`yes`/`on` to log every API call to `stderr`. |
+
+When enabled, the SDK logs each HTTP request (method, full URL, headers, body) and response
+(status, duration, body) to **stderr** for every domain — scan, management, model security, and
+red teaming. It logs once per attempt, so retries and 401-driven token refreshes are visible.
+
+Access-token header values (`Authorization`, `x-pan-token`) are replaced with a non-reversible
+`sha256:<prefix>` hash, so debug logs are safe to share and you can still tell when a token
+rotates. The raw token is never written.
+
+```text
+[airs-sdk] → GET https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane/v1/custom-attack/list-custom-prompt-sets?limit=1
+[airs-sdk]   headers {"User-Agent":"PAN-AIRS/0.12.0-typescript-sdk","service-name":"api","Authorization":"sha256:6ba877dddebe"}
+[airs-sdk] ← 200 (1397ms) {"pagination":{"total_items":1},"data":[...]}
+```
+
+Enable it inline for a single run:
+
+```bash
+PANW_AI_SEC_DEBUG=1 npx tsx your-script.ts
+```
+
+> Request and response bodies are logged verbatim. They may contain prompt content — keep debug
+> logging off in production and scrub captured output before sharing.
+
 ## Example Scripts
 
 The following variables are **not** consumed by the SDK itself. They are used only by the example scripts in `examples/`.

--- a/src/http/debug.ts
+++ b/src/http/debug.ts
@@ -1,0 +1,59 @@
+import { createHash } from 'node:crypto';
+import { HEADER_API_KEY, HEADER_AUTH_TOKEN } from '../constants.js';
+
+/**
+ * @internal
+ * Opt-in request/response debug logging for the AIRS SDK. Enabled via the
+ * `PANW_AI_SEC_DEBUG` environment variable. Access-token header values are
+ * replaced with a non-reversible `sha256:<prefix>` hash so logs are safe to
+ * share while still correlating which token a request used.
+ *
+ * When disabled there is zero output and zero work beyond a single env read.
+ */
+
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+/** Header names whose values must be hashed before logging (compared case-insensitively). */
+const SENSITIVE_HEADERS = new Set([HEADER_AUTH_TOKEN.toLowerCase(), HEADER_API_KEY.toLowerCase()]);
+
+const PREFIX = '[airs-sdk]';
+
+/** True when `PANW_AI_SEC_DEBUG` is set to a truthy value (`1`/`true`/`yes`/`on`, case-insensitive). */
+export function isDebugEnabled(): boolean {
+  const raw = process.env.PANW_AI_SEC_DEBUG;
+  return raw !== undefined && TRUTHY.has(raw.trim().toLowerCase());
+}
+
+/** Hash a secret to a stable, non-reversible `sha256:<12 hex>` token for logging. */
+export function hashToken(value: string): string {
+  return 'sha256:' + createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+/**
+ * Return a copy of `headers` with sensitive auth values replaced by {@link hashToken}.
+ * Non-sensitive headers pass through unchanged. The input object is not mutated.
+ */
+export function sanitizeHeaders(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    out[key] = SENSITIVE_HEADERS.has(key.toLowerCase()) ? hashToken(value) : value;
+  }
+  return out;
+}
+
+/** Log an outbound request. Headers are sanitized here so callers cannot leak a raw token. */
+export function logRequest(
+  method: string,
+  url: string,
+  headers: Record<string, string>,
+  body?: string,
+): void {
+  console.error(`${PREFIX} → ${method} ${url}`);
+  console.error(`${PREFIX}   headers ${JSON.stringify(sanitizeHeaders(headers))}`);
+  if (body !== undefined) console.error(`${PREFIX}   body ${body}`);
+}
+
+/** Log a response: status, elapsed milliseconds, and (optionally) the body. */
+export function logResponse(status: number, ms: number, body?: string): void {
+  console.error(`${PREFIX} ← ${status} (${ms}ms)${body !== undefined ? ` ${body}` : ''}`);
+}

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -1,6 +1,7 @@
 import { USER_AGENT } from '../constants.js';
 import { AISecSDKException, ErrorType } from '../errors.js';
 import { executeWithRetry } from '../http-retry.js';
+import { isDebugEnabled, logRequest, logResponse } from './debug.js';
 import type { PreparedRequest, RequestSpec } from './types.js';
 
 /**
@@ -17,6 +18,7 @@ import type { PreparedRequest, RequestSpec } from './types.js';
  */
 export async function request<TResponse = void>(spec: RequestSpec<TResponse>): Promise<TResponse> {
   let hasRetriedAuth = false;
+  const debug = isDebugEnabled();
 
   const response = await executeWithRetry({
     maxRetries: spec.numRetries,
@@ -50,11 +52,29 @@ export async function request<TResponse = void>(spec: RequestSpec<TResponse>): P
       const prepared: PreparedRequest = { method: spec.method, url, headers, bodyText };
       const final = await spec.auth.prepare(prepared);
 
-      return fetch(final.url.toString(), {
+      const startedAt = debug ? Date.now() : 0;
+      if (debug) {
+        const logBody = spec.formData !== undefined ? '[multipart/form-data]' : final.bodyText;
+        logRequest(final.method, final.url.toString(), final.headers, logBody);
+      }
+
+      const res = await fetch(final.url.toString(), {
         method: final.method,
         headers: final.headers,
         body: spec.formData !== undefined ? bodyForFetch : final.bodyText,
       });
+
+      if (debug) {
+        let respBody: string | undefined;
+        try {
+          respBody = await res.clone().text();
+        } catch {
+          // Response not cloneable (e.g. a test stub) — log status/timing without the body.
+        }
+        logResponse(res.status, Date.now() - startedAt, respBody);
+      }
+
+      return res;
     },
     onRetryableFailure: async (res) => {
       if (hasRetriedAuth) return false;

--- a/test/http/debug.spec.ts
+++ b/test/http/debug.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  isDebugEnabled,
+  hashToken,
+  sanitizeHeaders,
+  logRequest,
+  logResponse,
+} from '../../src/http/debug.js';
+
+describe('debug — isDebugEnabled', () => {
+  const original = process.env.PANW_AI_SEC_DEBUG;
+  afterEach(() => {
+    if (original === undefined) delete process.env.PANW_AI_SEC_DEBUG;
+    else process.env.PANW_AI_SEC_DEBUG = original;
+  });
+
+  it('is false when unset', () => {
+    delete process.env.PANW_AI_SEC_DEBUG;
+    expect(isDebugEnabled()).toBe(false);
+  });
+
+  it.each(['1', 'true', 'TRUE', 'yes', 'YES', 'on'])('is true for %s', (v) => {
+    process.env.PANW_AI_SEC_DEBUG = v;
+    expect(isDebugEnabled()).toBe(true);
+  });
+
+  it.each(['0', 'false', 'no', '', 'off'])('is false for %s', (v) => {
+    process.env.PANW_AI_SEC_DEBUG = v;
+    expect(isDebugEnabled()).toBe(false);
+  });
+});
+
+describe('debug — hashToken', () => {
+  it('formats as sha256:<12 hex>', () => {
+    const h = hashToken('super-secret-token');
+    expect(h).toMatch(/^sha256:[0-9a-f]{12}$/);
+  });
+
+  it('is deterministic and matches a sha256 prefix', () => {
+    const value = 'Bearer abc.def.ghi';
+    const expected = 'sha256:' + createHash('sha256').update(value).digest('hex').slice(0, 12);
+    expect(hashToken(value)).toBe(expected);
+    expect(hashToken(value)).toBe(hashToken(value));
+  });
+
+  it('differs for different inputs', () => {
+    expect(hashToken('token-a')).not.toBe(hashToken('token-b'));
+  });
+
+  it('never contains the raw secret', () => {
+    const secret = 'pan-key-1234567890';
+    expect(hashToken(secret)).not.toContain(secret);
+  });
+});
+
+describe('debug — sanitizeHeaders', () => {
+  it('hashes Authorization and x-pan-token, leaves others intact', () => {
+    const out = sanitizeHeaders({
+      'User-Agent': 'PAN-AIRS/0.0.0',
+      Authorization: 'Bearer the-oauth-token',
+      'x-pan-token': 'Bearer the-api-token',
+      'x-payload-hash': 'already-a-hash',
+    });
+    expect(out['User-Agent']).toBe('PAN-AIRS/0.0.0');
+    expect(out['x-payload-hash']).toBe('already-a-hash');
+    expect(out.Authorization).toMatch(/^sha256:[0-9a-f]{12}$/);
+    expect(out['x-pan-token']).toMatch(/^sha256:[0-9a-f]{12}$/);
+    expect(out.Authorization).not.toContain('the-oauth-token');
+    expect(out['x-pan-token']).not.toContain('the-api-token');
+  });
+
+  it('matches sensitive header names case-insensitively', () => {
+    const out = sanitizeHeaders({ authorization: 'Bearer x', 'X-PAN-TOKEN': 'secret' });
+    expect(out.authorization).toMatch(/^sha256:/);
+    expect(out['X-PAN-TOKEN']).toMatch(/^sha256:/);
+  });
+
+  it('does not mutate the input object', () => {
+    const input = { Authorization: 'Bearer keep-me' };
+    sanitizeHeaders(input);
+    expect(input.Authorization).toBe('Bearer keep-me');
+  });
+});
+
+describe('debug — logRequest / logResponse', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('logRequest writes a sanitized line to stderr', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logRequest('POST', 'https://api/x', { Authorization: 'Bearer raw-secret' }, '{"a":1}');
+    const out = spy.mock.calls.flat().join(' ');
+    expect(out).toContain('[airs-sdk]');
+    expect(out).toContain('POST');
+    expect(out).toContain('https://api/x');
+    expect(out).not.toContain('raw-secret');
+  });
+
+  it('logResponse writes status and duration to stderr', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logResponse(200, 143, '{"ok":true}');
+    const out = spy.mock.calls.flat().join(' ');
+    expect(out).toContain('[airs-sdk]');
+    expect(out).toContain('200');
+    expect(out).toContain('143');
+  });
+});

--- a/test/http/request.spec.ts
+++ b/test/http/request.spec.ts
@@ -662,3 +662,101 @@ describe('request — auth integration', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('request — debug logging (PANW_AI_SEC_DEBUG)', () => {
+  const originalFetch = globalThis.fetch;
+  const originalDebug = process.env.PANW_AI_SEC_DEBUG;
+
+  // A mock Response that supports clone() so the debug hook can read the body.
+  function cloneableResponse(body: unknown, status = 200): Response {
+    const text = typeof body === 'string' ? body : JSON.stringify(body);
+    const make = (): Response =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        text: () => Promise.resolve(text),
+        clone: () => make(),
+      }) as unknown as Response;
+    return make();
+  }
+
+  // Auth adapter that injects a real bearer token, like the OAuth adapter.
+  const bearerAuth: AuthAdapter = {
+    prepare: async (req: PreparedRequest) => ({
+      ...req,
+      headers: { ...req.headers, Authorization: 'Bearer super-secret-token-value' },
+    }),
+  };
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalDebug === undefined) delete process.env.PANW_AI_SEC_DEBUG;
+    else process.env.PANW_AI_SEC_DEBUG = originalDebug;
+    vi.restoreAllMocks();
+  });
+
+  it('logs sanitized request + response to stderr when enabled, never the raw token', async () => {
+    process.env.PANW_AI_SEC_DEBUG = '1';
+    globalThis.fetch = vi.fn().mockResolvedValue(cloneableResponse({ id: '1', name: 'a' }));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await request({
+      method: 'POST',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      body: { hello: 'world' },
+      auth: bearerAuth,
+      responseSchema: ItemSchema,
+      numRetries: 0,
+    });
+
+    const out = errSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('[airs-sdk]');
+    expect(out).toContain('POST https://api.example.com/v1/items');
+    expect(out).not.toContain('super-secret-token-value');
+    expect(out).toMatch(/sha256:[0-9a-f]{12}/);
+    expect(out).toContain('200');
+  });
+
+  it('produces no debug output when disabled', async () => {
+    delete process.env.PANW_AI_SEC_DEBUG;
+    globalThis.fetch = vi.fn().mockResolvedValue(cloneableResponse({ id: '1', name: 'a' }));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      auth: bearerAuth,
+      responseSchema: ItemSchema,
+      numRetries: 0,
+    });
+
+    const airsLines = errSpy.mock.calls.flat().filter((a) => String(a).includes('[airs-sdk]'));
+    expect(airsLines).toHaveLength(0);
+  });
+
+  it('logs once per attempt across an auth retry', async () => {
+    process.env.PANW_AI_SEC_DEBUG = '1';
+    let call = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      call++;
+      return Promise.resolve(
+        cloneableResponse(call === 1 ? {} : { id: '1', name: 'a' }, call === 1 ? 401 : 200),
+      );
+    });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await request({
+      method: 'GET',
+      baseUrl: 'https://api.example.com',
+      path: '/v1/items',
+      auth: refreshAuth({ unauthorizedReturns: true }),
+      responseSchema: ItemSchema,
+      numRetries: 2,
+    });
+
+    const reqLines = errSpy.mock.calls.flat().filter((a) => String(a).includes('→ GET'));
+    expect(reqLines).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #179.

## What

Opt-in debug logging of every SDK API call, gated by the `PANW_AI_SEC_DEBUG` env var. Access tokens are hashed so logs are safe to share.

- New internal module `src/http/debug.ts`: `isDebugEnabled`, `hashToken` (`sha256:<12 hex>`), `sanitizeHeaders`, `logRequest`/`logResponse`.
- Hooked into the single `request()` chokepoint → covers scan, management, model security, and red teaming uniformly.
- Logs once per attempt (retries / 401 refreshes visible). `res.clone()` so the real body isn't consumed. formData bodies log as `[multipart/form-data]`.

## Security

`Authorization` and `x-pan-token` values are replaced with a non-reversible `sha256:<prefix>` hash — `logRequest` sanitizes internally so a caller can't leak a raw token. Verified live: real OAuth bearer logged as `Authorization":"sha256:6ba877dddebe"`. Zero output / zero overhead when the var is unset.

## Sample

```text
[airs-sdk] → GET https://api.sase.../v1/custom-attack/list-custom-prompt-sets?limit=1
[airs-sdk]   headers {"User-Agent":"PAN-AIRS/0.12.0-typescript-sdk","service-name":"api","Authorization":"sha256:6ba877dddebe"}
[airs-sdk] ← 200 (1397ms) {"pagination":{"total_items":1},"data":[...]}
```

## Tests

- `test/http/debug.spec.ts` — hashToken format/determinism, sanitizeHeaders redaction + case-insensitivity + no-mutation, isDebugEnabled truthy parsing.
- `test/http/request.spec.ts` — integration: enabled logs sanitized req/resp (raw token absent, hash present, status logged); disabled = silent; one log pair per retry attempt.
- Full suite: 1303 passing. Live E2E confirmed. Docs build clean.

## Docs

`docs/getting-started/environment-variables.md` — new Debugging section with sample output + prompt-content warning.

## Changeset

`minor` — additive feature.