### PR TITLE
feat(red-team): add Network Broker channel sub-client

### DIFF
--- a/.changeset/0186-red-team-network-broker.md
+++ b/.changeset/0186-red-team-network-broker.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Add a Red Team Network Broker channel sub-client. `RedTeamClient.networkBroker` exposes `listChannels`, `createChannel`, `getChannel`, `updateChannel`, and `getChannelStats` against the network broker data plane, letting you discover and manage the channel UUIDs referenced by Red Team targets (`network_broker_channel_uuid`). The endpoint is overridable via the `networkBrokerEndpoint` option or `PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT`. Adds typed request/response models and Zod schemas (`Channel`, `ChannelStats`, `ChannelStatus`, create/update requests, and channel list types).

--- a/docs-site/docs/getting-started/configuration.mdx
+++ b/docs-site/docs/getting-started/configuration.mdx
@@ -77,6 +77,7 @@ Falls back to `PANW_MGMT_*` variables if service-specific ones are not set.
 | `PANW_RED_TEAM_TSG_ID`         | Falls back to MGMT | —                                                                 |
 | `PANW_RED_TEAM_DATA_ENDPOINT`  | No                 | `https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane` |
 | `PANW_RED_TEAM_MGMT_ENDPOINT`  | No                 | `https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane` |
+| `PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT` | No        | `https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane/network-broker` |
 | `PANW_RED_TEAM_TOKEN_ENDPOINT` | Falls back to MGMT | —                                                                 |
 
 ## Regional Endpoints

--- a/docs-site/docs/getting-started/environment-variables.mdx
+++ b/docs-site/docs/getting-started/environment-variables.mdx
@@ -51,6 +51,7 @@ All fall back to the corresponding `PANW_MGMT_*` variable if not set.
 | `PANW_RED_TEAM_TSG_ID`         | `PANW_MGMT_TSG_ID`         | —                                                                 | Tenant Service Group ID   |
 | `PANW_RED_TEAM_DATA_ENDPOINT`  | —                          | `https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane` | Data plane base URL       |
 | `PANW_RED_TEAM_MGMT_ENDPOINT`  | —                          | `https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane` | Management plane base URL |
+| `PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT` | —                | `https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane/network-broker` | Network broker base URL |
 | `PANW_RED_TEAM_TOKEN_ENDPOINT` | `PANW_MGMT_TOKEN_ENDPOINT` | —                                                                 | OAuth2 token endpoint     |
 
 ## Debugging

--- a/docs-site/docs/guides/red-team-api.md
+++ b/docs-site/docs/guides/red-team-api.md
@@ -32,6 +32,7 @@ The Red Team API uses OAuth2 `client_credentials` flow. Each env var falls back 
 | `PANW_RED_TEAM_TSG_ID`         | `PANW_MGMT_TSG_ID`         | Yes      | Tenant Service Group ID                                                                     |
 | `PANW_RED_TEAM_DATA_ENDPOINT`  | --                         | No       | Data plane URL (default: `https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane`) |
 | `PANW_RED_TEAM_MGMT_ENDPOINT`  | --                         | No       | Mgmt plane URL (default: `https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane`) |
+| `PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT` | --                | No       | Network broker URL (default: `https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane/network-broker`) |
 | `PANW_RED_TEAM_TOKEN_ENDPOINT` | `PANW_MGMT_TOKEN_ENDPOINT` | No       | Token URL (default: `https://auth.apps.paloaltonetworks.com/oauth2/access_token`)           |
 
 ### Setup
@@ -79,17 +80,20 @@ Token fetch, caching, and refresh are handled automatically. Retries (up to 5) u
 
 ## Sub-Clients
 
-The `RedTeamClient` exposes seven sub-clients:
+The `RedTeamClient` exposes eight sub-clients:
 
-| Sub-Client            | Plane      | Access                       |
-| --------------------- | ---------- | ---------------------------- |
-| `scans`               | Data       | `client.scans`               |
-| `reports`             | Data       | `client.reports`             |
-| `customAttackReports` | Data       | `client.customAttackReports` |
-| `targets`             | Management | `client.targets`             |
-| `customAttacks`       | Management | `client.customAttacks`       |
-| `eula`                | Management | `client.eula`                |
-| `instances`           | Management | `client.instances`           |
+| Sub-Client            | Plane          | Access                       |
+| --------------------- | -------------- | ---------------------------- |
+| `scans`               | Data           | `client.scans`               |
+| `reports`             | Data           | `client.reports`             |
+| `customAttackReports` | Data           | `client.customAttackReports` |
+| `targets`             | Management     | `client.targets`             |
+| `customAttacks`       | Management     | `client.customAttacks`       |
+| `eula`                | Management     | `client.eula`                |
+| `instances`           | Management     | `client.instances`           |
+| `networkBroker`       | Network Broker | `client.networkBroker`       |
+
+`networkBroker` talks to a **distinct base URL** — the network broker data plane (`.../ai-red-teaming/data-plane/network-broker`) — while sharing the same Red Team OAuth credentials.
 
 Plus 7 convenience methods directly on `RedTeamClient` for dashboard, quota, error logs, and sentiment.
 
@@ -463,6 +467,39 @@ const creds = await client.instances.getRegistryCredentials();
 console.log(creds.token); // JWT token
 console.log(creds.expiry); // expiration timestamp
 ```
+
+## Network Broker
+
+The network broker routes attack traffic to targets that live behind a private network. A target references a broker channel by its UUID (`network_broker_channel_uuid`); the `networkBroker` sub-client lets you **discover and manage those channels from code** instead of copying UUIDs from the console.
+
+It uses a distinct base URL (the network broker data plane) but shares the Red Team OAuth credentials. Override the endpoint with the `networkBrokerEndpoint` constructor option or the `PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT` environment variable.
+
+```ts
+// List channels, optionally filtering by one or more statuses.
+const { data } = await client.networkBroker.listChannels({
+  status: ['ONLINE', 'DRAFT'],
+  search: 'prod',
+  limit: 20,
+});
+for (const c of data) {
+  console.log(c.uuid, c.name, c.status); // feed c.uuid into target.network_broker_channel_uuid
+}
+
+// Create a channel.
+const channel = await client.networkBroker.createChannel({
+  name: 'prod-broker',
+  description: 'Production network broker channel',
+});
+
+// Get, update, and inspect infrastructure stats.
+const detail = await client.networkBroker.getChannel(channel.uuid!);
+await client.networkBroker.updateChannel(channel.uuid!, { description: 'Updated description' });
+
+const stats = await client.networkBroker.getChannelStats();
+console.log(stats.online_channel_count, stats.total_channel_count);
+```
+
+Channel statuses are `ONLINE`, `OFFLINE`, and `DRAFT` (see the `ChannelStatus` enum).
 
 ## Custom Attacks
 

--- a/docs-site/examples/red-team-network-broker.ts
+++ b/docs-site/examples/red-team-network-broker.ts
@@ -1,0 +1,59 @@
+import { RedTeamClient, AISecSDKException } from '@cdot65/prisma-airs-sdk';
+
+async function main() {
+  // Uses PANW_RED_TEAM_* env vars (falls back to PANW_MGMT_*) for auth.
+  // Override the broker endpoint with PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT or:
+  //   new RedTeamClient({ networkBrokerEndpoint: 'https://...' })
+  const client = new RedTeamClient();
+
+  try {
+    // --- LIST CHANNELS ---
+    console.log('Listing network broker channels...');
+    const channels = await client.networkBroker.listChannels({
+      status: ['ONLINE', 'DRAFT'],
+      limit: 20,
+    });
+    console.log(`Found ${channels.pagination?.total_items ?? 0} channels:`);
+    for (const c of channels.data) {
+      console.log(`  - ${c.uuid}: ${c.name} [${c.status}]`);
+    }
+
+    // --- CREATE A CHANNEL ---
+    console.log('\nCreating a channel...');
+    const created = await client.networkBroker.createChannel({
+      name: 'sdk-example-broker',
+      description: 'Created from the SDK network broker example',
+    });
+    console.log('  Created:', created.uuid, created.name, created.status);
+
+    // --- GET / UPDATE ---
+    if (created.uuid) {
+      const detail = await client.networkBroker.getChannel(created.uuid);
+      console.log('\nChannel detail:', detail.name, detail.status);
+
+      const updated = await client.networkBroker.updateChannel(created.uuid, {
+        description: 'Updated from the SDK example',
+      });
+      console.log('  Updated description:', updated.description);
+
+      // The channel UUID is what a target references via network_broker_channel_uuid.
+      console.log('  Use this UUID for target.network_broker_channel_uuid:', created.uuid);
+    }
+
+    // --- STATS ---
+    console.log('\nGetting channel stats...');
+    const stats = await client.networkBroker.getChannelStats();
+    console.log('  Broker server:', stats.broker_server);
+    console.log('  Online channels:', stats.online_channel_count);
+    console.log('  Total channels:', stats.total_channel_count);
+  } catch (error) {
+    if (error instanceof AISecSDKException) {
+      console.error('Error:', error.message);
+      console.error('Type:', error.errorType);
+    } else {
+      throw error;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -126,6 +126,8 @@ export const DEFAULT_RED_TEAM_DATA_ENDPOINT =
   'https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane';
 export const DEFAULT_RED_TEAM_MGMT_ENDPOINT =
   'https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane';
+export const DEFAULT_RED_TEAM_NETWORK_BROKER_ENDPOINT =
+  'https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane/network-broker';
 
 // Red Team env vars
 export const RED_TEAM_CLIENT_ID = 'PANW_RED_TEAM_CLIENT_ID';
@@ -134,6 +136,7 @@ export const RED_TEAM_TSG_ID = 'PANW_RED_TEAM_TSG_ID';
 export const RED_TEAM_DATA_ENDPOINT = 'PANW_RED_TEAM_DATA_ENDPOINT';
 export const RED_TEAM_MGMT_ENDPOINT = 'PANW_RED_TEAM_MGMT_ENDPOINT';
 export const RED_TEAM_TOKEN_ENDPOINT = 'PANW_RED_TEAM_TOKEN_ENDPOINT';
+export const RED_TEAM_NETWORK_BROKER_ENDPOINT = 'PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT';
 
 // API paths — red team data plane
 export const RED_TEAM_SCAN_PATH = '/v1/scan';
@@ -156,3 +159,7 @@ export const RED_TEAM_INSTANCES_PATH = '/v1/instances';
 export const RED_TEAM_REGISTRY_CREDENTIALS_PATH = '/v1/registry-credentials';
 export const RED_TEAM_CUSTOM_ATTACK_PATH = '/v1/custom-attack';
 export const RED_TEAM_MGMT_DASHBOARD_PATH = '/v1/dashboard/overview';
+
+// API paths — red team network broker (distinct data-plane base URL)
+export const RED_TEAM_CHANNELS_PATH = '/v1/channels';
+export const RED_TEAM_CHANNELS_STATS_PATH = '/v1/channels/stats';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -375,3 +375,4 @@ export * from './model-security-enums.js';
 export * from './model-security.js';
 export * from './red-team-enums.js';
 export * from './red-team.js';
+export * from './red-team-network-broker.js';

--- a/src/models/red-team-enums.ts
+++ b/src/models/red-team-enums.ts
@@ -57,6 +57,14 @@ export const BrandSubCategory = {
 } as const;
 export type BrandSubCategory = (typeof BrandSubCategory)[keyof typeof BrandSubCategory];
 
+/** Network broker channel lifecycle status. */
+export const ChannelStatus = {
+  ONLINE: 'ONLINE',
+  OFFLINE: 'OFFLINE',
+  DRAFT: 'DRAFT',
+} as const;
+export type ChannelStatus = (typeof ChannelStatus)[keyof typeof ChannelStatus];
+
 /** Compliance framework subcategories. */
 export const ComplianceSubCategory = {
   OWASP: 'OWASP',

--- a/src/models/red-team-network-broker.ts
+++ b/src/models/red-team-network-broker.ts
@@ -1,0 +1,81 @@
+// src/models/red-team-network-broker.ts — Zod schemas + types for the AIRS Red Teaming
+// Network Broker channel API. Response schemas use `.passthrough()` for forward compatibility.
+
+import { z } from 'zod';
+import { ChannelStatus } from './red-team-enums.js';
+
+// ---------------------------------------------------------------------------
+// Channel status
+// ---------------------------------------------------------------------------
+
+/** Channel lifecycle status. Accepts the upstream values `ONLINE`, `OFFLINE`, `DRAFT`. */
+export const ChannelStatusSchema = z.nativeEnum(ChannelStatus);
+export type ChannelStatusType = z.infer<typeof ChannelStatusSchema>;
+
+// ---------------------------------------------------------------------------
+// Requests
+// ---------------------------------------------------------------------------
+
+/** Request body for creating a network broker channel. */
+export const CreateChannelRequestSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+  })
+  .passthrough();
+export type CreateChannelRequest = z.infer<typeof CreateChannelRequestSchema>;
+
+/** Request body for updating a network broker channel. */
+export const UpdateChannelRequestSchema = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+  })
+  .passthrough();
+export type UpdateChannelRequest = z.infer<typeof UpdateChannelRequestSchema>;
+
+// ---------------------------------------------------------------------------
+// Responses
+// ---------------------------------------------------------------------------
+
+/** A network broker channel. */
+export const ChannelSchema = z
+  .object({
+    uuid: z.string().optional(),
+    name: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    // Kept as a plain string (not the enum) so unknown upstream statuses never fail parsing.
+    status: z.string().nullable().optional(),
+    created_at: z.string().nullable().optional(),
+    updated_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type Channel = z.infer<typeof ChannelSchema>;
+
+/** Pagination metadata for a channel list response. */
+export const ChannelListPaginationSchema = z
+  .object({ total_items: z.number().int().nullable().optional() })
+  .passthrough();
+export type ChannelListPagination = z.infer<typeof ChannelListPaginationSchema>;
+
+/** Paginated list of network broker channels. */
+export const ChannelListResponseSchema = z
+  .object({
+    pagination: ChannelListPaginationSchema.optional(),
+    data: z.array(ChannelSchema).default([]),
+  })
+  .passthrough();
+export type ChannelListResponse = z.infer<typeof ChannelListResponseSchema>;
+
+/** Network broker infrastructure and channel-count stats. */
+export const ChannelStatsSchema = z
+  .object({
+    broker_server: z.string().nullable().optional(),
+    registry: z.string().nullable().optional(),
+    chart: z.string().nullable().optional(),
+    image: z.string().nullable().optional(),
+    online_channel_count: z.number().int().nullable().optional(),
+    total_channel_count: z.number().int().nullable().optional(),
+  })
+  .passthrough();
+export type ChannelStats = z.infer<typeof ChannelStatsSchema>;

--- a/src/red-team/client.ts
+++ b/src/red-team/client.ts
@@ -1,8 +1,10 @@
 import {
   DEFAULT_RED_TEAM_DATA_ENDPOINT,
   DEFAULT_RED_TEAM_MGMT_ENDPOINT,
+  DEFAULT_RED_TEAM_NETWORK_BROKER_ENDPOINT,
   RED_TEAM_DATA_ENDPOINT,
   RED_TEAM_MGMT_ENDPOINT,
+  RED_TEAM_NETWORK_BROKER_ENDPOINT,
   RED_TEAM_DASHBOARD_PATH,
   RED_TEAM_QUOTA_PATH,
   RED_TEAM_ERROR_LOG_PATH,
@@ -22,6 +24,7 @@ import { RedTeamTargetsClient } from './targets-client.js';
 import { RedTeamCustomAttacksClient } from './custom-attacks-client.js';
 import { RedTeamEulaClient } from './eula-client.js';
 import { RedTeamInstancesClient } from './instances-client.js';
+import { RedTeamNetworkBrokerClient } from './network-broker-client.js';
 import {
   ScanStatisticsResponseSchema,
   ScoreTrendResponseSchema,
@@ -50,6 +53,8 @@ export interface RedTeamClientOptions {
   dataEndpoint?: string;
   /** Management plane endpoint URL. Falls back to `PANW_RED_TEAM_MGMT_ENDPOINT`. */
   mgmtEndpoint?: string;
+  /** Network broker endpoint URL. Falls back to `PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT`. */
+  networkBrokerEndpoint?: string;
   /** OAuth2 token endpoint URL. Falls back to `PANW_RED_TEAM_TOKEN_ENDPOINT`, then `PANW_MGMT_TOKEN_ENDPOINT`. */
   tokenEndpoint?: string;
   /** Max retry attempts (0-5). Defaults to 5. */
@@ -85,6 +90,8 @@ export class RedTeamClient {
   public readonly eula: RedTeamEulaClient;
   /** Management plane instance/licensing operations. */
   public readonly instances: RedTeamInstancesClient;
+  /** Network broker channel operations (distinct network broker base URL). */
+  public readonly networkBroker: RedTeamNetworkBrokerClient;
 
   private readonly dataEndpoint: string;
   private readonly mgmtEndpoint: string;
@@ -96,6 +103,10 @@ export class RedTeamClient {
       opts.dataEndpoint ?? process.env[RED_TEAM_DATA_ENDPOINT] ?? DEFAULT_RED_TEAM_DATA_ENDPOINT;
     const mgmtEndpoint =
       opts.mgmtEndpoint ?? process.env[RED_TEAM_MGMT_ENDPOINT] ?? DEFAULT_RED_TEAM_MGMT_ENDPOINT;
+    const networkBrokerEndpoint =
+      opts.networkBrokerEndpoint ??
+      process.env[RED_TEAM_NETWORK_BROKER_ENDPOINT] ??
+      DEFAULT_RED_TEAM_NETWORK_BROKER_ENDPOINT;
 
     const { oauthClient, numRetries } = resolveOAuthConfig({
       clientId: opts.clientId,
@@ -129,6 +140,11 @@ export class RedTeamClient {
     });
     this.eula = new RedTeamEulaClient({ baseUrl: mgmtEndpoint, auth, numRetries });
     this.instances = new RedTeamInstancesClient({ baseUrl: mgmtEndpoint, auth, numRetries });
+    this.networkBroker = new RedTeamNetworkBrokerClient({
+      baseUrl: networkBrokerEndpoint,
+      auth,
+      numRetries,
+    });
   }
 
   // -----------------------------------------------------------------------

--- a/src/red-team/index.ts
+++ b/src/red-team/index.ts
@@ -31,3 +31,8 @@ export {
 } from './custom-attacks-client.js';
 export { RedTeamEulaClient, type RedTeamEulaClientOptions } from './eula-client.js';
 export { RedTeamInstancesClient, type RedTeamInstancesClientOptions } from './instances-client.js';
+export {
+  RedTeamNetworkBrokerClient,
+  type RedTeamNetworkBrokerClientOptions,
+  type ChannelListOptions,
+} from './network-broker-client.js';

--- a/src/red-team/network-broker-client.ts
+++ b/src/red-team/network-broker-client.ts
@@ -1,0 +1,190 @@
+import { RED_TEAM_CHANNELS_PATH, RED_TEAM_CHANNELS_STATS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { serializeListing } from '../listing.js';
+import { assertUuid } from '../validators.js';
+import {
+  ChannelSchema,
+  ChannelListResponseSchema,
+  ChannelStatsSchema,
+  type Channel,
+  type ChannelListResponse,
+  type ChannelStats,
+  type CreateChannelRequest,
+  type UpdateChannelRequest,
+} from '../models/red-team-network-broker.js';
+import type { RedTeamListOptions } from './scans-client.js';
+
+/** Filter options for {@link RedTeamNetworkBrokerClient.listChannels}. */
+export interface ChannelListOptions extends RedTeamListOptions {
+  /** Filter by channel status. Pass an array to filter by several statuses at once. */
+  status?: string | string[];
+  /** Include all channels when the other filters match nothing. */
+  include_all_if_empty?: boolean;
+}
+
+/** @internal */
+export interface RedTeamNetworkBrokerClientOptions {
+  baseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+}
+
+/**
+ * Client for Red Team Network Broker channel operations.
+ * Uses a distinct network broker base URL (data plane), sharing the Red Team OAuth adapter.
+ */
+export class RedTeamNetworkBrokerClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: RedTeamNetworkBrokerClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List network broker channels with optional filters.
+   * @param opts - Optional pagination, search, and status filter options.
+   * @returns The paginated list of channels.
+   * @example
+   * ```ts
+   * import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
+   * const rt = new RedTeamClient();
+   *
+   * const channels = await rt.networkBroker.listChannels({ status: ['ONLINE', 'DRAFT'], limit: 10 });
+   * // channels =>
+   * // { pagination: { total_items: 2 }, data: [{ uuid: '550e8400-...', name: 'prod-broker', status: 'ONLINE' }] }
+   * ```
+   */
+  async listChannels(opts?: ChannelListOptions): Promise<ChannelListResponse> {
+    const params = serializeListing(opts) as Record<string, string | string[]>;
+    if (opts?.status !== undefined) {
+      params.status = Array.isArray(opts.status) ? opts.status : [opts.status];
+    }
+    if (opts?.include_all_if_empty !== undefined) {
+      params.include_all_if_empty = String(opts.include_all_if_empty);
+    }
+
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_CHANNELS_PATH,
+      params,
+      responseSchema: ChannelListResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Create a network broker channel.
+   * @param body - Channel creation request body (requires `name`).
+   * @returns The created channel.
+   * @example
+   * ```ts
+   * import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
+   * const rt = new RedTeamClient();
+   *
+   * const channel = await rt.networkBroker.createChannel({
+   *   name: 'prod-broker',
+   *   description: 'Production network broker channel',
+   * });
+   * // channel =>
+   * // { uuid: '550e8400-...', name: 'prod-broker', status: 'DRAFT' }
+   * ```
+   */
+  async createChannel(body: CreateChannelRequest): Promise<Channel> {
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_CHANNELS_PATH,
+      body,
+      responseSchema: ChannelSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Get network broker channel stats.
+   * @returns The channel stats (broker server, registry, chart, image, channel counts).
+   * @example
+   * ```ts
+   * import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
+   * const rt = new RedTeamClient();
+   *
+   * const stats = await rt.networkBroker.getChannelStats();
+   * // stats =>
+   * // { broker_server: 'broker.example.com', online_channel_count: 3, total_channel_count: 5 }
+   * ```
+   */
+  async getChannelStats(): Promise<ChannelStats> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_CHANNELS_STATS_PATH,
+      responseSchema: ChannelStatsSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Get a network broker channel by UUID.
+   * @param channelId - The channel UUID.
+   * @returns The channel.
+   * @example
+   * ```ts
+   * import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
+   * const rt = new RedTeamClient();
+   *
+   * const channel = await rt.networkBroker.getChannel('550e8400-e29b-41d4-a716-446655440000');
+   * // channel =>
+   * // { uuid: '550e8400-...', name: 'prod-broker', status: 'ONLINE' }
+   * ```
+   */
+  async getChannel(channelId: string): Promise<Channel> {
+    assertUuid(channelId, 'channel id');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CHANNELS_PATH}/${channelId}`,
+      responseSchema: ChannelSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Update a network broker channel's name or description.
+   * @param channelId - The channel UUID.
+   * @param body - Channel update request body.
+   * @returns The updated channel.
+   * @example
+   * ```ts
+   * import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
+   * const rt = new RedTeamClient();
+   *
+   * const channel = await rt.networkBroker.updateChannel('550e8400-e29b-41d4-a716-446655440000', {
+   *   description: 'Updated description',
+   * });
+   * // channel =>
+   * // { uuid: '550e8400-...', name: 'prod-broker', description: 'Updated description', status: 'ONLINE' }
+   * ```
+   */
+  async updateChannel(channelId: string, body: UpdateChannelRequest): Promise<Channel> {
+    assertUuid(channelId, 'channel id');
+    return request({
+      method: 'PATCH',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_CHANNELS_PATH}/${channelId}`,
+      body,
+      responseSchema: ChannelSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/test/models/red-team-network-broker.spec.ts
+++ b/test/models/red-team-network-broker.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { ChannelStatus } from '../../src/models/red-team-enums.js';
+import {
+  ChannelStatusSchema,
+  CreateChannelRequestSchema,
+  UpdateChannelRequestSchema,
+  ChannelSchema,
+  ChannelStatsSchema,
+  ChannelListPaginationSchema,
+  ChannelListResponseSchema,
+} from '../../src/models/red-team-network-broker.js';
+
+describe('red-team network broker models', () => {
+  it('ChannelStatus enum exposes upstream values', () => {
+    expect(ChannelStatus.ONLINE).toBe('ONLINE');
+    expect(ChannelStatus.OFFLINE).toBe('OFFLINE');
+    expect(ChannelStatus.DRAFT).toBe('DRAFT');
+  });
+
+  it('ChannelStatusSchema accepts the three upstream values', () => {
+    expect(ChannelStatusSchema.parse('ONLINE')).toBe('ONLINE');
+    expect(ChannelStatusSchema.parse('OFFLINE')).toBe('OFFLINE');
+    expect(ChannelStatusSchema.parse('DRAFT')).toBe('DRAFT');
+    expect(() => ChannelStatusSchema.parse('BOGUS')).toThrow();
+  });
+
+  it('CreateChannelRequestSchema requires name, allows optional description', () => {
+    expect(CreateChannelRequestSchema.parse({ name: 'c1' })).toEqual({ name: 'c1' });
+    expect(CreateChannelRequestSchema.parse({ name: 'c1', description: 'd' })).toEqual({
+      name: 'c1',
+      description: 'd',
+    });
+    expect(() => CreateChannelRequestSchema.parse({})).toThrow();
+  });
+
+  it('UpdateChannelRequestSchema allows optional name and description', () => {
+    expect(UpdateChannelRequestSchema.parse({})).toEqual({});
+    expect(UpdateChannelRequestSchema.parse({ name: 'x', description: 'y' })).toEqual({
+      name: 'x',
+      description: 'y',
+    });
+  });
+
+  it('ChannelSchema parses an upstream-shaped channel and keeps extra fields', () => {
+    const parsed = ChannelSchema.parse({
+      uuid: '550e8400-e29b-41d4-a716-446655440000',
+      name: 'prod-broker',
+      description: 'desc',
+      status: 'ONLINE',
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      extra_upstream_field: 'kept',
+    });
+    expect(parsed.name).toBe('prod-broker');
+    expect(parsed.status).toBe('ONLINE');
+    expect((parsed as Record<string, unknown>).extra_upstream_field).toBe('kept');
+  });
+
+  it('ChannelListPaginationSchema parses total_items', () => {
+    expect(ChannelListPaginationSchema.parse({ total_items: 5 }).total_items).toBe(5);
+    expect(ChannelListPaginationSchema.parse({}).total_items).toBeUndefined();
+  });
+
+  it('ChannelListResponseSchema parses pagination + data', () => {
+    const parsed = ChannelListResponseSchema.parse({
+      pagination: { total_items: 1 },
+      data: [{ uuid: '550e8400-e29b-41d4-a716-446655440000', name: 'c', status: 'DRAFT' }],
+    });
+    expect(parsed.pagination?.total_items).toBe(1);
+    expect(parsed.data).toHaveLength(1);
+    expect(parsed.data[0].name).toBe('c');
+  });
+
+  it('ChannelStatsSchema parses stats and keeps extra fields', () => {
+    const parsed = ChannelStatsSchema.parse({
+      broker_server: 'broker.example.com',
+      registry: 'registry.example.com',
+      chart: 'chart-1',
+      image: 'image-1',
+      online_channel_count: 3,
+      total_channel_count: 5,
+      future_field: true,
+    });
+    expect(parsed.online_channel_count).toBe(3);
+    expect(parsed.total_channel_count).toBe(5);
+    expect((parsed as Record<string, unknown>).future_field).toBe(true);
+  });
+});

--- a/test/red-team/_fixtures.ts
+++ b/test/red-team/_fixtures.ts
@@ -321,3 +321,31 @@ export function sentimentMock(overrides: Record<string, unknown> = {}): Record<s
 export function dashboardOverviewMock(): Record<string, unknown> {
   return { total_targets: 7, targets_by_type: [] };
 }
+
+export function channelMock(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    uuid: VALID_UUID,
+    name: 'prod-broker',
+    description: 'Production network broker channel',
+    status: 'ONLINE',
+    created_at: isoNow,
+    updated_at: isoNow,
+    ...overrides,
+  };
+}
+
+export function channelListMock(items: unknown[] = []): Record<string, unknown> {
+  return { pagination: { total_items: items.length }, data: items };
+}
+
+export function channelStatsMock(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    broker_server: 'broker.example.com',
+    registry: 'registry.example.com',
+    chart: 'network-broker-1.0.0',
+    image: 'network-broker:1.0.0',
+    online_channel_count: 3,
+    total_channel_count: 5,
+    ...overrides,
+  };
+}

--- a/test/red-team/client.spec.ts
+++ b/test/red-team/client.spec.ts
@@ -5,6 +5,7 @@ import { RedTeamReportsClient } from '../../src/red-team/reports-client.js';
 import { RedTeamCustomAttackReportsClient } from '../../src/red-team/custom-attack-reports-client.js';
 import { RedTeamTargetsClient } from '../../src/red-team/targets-client.js';
 import { RedTeamCustomAttacksClient } from '../../src/red-team/custom-attacks-client.js';
+import { RedTeamNetworkBrokerClient } from '../../src/red-team/network-broker-client.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 const validUuid = '550e8400-e29b-41d4-a716-446655440000';
@@ -29,6 +30,27 @@ describe('RedTeamClient', () => {
     expect(client.customAttackReports).toBeInstanceOf(RedTeamCustomAttackReportsClient);
     expect(client.targets).toBeInstanceOf(RedTeamTargetsClient);
     expect(client.customAttacks).toBeInstanceOf(RedTeamCustomAttacksClient);
+    expect(client.networkBroker).toBeInstanceOf(RedTeamNetworkBrokerClient);
+  });
+
+  it('accepts a custom network broker endpoint', () => {
+    const client = new RedTeamClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+      networkBrokerEndpoint: 'https://nb.example.com',
+    });
+    expect(client.networkBroker).toBeInstanceOf(RedTeamNetworkBrokerClient);
+  });
+
+  it('reads the network broker endpoint from env vars', () => {
+    process.env.PANW_RED_TEAM_CLIENT_ID = 'cid';
+    process.env.PANW_RED_TEAM_CLIENT_SECRET = 'sec';
+    process.env.PANW_RED_TEAM_TSG_ID = '1';
+    process.env.PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT = 'https://nb.env.com';
+
+    const client = new RedTeamClient();
+    expect(client.networkBroker).toBeInstanceOf(RedTeamNetworkBrokerClient);
   });
 
   it('reads credentials from RED_TEAM env vars', () => {

--- a/test/red-team/network-broker-client.spec.ts
+++ b/test/red-team/network-broker-client.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RedTeamNetworkBrokerClient } from '../../src/red-team/network-broker-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+import { VALID_UUID, channelMock, channelListMock, channelStatsMock } from './_fixtures.js';
+
+const validUuid = VALID_UUID;
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+function lastCall() {
+  return (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+}
+
+describe('RedTeamNetworkBrokerClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: RedTeamNetworkBrokerClient;
+
+  beforeEach(() => {
+    client = new RedTeamNetworkBrokerClient({
+      baseUrl: 'https://nb.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('listChannels', () => {
+    it('GETs /v1/channels', async () => {
+      mockFetch(channelListMock([channelMock()]));
+      const result = await client.listChannels();
+
+      expect(result.data).toHaveLength(1);
+      const [url, init] = lastCall();
+      expect(url).toBe('https://nb.example.com/v1/channels');
+      expect(init.method).toBe('GET');
+    });
+
+    it('serializes limit, skip, and search', async () => {
+      mockFetch(channelListMock());
+      await client.listChannels({ limit: 10, skip: 5, search: 'prod' });
+
+      const [url] = lastCall();
+      expect(url).toContain('limit=10');
+      expect(url).toContain('skip=5');
+      expect(url).toContain('search=prod');
+    });
+
+    it('serializes include_all_if_empty', async () => {
+      mockFetch(channelListMock());
+      await client.listChannels({ include_all_if_empty: true });
+
+      const [url] = lastCall();
+      expect(url).toContain('include_all_if_empty=true');
+    });
+
+    it('serializes a single status filter', async () => {
+      mockFetch(channelListMock());
+      await client.listChannels({ status: 'ONLINE' });
+
+      const [url] = lastCall();
+      expect(url).toContain('status=ONLINE');
+    });
+
+    it('serializes repeated status filters', async () => {
+      mockFetch(channelListMock());
+      await client.listChannels({ status: ['ONLINE', 'DRAFT'] });
+
+      const [url] = lastCall();
+      const params = new URL(url).searchParams.getAll('status');
+      expect(params).toEqual(['ONLINE', 'DRAFT']);
+    });
+  });
+
+  describe('createChannel', () => {
+    it('POSTs to /v1/channels with body', async () => {
+      mockFetch(channelMock({ name: 'new-chan' }), 201);
+      const result = await client.createChannel({ name: 'new-chan', description: 'd' });
+
+      expect(result.name).toBe('new-chan');
+      const [url, init] = lastCall();
+      expect(url).toBe('https://nb.example.com/v1/channels');
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body)).toEqual({ name: 'new-chan', description: 'd' });
+    });
+  });
+
+  describe('getChannelStats', () => {
+    it('GETs /v1/channels/stats', async () => {
+      mockFetch(channelStatsMock());
+      const result = await client.getChannelStats();
+
+      expect(result.total_channel_count).toBe(5);
+      const [url, init] = lastCall();
+      expect(url).toBe('https://nb.example.com/v1/channels/stats');
+      expect(init.method).toBe('GET');
+    });
+  });
+
+  describe('getChannel', () => {
+    it('GETs /v1/channels/{channelId}', async () => {
+      mockFetch(channelMock());
+      const result = await client.getChannel(validUuid);
+
+      expect(result.uuid).toBe(validUuid);
+      const [url, init] = lastCall();
+      expect(url).toBe(`https://nb.example.com/v1/channels/${validUuid}`);
+      expect(init.method).toBe('GET');
+    });
+
+    it('rejects an invalid UUID', async () => {
+      await expect(client.getChannel('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('updateChannel', () => {
+    it('PATCHes /v1/channels/{channelId} with body', async () => {
+      mockFetch(channelMock({ name: 'renamed' }));
+      const result = await client.updateChannel(validUuid, { name: 'renamed' });
+
+      expect(result.name).toBe('renamed');
+      const [url, init] = lastCall();
+      expect(url).toBe(`https://nb.example.com/v1/channels/${validUuid}`);
+      expect(init.method).toBe('PATCH');
+      expect(JSON.parse(init.body)).toEqual({ name: 'renamed' });
+    });
+
+    it('rejects an invalid UUID', async () => {
+      await expect(client.updateChannel('bad', { name: 'x' })).rejects.toThrow(AISecSDKException);
+    });
+  });
+});


### PR DESCRIPTION
Closes #186

## What

Adds a first-class Red Team **Network Broker** channel sub-client. `RedTeamClient.networkBroker` now lets SDK users discover and manage the broker channels that Red Team targets reference via `network_broker_channel_uuid` — previously those UUIDs had to be obtained out-of-band.

## API

`client.networkBroker`:
- `listChannels(options?)` → `GET /v1/channels` — supports `status` (single or repeated), `search`, `include_all_if_empty`, `limit`, `skip`
- `createChannel(body)` → `POST /v1/channels`
- `getChannel(channelId)` → `GET /v1/channels/{channelId}` (UUID-validated)
- `updateChannel(channelId, body)` → `PATCH /v1/channels/{channelId}` (UUID-validated)
- `getChannelStats()` → `GET /v1/channels/stats`

Uses a distinct network broker data-plane base URL, sharing the Red Team OAuth adapter. Overridable via the `networkBrokerEndpoint` constructor option or `PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT`.

New models/schemas (all `.passthrough()`): `ChannelStatus` (`ONLINE`/`OFFLINE`/`DRAFT`), `CreateChannelRequest`, `UpdateChannelRequest`, `Channel`, `ChannelStats`, `ChannelListPagination`, `ChannelListResponse`.

## Tests

- `test/red-team/network-broker-client.spec.ts` — HTTP verb, path, query serialization (incl. repeated `status`), request body, response parsing, UUID validation
- `test/models/red-team-network-broker.spec.ts` — schema parsing + passthrough of extra fields
- `test/red-team/client.spec.ts` — sub-client wiring + endpoint override (option and env var)

## Docs

Red Team guide gains a Network Broker section (distinct base endpoint, channel-UUID discovery), a runnable `docs-site/examples/red-team-network-broker.ts`, and env-var table updates.

## Verification

`format:check`, `lint`, `typecheck`, `preflight` (0 unacknowledged drift), `docs:check`, and the full Vitest suite (1324 tests) all pass locally.

## Notes

- Non-breaking; existing Red Team APIs unchanged. Shipping as **minor** (changeset included).
- The channel endpoints are not in the local `specs/`, so preflight lists the new schemas as unmatched local helpers (no drift). Follow-up gaps from the PRD (language endpoints, target-profile error logs, model-security model endpoints, customer-app list drift) are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)