### PR TITLE
feat(red-team): supported-languages + target-profile error-log endpoints

### DIFF
--- a/.changeset/0190-red-team-languages-target-errorlog.md
+++ b/.changeset/0190-red-team-languages-target-errorlog.md
@@ -1,0 +1,10 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Add Red Team supported-languages and target-profile error-log endpoints to `RedTeamClient`:
+
+- `getLanguages()` / `getManagementLanguages()` — the tenant's allowed languages for scans (`GET /v1/languages` on the data and management planes), returning `TenantLanguagesResponse` (`multilingual_enabled`, `supported_job_types`, `languages: { code, name }[]`).
+- `getTargetProfileErrorLogs(targetId, opts?)` — profiling errors for a target (`GET /v1/error-log/target-profile/{target_id}`), reusing the existing `ErrorLogListResponse` shape.
+
+Also refreshes the committed Red Team OpenAPI specs to the latest upstream revision.

--- a/docs-site/docs/guides/red-team-api.md
+++ b/docs-site/docs/guides/red-team-api.md
@@ -622,6 +622,15 @@ const errors = await client.getErrorLogs('job-uuid', {
   limit: 50,
 });
 
+// Profiling error logs for a target (the endpoint honors `limit`)
+const targetErrors = await client.getTargetProfileErrorLogs('target-uuid', { limit: 50 });
+
+// Tenant's allowed languages for scans (data plane and management plane share the same shape)
+const langs = await client.getLanguages();
+// { multilingual_enabled: true, supported_job_types: ['STATIC', 'DYNAMIC'],
+//   languages: [{ code: 'en', name: 'English' }, { code: 'es', name: 'Spanish' }] }
+const mgmtLangs = await client.getManagementLanguages();
+
 // Update sentiment (thumbs up/down) for a scan report
 const sentiment = await client.updateSentiment({
   job_id: 'job-uuid',

--- a/specs/PaloAltoNetworks-AIRS-RedTeam-DataPlane.yaml
+++ b/specs/PaloAltoNetworks-AIRS-RedTeam-DataPlane.yaml
@@ -1,23 +1,1542 @@
 openapi: 3.1.0
 info:
   title: Prisma AIRS Red Teaming Dataplane API
-  version: 0.5.20
-  description: "Red Teaming Data Plane API - Data processing and scanning services\
-    \ for AI/ML model security. \xA9 2025 Palo Alto Networks, Inc This Open API spec\
-    \ file was created on February 25, 2026. \xA9 2026 Palo Alto Networks, Inc. Palo\
-    \ Alto Networks is a registered trademark of Palo Alto Networks. A list of our\
-    \ trademarks can be found at [https://www.paloaltonetworks.com/company/trademarks.html](https://www.paloaltonetworks.com/company/trademarks.html).\
-    \ All other marks mentioned herein may be trademarks of their respective companies."
+  description: 'Red Teaming Data Plane API - Data processing and scanning services for AI/ML model security.'
+  version: 0.6.88
+  termsOfService: https://www.paloaltonetworks.com/content/dam/pan/en_US/assets/pdf/legal/palo-alto-networks-end-user-license-agreement-eula.pdf
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  contact:
+    email: support@paloaltonetworks.com
+    name: Palo Alto Networks Technical Support
+    url: https://support.paloaltonetworks.com
 servers:
 - url: https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane
 security:
-- bearerAuth: []
+  - bearerAuth: []
+
+tags:
+ - name: Categories
+   description: Operations for managing scan categories.
+ - name: CustomAttack
+   description: Operations for custom attack configurations and prompts.
+ - name: Dashboard
+   description: Operations for dashboard data and statistics.
+ - name: ErrorLogs
+   description: Operations for retrieving and managing error logs.
+ - name: Languages
+   description: Operations for language configuration and multilingual support.
+ - name: Quota
+   description: Operations for quota management and limits.
+ - name: Report
+   description: Operations for generating and retrieving scan job reports for static and dynamic.
+ - name: Scan
+   description: Operations for creating and managing scan jobs.
+ - name: Sentiment
+   description: Operations for managing sentiment and scan report summaries.
+ - name: Templates
+   description: Operations for managing scan templates and configurations.
+
+paths:
+  /v1/scan:
+    post:
+      tags:
+      - Scan
+      summary: Create scan
+      description: Create a new scan target.
+      operationId: create_job_v1_scan_post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobCreateRequestSchema'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Scan
+      summary: List scans
+      description: List jobs with filtering and pagination.
+      operationId: list_jobs_v1_scan_get
+      parameters:
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Number of jobs to return (1-100)
+          default: 50
+          title: Limit
+        description: Number of jobs to return (1-100)
+      -
+        name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of jobs to skip for pagination
+          default: 0
+          title: Skip
+        description: Number of jobs to skip for pagination
+      -
+        name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/JobStatusFilter'
+          - type: 'null'
+          description: Filter by job status
+          title: Status
+        description: Filter by job status
+      -
+        name: job_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/JobType'
+          - type: 'null'
+          description: Filter by job type
+          title: Job Type
+        description: Filter by job type
+      -
+        name: search
+        in: query
+        required: false
+        schema:
+          anyOf:
+          -
+            type: string
+            maxLength: 255
+          - type: 'null'
+          description: Search jobs by name
+          title: Search
+        description: Search jobs by name
+      -
+        name: target_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          -
+            type: string
+            format: uuid
+          - type: 'null'
+          description: Filter by target UUID
+          title: Target Id
+        description: Filter by target UUID
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/scan/{job_id}:
+    get:
+      tags:
+      - Scan
+      summary: Get scan details
+      description: Get a job by its ID.
+      operationId: get_job_v1_scan__job_id__get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/scan/{job_id}/abort:
+    post:
+      tags:
+      - Scan
+      summary: Abort scan
+      description: Abort a running job by cancelling its workflow and updating status.
+      operationId: abort_job_v1_scan__job_id__abort_post
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobAbortResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/categories:
+    get:
+      tags:
+      - Categories
+      summary: Get all categories with subcategories
+      description: Get all available categories with their subcategories.
+      operationId: get_all_categories_v1_categories_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/CategoryModel'
+                type: array
+                title: Response Get All Categories V1 Categories Get
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/scan/scan-metadata:
+    get:
+      tags:
+      - Templates
+      summary: Get scan target metadata
+      description: Get the metadata for scan targets.
+      operationId: get_scan_metadata_v1_scan_scan_metadata_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Get Scan Metadata V1 Scan Scan Metadata Get
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/static/{job_id}/list-attacks:
+    get:
+      tags:
+      - Report
+      summary: List attacks for a scan
+      description: List attacks with filtering and pagination.
+      operationId: list_attacks_v1_report_static__job_id__list_attacks_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Number of attacks to return (1-100)
+          default: 50
+          title: Limit
+        description: Number of attacks to return (1-100)
+      -
+        name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of attacks to skip for pagination
+          default: 0
+          title: Skip
+        description: Number of attacks to skip for pagination
+      -
+        name: attack_status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/AttackStatus'
+          - type: 'null'
+          description: Filter by attack processing status
+          title: Attack Status
+        description: Filter by attack processing status
+      -
+        name: attack_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/AttackType'
+          - type: 'null'
+          description: Filter by attack type
+          title: Attack Type
+        description: Filter by attack type
+      -
+        name: category
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/Category'
+          - type: 'null'
+          description: Filter by attack category
+          title: Category
+        description: Filter by attack category
+      -
+        name: sub_category
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/SecuritySubCategory'
+          - $ref: '#/components/schemas/SafetySubCategory'
+          - $ref: '#/components/schemas/BrandSubCategory'
+          - type: 'null'
+          description: Filter by attack subcategory
+          title: Sub Category
+        description: Filter by attack subcategory
+      -
+        name: compliance
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/ComplianceSubCategory'
+          - type: 'null'
+          description: Filter by compliance framework
+          title: Compliance
+        description: Filter by compliance framework
+      -
+        name: threat
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: '[Deprecated: use status] Filter by threat status'
+          title: Threat
+        description: '[Deprecated: use status] Filter by threat status'
+      -
+        name: severity
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/SeverityFilter'
+          - type: 'null'
+          description: Filter by severity level
+          title: Severity
+        description: Filter by severity level
+      -
+        name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/StatusQueryParam'
+          - type: 'null'
+          description: 'Filter by status: SUCCESSFUL, FAILED, ERROR'
+          title: Status
+        description: 'Filter by status: SUCCESSFUL, FAILED, ERROR'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttackListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/static/{job_id}/attack/{attack_id}:
+    get:
+      tags:
+      - Report
+      summary: Get attack details
+      description: Get detailed attack information including outputs and framework techniques.
+      operationId: get_attack_detail_v1_report_static__job_id__attack__attack_id__get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: attack_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Attack Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttackDetailResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/static/{job_id}/report:
+    get:
+      tags:
+      - Report
+      summary: Get attack library report
+      description: Get attack library report for a job.  Raises ForbiddenError if report is partially complete and locked.
+      operationId: get_attack_report_v1_report_static__job_id__report_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StaticJobReportSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/static/{job_id}/runtime-policy-config:
+    get:
+      tags:
+      - Report
+      summary: Get attack library runtime security profile
+      description: Get Runtime security profile for a static job.
+      operationId: get_static_runtime_security_policy_config_v1_report_static__job_id__runtime_policy_config_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeSecurityProfileResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/static/{job_id}/remediation:
+    get:
+      tags:
+      - Report
+      summary: Get attack library scan remediation
+      description: Get other remediation measures for a static job.
+      operationId: get_static_remediations_v1_report_static__job_id__remediation_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemediationResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/dynamic/{job_id}/report:
+    get:
+      tags:
+      - Report
+      summary: Get agent scan report
+      description: Get dynamic job report for a job.
+      operationId: get_dynamic_job_report_v1_report_dynamic__job_id__report_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DynamicJobReportSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/dynamic/{job_id}/runtime-policy-config:
+    get:
+      tags:
+      - Report
+      summary: Get agent scan runtime security profile
+      description: Get Runtime security profile for a dynamic job.
+      operationId: get_dynamic_runtime_security_policy_config_v1_report_dynamic__job_id__runtime_policy_config_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeSecurityProfileResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/dynamic/{job_id}/remediation:
+    get:
+      tags:
+      - Report
+      summary: Get agent scan remediation
+      description: Get other remediation measures for a dynamic job.
+      operationId: get_dynamic_remediations_v1_report_dynamic__job_id__remediation_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemediationResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/dynamic/{job_id}/list-goals:
+    get:
+      tags:
+      - Report
+      summary: List agent scan goals
+      description: Get the goals for a job.
+      operationId: list_dynamic_job_goals_v1_report_dynamic__job_id__list_goals_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of goals to skip for pagination
+          default: 0
+          title: Skip
+        description: Number of goals to skip for pagination
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Number of goals to return (1-100)
+          default: 20
+          title: Limit
+        description: Number of goals to return (1-100)
+      -
+        name: count
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Include total count of goals
+          default: true
+          title: Count
+        description: Include total count of goals
+      -
+        name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/StatusQueryParam'
+          - type: 'null'
+          description: Filter by status
+          title: Status
+        description: Filter by status
+      -
+        name: goal_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/GoalTypeQueryParam'
+          - type: 'null'
+          description: Filter by goal type
+          title: Goal Type
+        description: Filter by goal type
+      -
+        name: search
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Search string to filter goals
+          title: Search
+        description: Search string to filter goals
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GoalListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/dynamic/{job_id}/goal/{goal_id}/list-streams:
+    get:
+      tags:
+      - Report
+      summary: List agent scan goal deatils
+      description: Get streams for a specific goal in a job.
+      operationId: list_dynamic_job_streams_v1_report_dynamic__job_id__goal__goal_id__list_streams_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: goal_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Goal Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/dynamic/stream/{stream_id}:
+    get:
+      tags:
+      - Report
+      summary: List agent scan stream details
+      operationId: get_stream_detail_v1_report_dynamic_stream__stream_id__get
+      parameters:
+      -
+        name: stream_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Stream Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamDetailResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      description: Get detailed stream information including iteration data for a specific stream.
+  /v1/report/{job_id}/download:
+    get:
+      tags:
+      - Report
+      summary: Download report
+      description: Download report files for a job.
+      operationId: download_report_v1_report__job_id__download_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: file_format
+        in: query
+        required: true
+        schema:
+          $ref: '#/components/schemas/FileFormat'
+          description: 'Format of the report file (CSV, JSON, or ALL)'
+        description: 'Format of the report file (CSV, JSON, or ALL)'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/{job_id}/generate-partial-report:
+    post:
+      tags:
+      - Report
+      summary: Generate partial scan report
+      description: 'Unlock a partial report by consuming a quota credit.  This endpoint: - Validates the job is PARTIALLY_COMPLETE - Consumes 1 quota credit of the job type - Unlocks the report for viewing  **Returns:** - Updated job information with unlocked report'
+      operationId: generate_partial_job_report_v1_report__job_id__generate_partial_report_post
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/report/static/{job_id}/attack-multi-turn/{attack_id}:
+    get:
+      tags:
+      - Report
+      summary: Get multi-turn attack details
+      description: Get detailed multi-turn attack information including outputs and framework techniques.
+      operationId: get_attack_multi_turn_detail_v1_report_static__job_id__attack_multi_turn__attack_id__get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: attack_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Attack Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttackMultiTurnDetailResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/metering/quota:
+    post:
+      tags:
+      - Quota
+      summary: Get quota summary
+      description: Get aggregated quota summary for the current TSG (POST endpoint for backward compatibility).
+      operationId: post_quota_summary_v1_metering_quota_post
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuotaSummarySchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attacks/report/{job_id}:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get custom attack Report
+      description: Get comprehensive custom attack report.
+      operationId: get_custom_attack_report_v1_custom_attacks_report__job_id__get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomAttackReportResponse'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attacks/report/{job_id}/prompt-sets:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get prompt sets
+      description: Get prompt sets with filtering and pagination.
+      operationId: get_prompt_sets_v1_custom_attacks_report__job_id__prompt_sets_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: property_filters
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: JSON string of property filters
+          title: Property Filters
+        description: JSON string of property filters
+      -
+        name: is_threat
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Filter by threat status
+          title: Is Threat
+        description: Filter by threat status
+      -
+        name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Maximum number of records to return
+          default: 20
+          title: Limit
+        description: Maximum number of records to return
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptSetsReportResponse'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attacks/report/{job_id}/prompt-set/{prompt_set_id}/prompts:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get prompts by set
+      description: Get prompts for a specific prompt set with pagination.
+      operationId: get_prompts_by_set_v1_custom_attacks_report__job_id__prompt_set__prompt_set_id__prompts_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: prompt_set_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Id
+      -
+        name: is_threat
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Filter by threat status
+          title: Is Threat
+        description: Filter by threat status
+      -
+        name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Maximum number of records to return
+          default: 20
+          title: Limit
+        description: Maximum number of records to return
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PromptDetailResponse'
+                title: Response Get Prompts By Set V1 Custom Attacks Report  Job Id  Prompt Set  Prompt Set Id  Prompts Get
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attacks/report/{job_id}/prompt/{prompt_id}:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get prompt detail
+      description: Get detailed information for a specific prompt.
+      operationId: get_prompt_detail_v1_custom_attacks_report__job_id__prompt__prompt_id__get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: prompt_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptDetailResponse'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attacks/job/{job_id}/list-custom-attacks:
+    get:
+      tags:
+      - CustomAttack
+      summary: List custom attacks
+      description: List custom attacks with V2 features.
+      operationId: list_custom_attacks_v1_custom_attacks_job__job_id__list_custom_attacks_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          description: Maximum number of records to return
+          default: 100
+          title: Limit
+        description: Maximum number of records to return
+      -
+        name: threat
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: '[Deprecated: use status] Filter by threat status'
+          title: Threat
+        description: '[Deprecated: use status] Filter by threat status'
+      -
+        name: prompt_set_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by prompt set ID
+          title: Prompt Set Id
+        description: Filter by prompt set ID
+      -
+        name: property_value
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: JSON string of property filters
+          title: Property Value
+        description: JSON string of property filters
+      -
+        name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/StatusQueryParam'
+          - type: 'null'
+          description: 'Filter by status: SUCCESSFUL, FAILED, ERROR'
+          title: Status
+        description: 'Filter by status: SUCCESSFUL, FAILED, ERROR'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomAttacksListResponse'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attacks/job/{job_id}/attack/{attack_id}/list-outputs:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get attack outputs
+      description: Get outputs for a specific attack.
+      operationId: get_attack_outputs_v1_custom_attacks_job__job_id__attack__attack_id__list_outputs_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: attack_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Attack Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CustomAttackOutputResponseSchema'
+                title: Response Get Attack Outputs V1 Custom Attacks Job  Job Id  Attack  Attack Id  List Outputs Get
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attacks/job/{job_id}/property-stats:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get property stats
+      description: Get property-based statistics for custom attacks.
+      operationId: get_property_stats_v1_custom_attacks_job__job_id__property_stats_get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: true
+                title: Response Get Property Stats V1 Custom Attacks Job  Job Id  Property Stats Get
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/error-log/job/{job_id}:
+    get:
+      tags:
+      - ErrorLogs
+      summary: List error logs for a scan
+      description: List error logs for a specific job
+      operationId: list_error_logs_for_job_v1_error_log_job__job_id__get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Number of attacks to return (1-100)
+          default: 5
+          title: Limit
+        description: Number of attacks to return (1-100)
+      -
+        name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of attacks to skip for pagination
+          default: 0
+          title: Skip
+        description: Number of attacks to skip for pagination
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorLogListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/error-log/target-profile/{target_id}:
+    get:
+      tags:
+      - ErrorLogs
+      summary: List profiling errors for a target
+      description: List deduplicated profiling error logs for a target's latest profiling run.
+      operationId: list_error_logs_for_target_profile_v1_error_log_target_profile__target_id__get
+      parameters:
+      -
+        name: target_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Id
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Number of errors to return (1-100)
+          default: 5
+          title: Limit
+        description: Number of errors to return (1-100)
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorLogListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/languages:
+    get:
+      tags:
+      - Languages
+      summary: Get available languages for scan
+      description: Return allowed languages for the requesting tenant's scan page.
+      operationId: get_languages_v1_languages_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantLanguagesResponseSchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/dashboard/scan-statistics:
+    get:
+      tags:
+      - Dashboard
+      summary: Get scan statistics and risk profile
+      description: 'Returns scan counts, target statistics, status breakdown, and risk profile for dashboard display.'
+      operationId: get_scan_statistics_v1_dashboard_scan_statistics_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanStatisticsResponseSchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/dashboard/score-trend:
+    get:
+      tags:
+      - Dashboard
+      summary: Get score trend for a target
+      description: Returns time-series risk scores grouped by job type for chart display.
+      operationId: get_score_trend_v1_dashboard_score_trend_get
+      parameters:
+      -
+        name: target_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          description: Target UUID to fetch scores for
+          title: Target Id
+        description: Target UUID to fetch scores for
+      -
+        name: date_range
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/DateRangeFilter'
+          description: Predefined date range filter
+          default: LAST_7_DAYS
+        description: Predefined date range filter
+      -
+        name: start_date
+        in: query
+        required: false
+        schema:
+          anyOf:
+          -
+            type: string
+            format: date
+          - type: 'null'
+          description: Custom start date (overrides date_range if both provided)
+          title: Start Date
+        description: Custom start date (overrides date_range if both provided)
+      -
+        name: end_date
+        in: query
+        required: false
+        schema:
+          anyOf:
+          -
+            type: string
+            format: date
+          - type: 'null'
+          description: Custom end date (overrides date_range if both provided)
+          title: End Date
+        description: Custom end date (overrides date_range if both provided)
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScoreTrendResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/sentiment:
+    post:
+      tags:
+      - Sentiment
+      summary: Update sentiment scan report
+      description: Create or update sentiment for a job report.
+      operationId: create_or_update_sentiment_v1_sentiment_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SentimentRequestSchema'
+        required: true
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SentimentResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/sentiment/{job_id}:
+    get:
+      tags:
+      - Sentiment
+      summary: Get sentiment for a scan
+      description: Get Sentiment status of a scan.
+      operationId: get_job_sentiment_v1_sentiment__job_id__get
+      parameters:
+      -
+        name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SentimentResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
+      bearerAuth:
+        type: http
+        scheme: bearer
+        bearerFormat: JWT
   schemas:
     ApiEndpointType:
       type: string
@@ -82,9 +1601,10 @@ components:
           default: false
         asr:
           anyOf:
-          - type: number
-            maximum: 100
-            minimum: 0
+          -
+            type: number
+            maximum: 100.0
+            minimum: 0.0
           - type: 'null'
           title: Asr
           description: Attack Success Rate (0-100)
@@ -94,6 +1614,12 @@ components:
           - type: 'null'
           title: Version
           description: Attack version
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: True if all attack attempts failed (zero outputs produced)
         prompt_mapping_id:
           type: string
           format: uuid
@@ -131,7 +1657,7 @@ components:
           title: Compliance Frameworks
         outputs:
           items:
-            $ref: '#/components/schemas/AttackOutputSchema'
+            $ref: '#/components/schemas/AttackOutputResponseSchema'
           type: array
           title: Outputs
           description: Outputs for attacks
@@ -171,8 +1697,7 @@ components:
       - pagination
       - data
       title: AttackListResponseSchema
-      description: Response schema for listing attacks following common pagination
-        pattern.
+      description: Response schema for listing attacks following common pagination pattern.
     AttackListSchema:
       properties:
         uuid:
@@ -228,9 +1753,10 @@ components:
           default: false
         asr:
           anyOf:
-          - type: number
-            maximum: 100
-            minimum: 0
+          -
+            type: number
+            maximum: 100.0
+            minimum: 0.0
           - type: 'null'
           title: Asr
           description: Attack Success Rate (0-100)
@@ -240,6 +1766,12 @@ components:
           - type: 'null'
           title: Version
           description: Attack version
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: True if all attack attempts failed (zero outputs produced)
         prompt_mapping_id:
           type: string
           format: uuid
@@ -339,9 +1871,10 @@ components:
           default: false
         asr:
           anyOf:
-          - type: number
-            maximum: 100
-            minimum: 0
+          -
+            type: number
+            maximum: 100.0
+            minimum: 0.0
           - type: 'null'
           title: Asr
           description: Attack Success Rate (0-100)
@@ -351,6 +1884,12 @@ components:
           - type: 'null'
           title: Version
           description: Attack version
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: True if all attack attempts failed (zero outputs produced)
         prompt_mapping_id:
           type: string
           format: uuid
@@ -389,13 +1928,11 @@ components:
         outputs:
           items:
             items:
-              $ref: '#/components/schemas/AttackMultiTurnOutputSchema'
+              $ref: '#/components/schemas/AttackMultiTurnOutputResponseSchema'
             type: array
           type: array
           title: Outputs
-          description: List of conversations, where each conversation is a list of
-            turns ordered by turn number. Each inner list represents one generation
-            of the multi-turn attack.
+          description: 'List of conversations, where each conversation is a list of turns ordered by turn number. Each inner list represents one generation of the multi-turn attack.'
         goal:
           anyOf:
           - type: string
@@ -417,7 +1954,7 @@ components:
       - compliance_frameworks
       - goal
       title: AttackMultiTurnDetailResponseSchema
-    AttackMultiTurnOutputSchema:
+    AttackMultiTurnOutputResponseSchema:
       properties:
         uuid:
           type: string
@@ -444,7 +1981,7 @@ components:
         output:
           type: string
           title: Output
-          description: Attack output. String for single-turn, dict for multi-turn.
+          description: 'Attack output. String for single-turn, dict for multi-turn.'
         threat:
           anyOf:
           - type: boolean
@@ -468,14 +2005,25 @@ components:
         generation:
           type: integer
           title: Generation
-          description: Generation/conversation number (1-based) for grouping multi-turn
-            outputs
+          description: Generation/conversation number (1-based) for grouping multi-turn outputs
           default: 1
         multi_turn:
           type: boolean
           title: Multi Turn
           description: Multi-turn conversation flag
           default: true
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: Whether this output is an error
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+          description: 'Error message in format ''errType: description'''
       type: object
       required:
       - uuid
@@ -486,9 +2034,9 @@ components:
       - output
       - prompt
       - turn
-      title: AttackMultiTurnOutputSchema
-      description: Schema for multi-turn attack outputs.
-    AttackOutputSchema:
+      title: AttackMultiTurnOutputResponseSchema
+      description: API response schema — excludes internal/debug fields from client responses.
+    AttackOutputResponseSchema:
       properties:
         uuid:
           type: string
@@ -515,7 +2063,7 @@ components:
         output:
           type: string
           title: Output
-          description: Attack output. String for single-turn, dict for multi-turn.
+          description: 'Attack output. String for single-turn, dict for multi-turn.'
         threat:
           anyOf:
           - type: boolean
@@ -528,6 +2076,18 @@ components:
           - type: 'null'
           title: Marked Safe
           description: Manual safety marking
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: Whether this output is an error
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+          description: 'Error message in format ''errType: description'''
       type: object
       required:
       - uuid
@@ -536,8 +2096,8 @@ components:
       - job_id
       - target_id
       - output
-      title: AttackOutputSchema
-      description: Schema for attack output responses.
+      title: AttackOutputResponseSchema
+      description: API response schema — excludes internal/debug fields from client responses.
     AttackStatus:
       type: string
       enum:
@@ -554,6 +2114,14 @@ components:
       - NORMAL
       - CUSTOM
       title: AttackType
+    AuthType:
+      type: string
+      enum:
+      - HEADERS
+      - BASIC_AUTH
+      - OAUTH2
+      title: AuthType
+      description: Authentication method for target API access.
     BrandSubCategory:
       type: string
       enum:
@@ -627,11 +2195,11 @@ components:
             $ref: '#/components/schemas/SubCategoryStatsSchema'
           type: array
           title: Sub Categories
-          description: Statistics per subcategory (e.g., ADVERSARIAL_SUFFIX, BIAS)
+          description: 'Statistics per subcategory (e.g., ADVERSARIAL_SUFFIX, BIAS)'
         asr:
           type: number
-          maximum: 100
-          minimum: 0
+          maximum: 100.0
+          minimum: 0.0
           title: Asr
           description: Attack success rate percentage
         total_prompts:
@@ -663,6 +2231,38 @@ components:
       - failed
       title: CategoryReportSchema
       description: Security or Safety risk overview widget data.
+    ClaraJobMetadata:
+      properties:
+        scan_name:
+          type: string
+          maxLength: 255
+          minLength: 3
+          title: Scan Name
+        categories:
+          additionalProperties:
+            items:
+              anyOf:
+              - $ref: '#/components/schemas/SecuritySubCategory'
+              - $ref: '#/components/schemas/SafetySubCategory'
+              - $ref: '#/components/schemas/BrandSubCategory'
+              - $ref: '#/components/schemas/ComplianceSubCategory'
+            type: array
+          propertyNames:
+            $ref: '#/components/schemas/Category'
+          type: object
+          title: Categories
+          description: Auto-derived from uploaded prompt data — determines report sections
+        language:
+          type: 'null'
+          title: Language
+          description: Always None — CLARA is English-only
+      type: object
+      required:
+      - scan_name
+      title: ClaraJobMetadata
+      description: |
+        Metadata for CLARA scan jobs. Intentionally minimal —
+        no rate_limit/content_filter since CLARA doesn't execute attacks.
     ComplianceReportSchema:
       properties:
         id:
@@ -820,10 +2420,10 @@ components:
         name:
           type: string
           title: Name
-          description: Name of the item (e.g., target type, status)
+          description: 'Name of the item (e.g., target type, status)'
         count:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Count
           description: Count of items
       type: object
@@ -831,15 +2431,11 @@ components:
       - name
       - count
       title: CountByNameSchema
-      description: 'Generic count schema with name field for extensible list structures.
-
-
-        Used in dashboard and other endpoints to provide counts grouped by a name
-        field.
-
+      description: |
+        Generic count schema with name field for extensible list structures.
+        
+        Used in dashboard and other endpoints to provide counts grouped by a name field.
         Frontend-friendly list format for easy iteration.
-
-        '
     CountedQuotaEnum:
       type: string
       enum:
@@ -848,7 +2444,7 @@ components:
       - NOT_COUNTED
       title: CountedQuotaEnum
       description: Enum for counting Quota.
-    CustomAttackOutputSchema:
+    CustomAttackOutputResponseSchema:
       properties:
         uuid:
           type: string
@@ -888,6 +2484,18 @@ components:
           - type: 'null'
           title: Marked Safe
           description: Manual safety marking
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: Whether this output is an error
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+          description: 'Error message in format ''errType: description'''
       type: object
       required:
       - uuid
@@ -896,8 +2504,8 @@ components:
       - job_id
       - target_id
       - output
-      title: CustomAttackOutputSchema
-      description: Schema for custom attack output response.
+      title: CustomAttackOutputResponseSchema
+      description: API response schema — excludes English translation fields.
     CustomAttackReportResponse:
       properties:
         total_prompts:
@@ -995,7 +2603,8 @@ components:
           title: Rate Limit Error Message
         rate_limit_error_json:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Rate Limit Error Json
@@ -1006,9 +2615,10 @@ components:
           default: false
         content_filter_error_code:
           anyOf:
-          - type: integer
-            maximum: 599
-            minimum: 400
+          -
+            type: integer
+            maximum: 599.0
+            minimum: 400.0
           - type: 'null'
           title: Content Filter Error Code
           description: HTTP error code for content filter (400-599)
@@ -1020,10 +2630,16 @@ components:
           description: Content filter error message
         content_filter_error_json:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Content Filter Error Json
+        language:
+          anyOf:
+          - $ref: '#/components/schemas/LanguageOptionSchema'
+          - type: 'null'
+          description: Language for this scan. None = English.
         custom_prompt_sets:
           items:
             type: string
@@ -1084,7 +2700,8 @@ components:
           title: Rate Limit Error Message
         rate_limit_error_json:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Rate Limit Error Json
@@ -1095,9 +2712,10 @@ components:
           default: false
         content_filter_error_code:
           anyOf:
-          - type: integer
-            maximum: 599
-            minimum: 400
+          -
+            type: integer
+            maximum: 599.0
+            minimum: 400.0
           - type: 'null'
           title: Content Filter Error Code
           description: HTTP error code for content filter (400-599)
@@ -1109,35 +2727,41 @@ components:
           description: Content filter error message
         content_filter_error_json:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Content Filter Error Json
+        language:
+          anyOf:
+          - $ref: '#/components/schemas/LanguageOptionSchema'
+          - type: 'null'
+          description: Language for this scan. None = English.
         stream_breadth:
           type: integer
-          maximum: 20
-          minimum: 1
+          maximum: 20.0
+          minimum: 1.0
           title: Stream Breadth
           description: Number of parallel attack streams (1-20)
           default: 6
         stream_depth:
           type: integer
-          maximum: 20
-          minimum: 1
+          maximum: 20.0
+          minimum: 1.0
           title: Stream Depth
           description: Depth of each attack stream (1-20)
           default: 10
         max_tokens:
           type: integer
-          maximum: 4096
-          minimum: 128
+          maximum: 4096.0
+          minimum: 128.0
           title: Max Tokens
           description: Maximum tokens per response (128-4096)
           default: 256
         context_size:
           type: integer
-          maximum: 20
-          minimum: 1
+          maximum: 20.0
+          minimum: 1.0
           title: Context Size
           description: Context window size (1-20)
           default: 10
@@ -1172,25 +2796,25 @@ components:
       properties:
         total_goals:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Total Goals
           description: Total number of goals tested
           default: 0
         total_streams:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Total Streams
           description: Total number of attack streams
           default: 0
         total_threats:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Total Threats
           description: Total number of threats detected
           default: 0
         goals_achieved:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Goals Achieved
           description: Number of goals with at least one threat
           default: 0
@@ -1202,18 +2826,18 @@ components:
           description: LLM-generated executive summary for the dynamic job
         score:
           type: number
-          maximum: 100
-          minimum: 0
+          maximum: 100.0
+          minimum: 0.0
           title: Score
           description: Overall security score (0-100)
-          default: 0
+          default: 0.0
         asr:
           type: number
-          maximum: 100
-          minimum: 0
+          maximum: 100.0
+          minimum: 0.0
           title: Asr
           description: Attack Success Rate (0-100)
-          default: 0
+          default: 0.0
       type: object
       title: DynamicJobReportSchema
       description: Core metrics for report generation.
@@ -1221,25 +2845,25 @@ components:
       properties:
         total_goals:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Total Goals
           description: Total number of goals tested
           default: 0
         total_streams:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Total Streams
           description: Total number of attack streams
           default: 0
         total_threats:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Total Threats
           description: Total number of threats detected
           default: 0
         goals_achieved:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Goals Achieved
           description: Number of goals with at least one threat
           default: 0
@@ -1271,14 +2895,16 @@ components:
       properties:
         job_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Job Id
           description: UUID of the job associated with this error
         target_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Target Id
@@ -1291,7 +2917,8 @@ components:
           description: Version of the target configuration when error occurred
         attack_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Attack Id
@@ -1314,14 +2941,16 @@ components:
           description: Human-readable error message
         target_object:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Target Object
           description: Snapshot of target configuration at error time
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
@@ -1365,6 +2994,7 @@ components:
       - NETWORK
       - VALIDATION
       - NETWORK_CHANNEL
+      - TRANSLATION
       - UNKNOWN
       title: ErrorType
       description: Classification of error types.
@@ -1382,7 +3012,7 @@ components:
           $ref: '#/components/schemas/PaginationSchema'
         data:
           items:
-            $ref: '#/components/schemas/GoalSchema'
+            $ref: '#/components/schemas/GoalResponseSchema'
           type: array
           title: Data
           description: List of Goals
@@ -1391,9 +3021,8 @@ components:
       - pagination
       - data
       title: GoalListResponseSchema
-      description: Response schema for listing attacks following common pagination
-        pattern.
-    GoalSchema:
+      description: Response schema for listing attacks following common pagination pattern.
+    GoalResponseSchema:
       properties:
         goal:
           type: string
@@ -1420,7 +3049,7 @@ components:
           default: false
         goal_type:
           $ref: '#/components/schemas/GoalType'
-          description: 'Goal type: BASE, TOOL_MISUSE, GOAL_MANIPULATION'
+          description: 'Goal type: BASE, TOOL_MISUSE, GOAL_MANIPULATION, PRIVILEGE_MISUSE'
           default: BASE
         uuid:
           type: string
@@ -1453,11 +3082,106 @@ components:
           description: Goal schema version
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
           description: Extra info
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: Whether this goal has errors
+      type: object
+      required:
+      - goal
+      - safe_response
+      - jailbroken_response
+      - uuid
+      - tsg_id
+      - job_id
+      title: GoalResponseSchema
+      description: API response schema for Goals.
+    GoalSchema:
+      properties:
+        goal:
+          type: string
+          title: Goal
+          description: The test goal/prompt
+        goal_english:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal English
+          description: English version of goal for judge
+        safe_response:
+          type: string
+          title: Safe Response
+          description: The complete safe response with proper refusal
+        jailbroken_response:
+          type: string
+          minLength: 1
+          title: Jailbroken Response
+          description: The complete jailbroken response without disclaimers
+        goal_metadata:
+          additionalProperties: true
+          type: object
+          title: Goal Metadata
+          description: Additional metadata
+        custom_goal:
+          type: boolean
+          title: Custom Goal
+          description: Indicates if it is a custom goal
+          default: false
+        goal_type:
+          $ref: '#/components/schemas/GoalType'
+          description: 'Goal type: BASE, TOOL_MISUSE, GOAL_MANIPULATION, PRIVILEGE_MISUSE'
+          default: BASE
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Job identifier
+        goal_to_show:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Goal To Show
+          description: Goal to use in the backend
+        threat:
+          type: boolean
+          title: Threat
+          description: Indicates if it is a threat
+          default: false
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Goal schema version
+        extra_info:
+          anyOf:
+          -
+            additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Extra info
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: Whether this goal has errors
       type: object
       required:
       - goal
@@ -1473,6 +3197,7 @@ components:
       - BASE
       - TOOL_MISUSE
       - GOAL_MANIPULATION
+      - PRIVILEGE_MISUSE
       title: GoalType
     GoalTypeQueryParam:
       type: string
@@ -1532,6 +3257,7 @@ components:
           - $ref: '#/components/schemas/StaticJobMetadata'
           - $ref: '#/components/schemas/DynamicJobMetadata'
           - $ref: '#/components/schemas/CustomJobMetadata'
+          - $ref: '#/components/schemas/ClaraJobMetadata'
           title: Job Metadata
           description: Job-specific metadata
         version:
@@ -1542,7 +3268,8 @@ components:
           description: Job version
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
@@ -1597,6 +3324,7 @@ components:
           - $ref: '#/components/schemas/StaticJobMetadata'
           - $ref: '#/components/schemas/DynamicJobMetadata'
           - $ref: '#/components/schemas/CustomJobMetadata'
+          - $ref: '#/components/schemas/ClaraJobMetadata'
           title: Job Metadata
           description: Job-specific metadata
         version:
@@ -1607,7 +3335,8 @@ components:
           description: Job version
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
@@ -1619,18 +3348,20 @@ components:
         target_type:
           type: string
           title: Target Type
-          description: Target type (APPLICATION, AGENT, MODEL)
+          description: 'Target type (APPLICATION, AGENT, MODEL)'
         total:
           anyOf:
-          - type: integer
-            minimum: 0
+          -
+            type: integer
+            minimum: 0.0
           - type: 'null'
           title: Total
           description: Total tasks in job
         completed:
           anyOf:
-          - type: integer
-            minimum: 0
+          -
+            type: integer
+            minimum: 0.0
           - type: 'null'
           title: Completed
           description: Completed tasks
@@ -1640,17 +3371,19 @@ components:
           default: INIT
         score:
           anyOf:
-          - type: number
-            maximum: 100
-            minimum: 0
+          -
+            type: number
+            maximum: 100.0
+            minimum: 0.0
           - type: 'null'
           title: Score
           description: Overall job performance score (0-100)
         asr:
           anyOf:
-          - type: number
-            maximum: 100
-            minimum: 0
+          -
+            type: number
+            maximum: 100.0
+            minimum: 0.0
           - type: 'null'
           title: Asr
           description: Updated Attack Success Rate (0-100)
@@ -1661,21 +3394,24 @@ components:
           description: Job timing information
         created_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Created At
           description: Creation timestamp
         updated_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Updated At
           description: Last update timestamp
         created_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Created By User Id
@@ -1684,15 +3420,16 @@ components:
           anyOf:
           - $ref: '#/components/schemas/StaticJobReportStats'
           - $ref: '#/components/schemas/DynamicJobReportStats'
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Report Stats
-          description: Report statistics (StaticJobReportStats for STATIC/CUSTOM jobs,
-            DynamicJobReportStats for DYNAMIC jobs)
+          description: 'Report statistics (StaticJobReportStats for STATIC/CUSTOM jobs, DynamicJobReportStats for DYNAMIC jobs)'
         metering_quota_uuid:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Metering Quota Uuid
@@ -1746,28 +3483,32 @@ components:
       properties:
         queued_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Queued At
           description: Job queue timestamp
         started_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Started At
           description: Job start timestamp
         completed_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Completed At
           description: Job completion timestamp
         time_taken:
           anyOf:
-          - type: string
+          -
+            type: string
             format: duration
           - type: 'null'
           title: Time Taken
@@ -1781,8 +3522,23 @@ components:
       - STATIC
       - DYNAMIC
       - CUSTOM
+      - CLARA
       title: JobType
       description: Type of job execution.
+    LanguageOptionSchema:
+      properties:
+        code:
+          type: string
+          title: Code
+        name:
+          type: string
+          title: Name
+      type: object
+      required:
+      - code
+      - name
+      title: LanguageOptionSchema
+      description: Language representation with code and display name.
     MaliciousCodeDetectionSchema:
       properties:
         action:
@@ -1850,6 +3606,7 @@ components:
       - IN_PROGRESS
       - COMPLETED
       - FAILED
+      - PARTIALLY_COMPLETE
       title: ProfilingStatus
       description: Status of target profiling workflow.
     PromptDetailResponse:
@@ -1882,7 +3639,8 @@ components:
           description: Property assignments
         attack_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Attack Id
@@ -1901,15 +3659,17 @@ components:
           description: Attack output strings
         asr:
           anyOf:
-          - type: number
-            maximum: 100
-            minimum: 0
+          -
+            type: number
+            maximum: 100.0
+            minimum: 0.0
           - type: 'null'
           title: Asr
           description: Attack Success Rate for this prompt (0-100)
         prompt_set_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Prompt Set Id
@@ -1920,6 +3680,12 @@ components:
           - type: 'null'
           title: Prompt Set Name
           description: Prompt set name
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: Whether this attack has errors
       type: object
       required:
       - prompt_id
@@ -2148,8 +3914,7 @@ components:
             $ref: '#/components/schemas/RemediationDetailSchema'
           type: array
           title: Remediations
-          description: List of applicable remediation recommendations for static and
-            dynamic jobs
+          description: List of applicable remediation recommendations for static and dynamic jobs
       type: object
       title: RemediationResponseSchema
     ResponseMode:
@@ -2157,6 +3922,8 @@ components:
       enum:
       - REST
       - STREAMING
+      - WEBSOCKET
+      - WEBSOCKET_STREAMING
       title: ResponseMode
       description: Response mode for target interactions.
     RiskLevelSchema:
@@ -2166,7 +3933,7 @@ components:
           description: Risk rating level based on job score
         total:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Total
           description: Total count for this risk rating level
         targets_by_type:
@@ -2174,7 +3941,7 @@ components:
             $ref: '#/components/schemas/CountByNameSchema'
           type: array
           title: Targets By Type
-          description: Breakdown by target type (APPLICATION, AGENT, MODEL)
+          description: 'Breakdown by target type (APPLICATION, AGENT, MODEL)'
       type: object
       required:
       - risk_rating
@@ -2220,7 +3987,8 @@ components:
       properties:
         runtime_security_profile:
           anyOf:
-          - items:
+          -
+            items:
               $ref: '#/components/schemas/RuntimeSecurityPolicySchema'
             type: array
           - type: 'null'
@@ -2242,30 +4010,16 @@ components:
       - SEXUAL
       - VIOLENT_CRIMES_WEAPONS
       title: SafetySubCategory
-    SensitiveDataProtectionSchema:
-      properties:
-        action:
-          $ref: '#/components/schemas/GuardrailAction'
-          description: 'Action to take: ''allow'', ''block'''
-          default: BLOCK
-        masking_sensitive_data:
-          type: boolean
-          title: Masking Sensitive Data
-          description: Whether to mask sensitive data in responses
-          default: true
-      type: object
-      title: SensitiveDataProtectionSchema
-      description: Guardrail configuration for sensitive data protection.
     ScanStatisticsResponseSchema:
       properties:
         total_scans:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Total Scans
           description: Total number of scans
         targets_scanned:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Targets Scanned
           description: Number of unique targets scanned
         targets_scanned_by_type:
@@ -2273,13 +4027,13 @@ components:
             $ref: '#/components/schemas/CountByNameSchema'
           type: array
           title: Targets Scanned By Type
-          description: Targets scanned grouped by type (APPLICATION, AGENT, MODEL)
+          description: 'Targets scanned grouped by type (APPLICATION, AGENT, MODEL)'
         scan_status:
           items:
             $ref: '#/components/schemas/CountByNameSchema'
           type: array
           title: Scan Status
-          description: Scan counts by status (COMPLETED, IN_PROGRESS, QUEUED, FAILED)
+          description: 'Scan counts by status (COMPLETED, IN_PROGRESS, QUEUED, FAILED)'
         risk_profile:
           items:
             $ref: '#/components/schemas/RiskLevelSchema'
@@ -2291,14 +4045,11 @@ components:
       - total_scans
       - targets_scanned
       title: ScanStatisticsResponseSchema
-      description: 'Dashboard scan statistics response.
-
-
+      description: |
+        Dashboard scan statistics response.
+        
         Endpoint: GET /api/v1/dashboard/scan-statistics
-
         Returns scan counts, target stats, and risk profile in list format.
-
-        '
     ScoreTrendResponseSchema:
       properties:
         labels:
@@ -2306,7 +4057,7 @@ components:
             type: string
           type: array
           title: Labels
-          description: Date labels (e.g., 'Jan 1', 'Jan 2')
+          description: 'Date labels (e.g., ''Jan 1'', ''Jan 2'')'
         series:
           items:
             $ref: '#/components/schemas/ScoreTrendSeriesSchema'
@@ -2318,14 +4069,11 @@ components:
       - labels
       - series
       title: ScoreTrendResponseSchema
-      description: 'Response for score trend chart API.
-
-
+      description: |
+        Response for score trend chart API.
+        
         Endpoint: GET /api/v1/dashboard/score-trend
-
         Returns time-series risk scores grouped by job type for chart display.
-
-        '
     ScoreTrendSeriesSchema:
       properties:
         label:
@@ -2338,7 +4086,7 @@ components:
             - type: 'null'
           type: array
           title: Data
-          description: Score per date label, null if no completed scan on that date
+          description: 'Score per date label, null if no completed scan on that date'
       type: object
       required:
       - label
@@ -2359,6 +4107,20 @@ components:
       - TOOL_LEAK
       - MALWARE_GENERATION
       title: SecuritySubCategory
+    SensitiveDataProtectionSchema:
+      properties:
+        action:
+          $ref: '#/components/schemas/GuardrailAction'
+          description: 'Action to take: ''allow'', ''block'''
+          default: BLOCK
+        masking_sensitive_data:
+          type: boolean
+          title: Masking Sensitive Data
+          description: Whether to mask sensitive data in responses
+          default: true
+      type: object
+      title: SensitiveDataProtectionSchema
+      description: Guardrail configuration for sensitive data protection.
     SentimentRequestSchema:
       properties:
         job_id:
@@ -2454,7 +4216,7 @@ components:
       properties:
         severity:
           type: string
-          description: Severity level (LOW, MEDIUM, HIGH, CRITICAL)
+          description: 'Severity level (LOW, MEDIUM, HIGH, CRITICAL)'
         successful:
           type: integer
           title: Successful
@@ -2493,7 +4255,8 @@ components:
           title: Rate Limit Error Message
         rate_limit_error_json:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Rate Limit Error Json
@@ -2504,9 +4267,10 @@ components:
           default: false
         content_filter_error_code:
           anyOf:
-          - type: integer
-            maximum: 599
-            minimum: 400
+          -
+            type: integer
+            maximum: 599.0
+            minimum: 400.0
           - type: 'null'
           title: Content Filter Error Code
           description: HTTP error code for content filter (400-599)
@@ -2518,10 +4282,16 @@ components:
           description: Content filter error message
         content_filter_error_json:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Content Filter Error Json
+        language:
+          anyOf:
+          - $ref: '#/components/schemas/LanguageOptionSchema'
+          - type: 'null'
+          description: Language for this scan. None = English.
         categories:
           additionalProperties:
             items:
@@ -2554,7 +4324,8 @@ components:
       properties:
         runtime_security_policy_configuration:
           anyOf:
-          - items:
+          -
+            items:
               $ref: '#/components/schemas/RuntimeSecurityPolicySchema'
             type: array
           - type: 'null'
@@ -2568,8 +4339,7 @@ components:
           description: List of applicable remediations for static job
       type: object
       title: StaticJobRemediationRecommendationSchema
-      description: Remediation recommendations with security profile and other remediations.
-        To build and store in db
+      description: Remediation recommendations with security profile and other remediations. To build and store in db
     StaticJobRemediationSchema:
       properties:
         mapping_remediation_id:
@@ -2580,7 +4350,8 @@ components:
           description: UUID from remediations.csv identifying this remediation
         subcategories:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
@@ -2599,8 +4370,7 @@ components:
         priority:
           type: integer
           title: Priority
-          description: Priority level for implementing this remediation (LOW, MEDIUM,
-            HIGH)
+          description: 'Priority level for implementing this remediation (LOW, MEDIUM, HIGH)'
           default: 0
         remediation:
           type: string
@@ -2618,12 +4388,13 @@ components:
           description: URLs for additional resources and documentation
         categories:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
           title: Categories
-          description: Categories this remediation applies to (e.g., Security, Safety)
+          description: 'Categories this remediation applies to (e.g., Security, Safety)'
       type: object
       required:
       - remediation
@@ -2634,17 +4405,19 @@ components:
       properties:
         asr:
           anyOf:
-          - type: number
-            maximum: 100
-            minimum: 0
+          -
+            type: number
+            maximum: 100.0
+            minimum: 0.0
           - type: 'null'
           title: Asr
           description: Attack Success Rate percentage (0-100)
         score:
           anyOf:
-          - type: number
-            maximum: 100
-            minimum: 0
+          -
+            type: number
+            maximum: 100.0
+            minimum: 0.0
           - type: 'null'
           title: Score
           description: Overall job performance score (0-100)
@@ -2665,7 +4438,8 @@ components:
           description: Brand reputation risk overview widget
         compliance_report:
           anyOf:
-          - items:
+          -
+            items:
               $ref: '#/components/schemas/ComplianceReportSchema'
             type: array
           - type: 'null'
@@ -2673,8 +4447,7 @@ components:
           description: Compliance widget with all frameworks
         severity_report:
           $ref: '#/components/schemas/SeverityReportSchema'
-          description: Breakdown of all successful attacks by severity level for the
-            entire job
+          description: Breakdown of all successful attacks by severity level for the entire job
         report_summary:
           anyOf:
           - type: string
@@ -2685,8 +4458,7 @@ components:
           anyOf:
           - $ref: '#/components/schemas/StaticJobRemediationRecommendationSchema'
           - type: 'null'
-          description: Remediation recommendations with security profile and actionable
-            fixes
+          description: Remediation recommendations with security profile and actionable fixes
       type: object
       required:
       - severity_report
@@ -2696,7 +4468,7 @@ components:
       properties:
         output_completion_percentage:
           type: number
-          minimum: 0
+          minimum: 0.0
           title: Output Completion Percentage
           description: Percentage of attack outputs that completed successfully (0-100)
         partial_report_unlocked:
@@ -2706,7 +4478,8 @@ components:
           default: false
         partial_report_unlocked_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Partial Report Unlocked At
@@ -2721,17 +4494,15 @@ components:
       required:
       - output_completion_percentage
       title: StaticJobReportStats
-      description: 'Report statistics for static jobs stored in job.report_stats JSONB
-        field.
-
+      description: |
+        Report statistics for static jobs stored in job.report_stats JSONB field.
         Tracks output completion and partial report unlock status.
-
-        '
     StatusQueryParam:
       type: string
       enum:
       - SUCCESSFUL
       - FAILED
+      - ERROR
       title: StatusQueryParam
     StreamDetailResponseSchema:
       properties:
@@ -2795,13 +4566,15 @@ components:
           description: First threat iteration data (denormalized JSONB for performance)
         created_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Created At
         updated_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Updated At
@@ -2816,9 +4589,21 @@ components:
           - type: 'null'
           title: Version
           description: Stream schema version
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: Whether this stream encountered errors
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+          description: Error message details
         iterations:
           items:
-            $ref: '#/components/schemas/StreamIterationDataSchema'
+            $ref: '#/components/schemas/StreamIterationDataResponseSchema'
           type: array
           title: Iterations
           description: List of iterations
@@ -2830,7 +4615,7 @@ components:
       - target_id
       - goal_id
       title: StreamDetailResponseSchema
-    StreamIterationDataSchema:
+    StreamIterationDataResponseSchema:
       properties:
         uuid:
           type: string
@@ -2856,7 +4641,7 @@ components:
           description: Goal identifier
         iteration:
           type: integer
-          minimum: 0
+          minimum: 0.0
           title: Iteration
           description: Iteration number
         prompt:
@@ -2888,9 +4673,10 @@ components:
           description: Best target output (highest score)
         score:
           anyOf:
-          - type: integer
-            maximum: 10
-            minimum: 0
+          -
+            type: integer
+            maximum: 10.0
+            minimum: 0.0
           - type: 'null'
           title: Score
           description: Best judge score
@@ -2908,19 +4694,22 @@ components:
           default: false
         created_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Created At
         updated_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Updated At
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
@@ -2931,6 +4720,162 @@ components:
           - type: 'null'
           title: Version
           description: Stream Iter data schema version
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: Whether this iteration had an error
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+          description: Error message for this iteration
+      type: object
+      required:
+      - uuid
+      - tsg_id
+      - job_id
+      - stream_id
+      - goal_id
+      - iteration
+      - prompt
+      - techniques
+      - improvement
+      - prompts_objective
+      - summary
+      title: StreamIterationDataResponseSchema
+      description: API response schema for Stream Iteration Data.
+    StreamIterationDataSchema:
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          title: Uuid
+        tsg_id:
+          type: string
+          title: Tsg Id
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+          description: Job identifier
+        stream_id:
+          type: string
+          format: uuid
+          title: Stream Id
+          description: Stream identifier
+        goal_id:
+          type: string
+          format: uuid
+          title: Goal Id
+          description: Goal identifier
+        iteration:
+          type: integer
+          minimum: 0.0
+          title: Iteration
+          description: Iteration number
+        prompt:
+          type: string
+          minLength: 1
+          title: Prompt
+          description: The attack prompt
+        prompt_english:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Prompt English
+          description: English version of prompt for judge
+        techniques:
+          type: string
+          title: Techniques
+          description: Techniques used in the attack
+        improvement:
+          type: string
+          title: Improvement
+          description: Improvement strategy for next iteration
+        prompts_objective:
+          type: string
+          title: Prompts Objective
+          description: Objective of the prompt
+        summary:
+          type: string
+          title: Summary
+          description: Summary of the attack
+        output:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Output
+          description: Best target output (highest score)
+        output_english:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Output English
+          description: English version of output for judge
+        score:
+          anyOf:
+          -
+            type: integer
+            maximum: 10.0
+            minimum: 0.0
+          - type: 'null'
+          title: Score
+          description: Best judge score
+          default: 0
+        judge_reasoning:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Judge Reasoning
+          description: Judge reasoning for best output
+        threat:
+          type: boolean
+          title: Threat
+          description: Whether this is a threat (score == 3)
+          default: false
+        created_at:
+          anyOf:
+          -
+            type: string
+            format: date-time
+          - type: 'null'
+          title: Created At
+        updated_at:
+          anyOf:
+          -
+            type: string
+            format: date-time
+          - type: 'null'
+          title: Updated At
+        extra_info:
+          anyOf:
+          -
+            additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Extra Info
+          description: Extra information
+        version:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Version
+          description: Stream Iter data schema version
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: Whether this iteration had an error
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+          description: Error message for this iteration
       type: object
       required:
       - uuid
@@ -2961,8 +4906,7 @@ components:
       - pagination
       - data
       title: StreamListResponseSchema
-      description: Response schema for listing attacks following common pagination
-        pattern.
+      description: Response schema for listing attacks following common pagination pattern.
     StreamSchema:
       properties:
         uuid:
@@ -3026,13 +4970,15 @@ components:
           description: First threat iteration data (denormalized JSONB for performance)
         created_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Created At
         updated_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Updated At
@@ -3047,6 +4993,18 @@ components:
           - type: 'null'
           title: Version
           description: Stream schema version
+        error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Error
+          description: Whether this stream encountered errors
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+          description: Error message details
       type: object
       required:
       - uuid
@@ -3082,7 +5040,8 @@ components:
           default: true
         prerequisites:
           anyOf:
-          - items:
+          -
+            items:
               $ref: '#/components/schemas/PrerequisiteModel'
             type: array
           - type: 'null'
@@ -3121,7 +5080,8 @@ components:
           default: true
         prerequisites:
           anyOf:
-          - items:
+          -
+            items:
               $ref: '#/components/schemas/PrerequisiteModel'
             type: array
           - type: 'null'
@@ -3161,7 +5121,7 @@ components:
           - type: string
           - type: 'null'
           title: Base Model
-          description: Base model name (e.g., GPT-4, Claude)
+          description: 'Base model name (e.g., GPT-4, Claude)'
         core_architecture:
           anyOf:
           - type: string
@@ -3176,7 +5136,8 @@ components:
           description: System prompt
         languages_supported:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
@@ -3184,7 +5145,8 @@ components:
           description: Supported languages
         banned_keywords:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
@@ -3192,7 +5154,8 @@ components:
           description: Banned keywords/phrases
         tools_accessible:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
@@ -3200,15 +5163,11 @@ components:
           description: Accessible tools/capabilities
       type: object
       title: TargetAdditionalContext
-      description: 'Additional context - used in create/update API requests and stored
-        in DB/GCS.
-
-
+      description: |
+        Additional context - used in create/update API requests and stored in DB/GCS.
+        
         Single value fields are strings.
-
         List fields are lists of strings.
-
-        '
     TargetBackground:
       properties:
         industry:
@@ -3216,39 +5175,38 @@ components:
           - type: string
           - type: 'null'
           title: Industry
-          description: Target's industry (e.g., Healthcare, Finance)
+          description: 'Target''s industry (e.g., Healthcare, Finance)'
         use_case:
           anyOf:
           - type: string
           - type: 'null'
           title: Use Case
-          description: Primary use case (e.g., Customer Support, Code Assistant)
+          description: 'Primary use case (e.g., Customer Support, Code Assistant)'
         competitors:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
           title: Competitors
           description: Known competitor products
+        agentic_profiling_enabled:
+          type: boolean
+          title: Agentic Profiling Enabled
+          description: Whether agentic profiling is enabled for this target
+          default: true
       type: object
       title: TargetBackground
-      description: 'Target background - used in create/update API requests and stored
-        in DB/GCS.
-
-
+      description: |
+        Target background - used in create/update API requests and stored in DB/GCS.
+        
         Required fields for activation:
-
         - industry (string, required)
-
         - use_case (string, required)
-
-
+        
         Optional field:
-
         - competitors (list of strings)
-
-        '
     TargetConnectionType:
       type: string
       enum:
@@ -3259,6 +5217,9 @@ components:
       - CUSTOM
       - REST
       - STREAMING
+      - WEBSOCKET
+      - WEBSOCKET_STREAMING
+      - MS_COPILOT_STUDIO
       title: TargetConnectionType
       description: Connection type/provider for the target.
     TargetJobRequest:
@@ -3318,7 +5279,8 @@ components:
           - 429
         rate_limit_error_json:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Rate Limit Error Json
@@ -3326,9 +5288,7 @@ components:
           examples:
           - error:
               code: rate_limit_exceeded
-              message: 'Rate limit reached for o1-preview on requests per min (RPM):
-                Limit 20, Used 20, Requested 1. Please try again in 3s. Visit https://platform.openai.com/account/rate-limits
-                to learn more.'
+              message: 'Rate limit reached for o1-preview on requests per min (RPM): Limit 20, Used 20, Requested 1. Please try again in 3s. Visit https://platform.openai.com/account/rate-limits to learn more.'
               param: 'null'
               type: requests
         rate_limit_error_message:
@@ -3338,8 +5298,7 @@ components:
           title: Rate Limit Error Message
           description: Raw error message string for rate limit errors
           examples:
-          - 'Rate limit reached for o1-preview on requests per min (RPM): Limit 20,
-            Used 20, Requested 1. Please try again in 3s.'
+          - 'Rate limit reached for o1-preview on requests per min (RPM): Limit 20, Used 20, Requested 1. Please try again in 3s.'
         content_filter_enabled:
           type: boolean
           title: Content Filter Enabled
@@ -3355,7 +5314,8 @@ components:
           - 400
         content_filter_error_json:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Content Filter Error Json
@@ -3363,8 +5323,7 @@ components:
           examples:
           - error:
               code: invalid_prompt
-              message: 'Invalid prompt: your prompt was flagged as potentially violating
-                our usage policy. Please try again with a different prompt.'
+              message: 'Invalid prompt: your prompt was flagged as potentially violating our usage policy. Please try again with a different prompt.'
               type: invalid_request_error
         content_filter_error_message:
           anyOf:
@@ -3373,12 +5332,11 @@ components:
           title: Content Filter Error Message
           description: Raw error message string for content filter errors
           examples:
-          - 'Invalid prompt: your prompt was flagged as potentially violating our
-            usage policy. Please try again with a different prompt.'
+          - 'Invalid prompt: your prompt was flagged as potentially violating our usage policy. Please try again with a different prompt.'
         probe_message:
           type: string
           title: Probe Message
-          default: Hello, this is a test message from the red team validation system.
+          default: 'Hello, this is a test message from the red team validation system.'
         request_timeout:
           type: number
           title: Request Timeout
@@ -3388,8 +5346,7 @@ components:
           - 110
       type: object
       title: TargetMetadata
-      description: Metadata stored in the database for targets (user-provided + computed
-        fields).
+      description: Metadata stored in the database for targets (user-provided + computed fields).
     TargetReferenceSchema:
       properties:
         uuid:
@@ -3411,7 +5368,7 @@ components:
           - type: 'null'
           title: Description
           description: Optional target description
-          default: null
+          default: 
           examples:
           - AI model for testing
         target_type:
@@ -3445,6 +5402,16 @@ components:
           examples:
           - REST
           - STREAMING
+          - WEBSOCKET
+        auth_type:
+          anyOf:
+          - $ref: '#/components/schemas/AuthType'
+          - type: 'null'
+          description: Authentication method for target API access
+          examples:
+          - HEADERS
+          - BASIC_AUTH
+          - OAUTH2
         session_supported:
           type: boolean
           title: Session Supported
@@ -3452,12 +5419,13 @@ components:
           default: false
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
           description: Additional configuration or metadata for the target
-          default: null
+          default: {}
           examples:
           - custom_key: custom_value
         status:
@@ -3482,19 +5450,19 @@ components:
           - type: string
           - type: 'null'
           title: Secret Version
-          description: Secret Manager version for connection_params. When present,
-            sensitive connection data is stored in Secret Manager. When None, connection_params
-            are stored in GCS (legacy).
+          description: 'Secret Manager version for connection_params. When present, sensitive connection data is stored in Secret Manager. When None, connection_params are stored in GCS (legacy).'
         created_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Created By User Id
           description: User ID of target creator
         updated_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Updated By User Id
@@ -3509,6 +5477,17 @@ components:
           format: date-time
           title: Updated At
           description: Last update timestamp
+        profiling_status:
+          anyOf:
+          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: 'null'
+          description: Status of the profiling workflow
+        canonical_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Canonical Id
+          description: Partner-supplied stable identifier. Null for targets without partner integration metadata (most targets).
         target_metadata:
           $ref: '#/components/schemas/TargetMetadata'
           description: Target metadata and configuration options
@@ -3517,11 +5496,12 @@ components:
           - $ref: '#/components/schemas/TargetBackground'
           - type: 'null'
           description: 'Target background info: industry, use_case, competitors'
-        profiling_status:
+        profiling_progress:
           anyOf:
-          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: integer
           - type: 'null'
-          description: Status of the profiling workflow
+          title: Profiling Progress
+          description: Profiling progress percentage (0–100)
         additional_context:
           anyOf:
           - $ref: '#/components/schemas/TargetAdditionalContext'
@@ -3599,6 +5579,28 @@ components:
       - active
       title: TechniqueModel
       description: Pydantic model for technique data
+    TenantLanguagesResponseSchema:
+      properties:
+        multilingual_enabled:
+          type: boolean
+          title: Multilingual Enabled
+        supported_job_types:
+          items:
+            type: string
+          type: array
+          title: Supported Job Types
+        languages:
+          items:
+            $ref: '#/components/schemas/LanguageOptionSchema'
+          type: array
+          title: Languages
+      type: object
+      required:
+      - multilingual_enabled
+      - supported_job_types
+      - languages
+      title: TenantLanguagesResponseSchema
+      description: Response for GET /v1/languages — tenant-facing language dropdown.
     ToxicContentGuardrailSchema:
       properties:
         moderate:
@@ -3633,1419 +5635,3 @@ components:
       - msg
       - type
       title: ValidationError
-ExternalTags:
-  Categories:
-    title: Categories
-    description: Operations for managing scan categories.
-    tags:
-    - Categories
-  CustomAttack:
-    title: CustomAttack
-    description: Operations for custom attack configurations and prompts.
-    tags:
-    - CustomAttack
-  ErrorLogs:
-    title: ErrorLogs
-    description: Operations for retrieving and managing error logs.
-    tags:
-    - ErrorLogs
-  Dashboard:
-    title: Dashboard
-    description: Operations for dashboard data and statistics.
-    tags:
-    - Dashboard
-  HealthChecks:
-    title: HealthChecks
-    description: Operations related to health checks of the data plane service.
-    tags:
-    - HealthChecks
-  Quota:
-    title: Quota
-    description: Operations for quota management and limits.
-    tags:
-    - Quota
-  Scan:
-    title: Scan
-    description: Operations for creating and managing scan jobs.
-    tags:
-    - Scan
-  Report:
-    title: Report
-    description: Operations for generating and retrieving scan job reports for static
-      and dynamic.
-    tags:
-    - Report
-  Sentiment:
-    title: Sentiment
-    description: Operations for managing sentiment and scan report summaries.
-    tags:
-    - Sentiment
-paths:
-  /ready:
-    get:
-      summary: Readiness
-      description: Retrieve the ready details through this Application Programming
-        Interface endpoint.
-      operationId: readiness_ready_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                title: Response Readiness Ready Get
-        401:
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - HealthChecks
-  /liveness:
-    get:
-      summary: Liveness
-      description: Retrieve the liveness details through this Application Programming
-        Interface endpoint.
-      operationId: liveness_liveness_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  type: boolean
-                type: object
-                title: Response Liveness Liveness Get
-        401:
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - HealthChecks
-  /v1/scan:
-    post:
-      summary: Create scan
-      description: Create a new scan target.
-      operationId: create_job_v1_scan_post
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JobResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - Scan
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/JobCreateRequestSchema'
-    get:
-      summary: List scans
-      description: List jobs with filtering and pagination.
-      operationId: list_jobs_v1_scan_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JobListResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 100
-          minimum: 1
-          description: Number of jobs to return (1-100)
-          default: 50
-          title: Limit
-        description: Number of jobs to return (1-100)
-      - name: skip
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          description: Number of jobs to skip for pagination
-          default: 0
-          title: Skip
-        description: Number of jobs to skip for pagination
-      - name: status
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - $ref: '#/components/schemas/JobStatusFilter'
-          - type: 'null'
-          description: Filter by job status
-          title: Status
-        description: Filter by job status
-      - name: job_type
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - $ref: '#/components/schemas/JobType'
-          - type: 'null'
-          description: Filter by job type
-          title: Job Type
-        description: Filter by job type
-      - name: search
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-            maxLength: 255
-          - type: 'null'
-          description: Search jobs by name
-          title: Search
-        description: Search jobs by name
-      - name: target_id
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-            format: uuid
-          - type: 'null'
-          description: Filter by target UUID
-          title: Target Id
-        description: Filter by target UUID
-      tags:
-      - Scan
-  /v1/scan/{job_id}:
-    get:
-      summary: Get scan details
-      description: Get a job by its ID.
-      operationId: get_job_v1_scan__job_id__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JobResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - Scan
-  /v1/scan/{job_id}/abort:
-    post:
-      summary: Abort scan
-      description: Abort a running job by cancelling its workflow and updating status.
-      operationId: abort_job_v1_scan__job_id__abort_post
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JobAbortResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - Scan
-  /v1/categories:
-    get:
-      summary: Get all categories with subcategories
-      description: Get all available categories with their subcategories.
-      operationId: get_all_categories_v1_categories_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/CategoryModel'
-                type: array
-                title: Response Get All Categories V1 Categories Get
-        401:
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - Categories
-  /v1/report/static/{job_id}/list-attacks:
-    get:
-      summary: List attacks for a scan
-      description: List attacks with filtering and pagination.
-      operationId: list_attacks_v1_report_static__job_id__list_attacks_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AttackListResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 100
-          minimum: 1
-          description: Number of attacks to return (1-100)
-          default: 50
-          title: Limit
-        description: Number of attacks to return (1-100)
-      - name: skip
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          description: Number of attacks to skip for pagination
-          default: 0
-          title: Skip
-        description: Number of attacks to skip for pagination
-      - name: status
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - $ref: '#/components/schemas/AttackStatus'
-          - type: 'null'
-          description: Filter by attack status
-          title: Status
-        description: Filter by attack status
-      - name: attack_type
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - $ref: '#/components/schemas/AttackType'
-          - type: 'null'
-          description: Filter by attack type
-          title: Attack Type
-        description: Filter by attack type
-      - name: category
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - $ref: '#/components/schemas/Category'
-          - type: 'null'
-          description: Filter by attack category
-          title: Category
-        description: Filter by attack category
-      - name: sub_category
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - $ref: '#/components/schemas/SecuritySubCategory'
-          - $ref: '#/components/schemas/SafetySubCategory'
-          - $ref: '#/components/schemas/BrandSubCategory'
-          - type: 'null'
-          description: Filter by attack subcategory
-          title: Sub Category
-        description: Filter by attack subcategory
-      - name: threat
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: boolean
-          - type: 'null'
-          description: Filter by threat status
-          title: Threat
-        description: Filter by threat status
-      - name: severity
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - $ref: '#/components/schemas/SeverityFilter'
-          - type: 'null'
-          description: Filter by severity level
-          title: Severity
-        description: Filter by severity level
-      tags:
-      - Report
-  /v1/report/static/{job_id}/attack/{attack_id}:
-    get:
-      summary: Get attack details
-      description: Get detailed attack information including outputs and framework
-        techniques.
-      operationId: get_attack_detail_v1_report_static__job_id__attack__attack_id__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AttackDetailResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: attack_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Attack Id
-      tags:
-      - Report
-  /v1/report/static/{job_id}/report:
-    get:
-      summary: Get attack library report
-      description: Get attack library report for a job.  Raises ForbiddenError if
-        report is partially complete and locked.
-      operationId: get_attack_report_v1_report_static__job_id__report_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StaticJobReportSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - Report
-  /v1/report/static/{job_id}/remediation:
-    get:
-      summary: Get attack library scan remediation
-      description: Get other remediation measures for a static job.
-      operationId: get_static_remediations_v1_report_static__job_id__remediation_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RemediationResponseSchema'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - Report
-  /v1/report/static/{job_id}/runtime-policy-config:
-    get:
-      summary: Get attack library runtime security profile
-      description: Get Runtime security profile for a static job.
-      operationId: get_static_runtime_security_policy_config_v1_report_static__job_id__runtime_policy_config_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RuntimeSecurityProfileResponseSchema'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - Report
-  /v1/report/dynamic/{job_id}/report:
-    get:
-      summary: Get agent scan report
-      description: Get dynamic job report for a job.
-      operationId: get_dynamic_job_report_v1_report_dynamic__job_id__report_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DynamicJobReportSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - Report
-  /v1/report/dynamic/{job_id}/remediation:
-    get:
-      summary: Get agent scan rememdiation
-      description: Get other remediation measures for a dynamic job.
-      operationId: get_dynamic_remediations_v1_report_dynamic__job_id__remediation_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RemediationResponseSchema'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - Report
-  /v1/report/dynamic/{job_id}/runtime-policy-config:
-    get:
-      summary: Get agent scan runtime security profile
-      description: Get Runtime security profile for a dynamic job.
-      operationId: get_dynamic_runtime_security_policy_config_v1_report_dynamic__job_id__runtime_policy_config_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RuntimeSecurityProfileResponseSchema'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - Report
-  /v1/report/dynamic/{job_id}/list-goals:
-    get:
-      summary: List agent scan goals
-      description: Get the goals for a job.
-      operationId: list_dynamic_job_goals_v1_report_dynamic__job_id__list_goals_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GoalListResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: skip
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          description: Number of goals to skip for pagination
-          default: 0
-          title: Skip
-        description: Number of goals to skip for pagination
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 100
-          minimum: 1
-          description: Number of goals to return (1-100)
-          default: 20
-          title: Limit
-        description: Number of goals to return (1-100)
-      - name: count
-        in: query
-        required: false
-        schema:
-          type: boolean
-          description: Include total count of goals
-          default: true
-          title: Count
-        description: Include total count of goals
-      - name: status
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - $ref: '#/components/schemas/StatusQueryParam'
-          - type: 'null'
-          description: Filter by status
-          title: Status
-        description: Filter by status
-      - name: goal_type
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - $ref: '#/components/schemas/GoalTypeQueryParam'
-          - type: 'null'
-          description: Filter by goal type
-          title: Goal Type
-        description: Filter by goal type
-      - name: search
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          description: Search string to filter goals
-          title: Search
-        description: Search string to filter goals
-      tags:
-      - Report
-  /v1/report/dynamic/{job_id}/goal/{goal_id}/list-streams:
-    get:
-      summary: List agent scan goal deatils
-      description: Get streams for a specific goal in a job.
-      operationId: list_dynamic_job_streams_v1_report_dynamic__job_id__goal__goal_id__list_streams_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StreamListResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: goal_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Goal Id
-      tags:
-      - Report
-  /v1/report/dynamic/stream/{stream_id}:
-    get:
-      summary: List agent scan stream details
-      description: Retrieve the {stream id} details through this Application Programming
-        Interface endpoint.
-      operationId: get_stream_detail_v1_report_dynamic_stream__stream_id__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StreamDetailResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: stream_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Stream Id
-      tags:
-      - Report
-  /v1/report/{job_id}/download:
-    get:
-      summary: Download report
-      description: Download report files for a job.
-      operationId: download_report_v1_report__job_id__download_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: file_format
-        in: query
-        required: true
-        schema:
-          $ref: '#/components/schemas/FileFormat'
-          description: Format of the report file (CSV, JSON, or ALL)
-        description: Format of the report file (CSV, JSON, or ALL)
-      tags:
-      - Report
-  /v1/report/{job_id}/generate-partial-report:
-    post:
-      summary: Generate partial scan report
-      description: 'Unlock a partial report by consuming a quota credit.  This endpoint:
-        - Validates the job is PARTIALLY_COMPLETE - Consumes 1 quota credit of the
-        job type - Unlocks the report for viewing  **Returns:** - Updated job information
-        with unlocked report.'
-      operationId: generate_partial_job_report_v1_report__job_id__generate_partial_report_post
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - Report
-  /v1/report/static/{job_id}/attack-multi-turn/{attack_id}:
-    get:
-      summary: Get multi-turn attack details
-      description: Get detailed multi-turn attack information including outputs and
-        framework techniques.
-      operationId: get_attack_multi_turn_detail_v1_report_static__job_id__attack_multi_turn__attack_id__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AttackMultiTurnDetailResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: attack_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Attack Id
-      tags:
-      - Report
-  /v1/metering/quota:
-    post:
-      summary: Get quota summary
-      description: Get aggregated quota summary for the current TSG (POST endpoint
-        for backward compatibility).
-      operationId: post_quota_summary_v1_metering_quota_post
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QuotaSummarySchema'
-        401:
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - Quota
-  /v1/custom-attacks/report/{job_id}:
-    get:
-      summary: Get custom attack Report
-      description: Get comprehensive custom attack report.
-      operationId: get_custom_attack_report_v1_custom_attacks_report__job_id__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomAttackReportResponse'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - CustomAttack
-  /v1/custom-attacks/report/{job_id}/prompt-sets:
-    get:
-      summary: Get prompt sets
-      description: Get prompt sets with filtering and pagination.
-      operationId: get_prompt_sets_v1_custom_attacks_report__job_id__prompt_sets_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PromptSetsReportResponse'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: property_filters
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          description: JSON string of property filters
-          title: Property Filters
-        description: JSON string of property filters
-      - name: is_threat
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: boolean
-          - type: 'null'
-          description: Filter by threat status
-          title: Is Threat
-        description: Filter by threat status
-      - name: skip
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          description: Number of records to skip
-          default: 0
-          title: Skip
-        description: Number of records to skip
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 100
-          minimum: 1
-          description: Maximum number of records to return
-          default: 20
-          title: Limit
-        description: Maximum number of records to return
-      tags:
-      - CustomAttack
-  /v1/custom-attacks/report/{job_id}/prompt-set/{prompt_set_id}/prompts:
-    get:
-      summary: Get prompts by set
-      description: Get prompts for a specific prompt set with pagination.
-      operationId: get_prompts_by_set_v1_custom_attacks_report__job_id__prompt_set__prompt_set_id__prompts_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PromptDetailResponse'
-                title: Response Get Prompts By Set V1 Custom Attacks Report  Job Id  Prompt
-                  Set  Prompt Set Id  Prompts Get
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: prompt_set_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Id
-      - name: is_threat
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: boolean
-          - type: 'null'
-          description: Filter by threat status
-          title: Is Threat
-        description: Filter by threat status
-      - name: skip
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          description: Number of records to skip
-          default: 0
-          title: Skip
-        description: Number of records to skip
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 100
-          minimum: 1
-          description: Maximum number of records to return
-          default: 20
-          title: Limit
-        description: Maximum number of records to return
-      tags:
-      - CustomAttack
-  /v1/custom-attacks/report/{job_id}/prompt/{prompt_id}:
-    get:
-      summary: Get prompt details
-      description: Get detailed information for a specific prompt.
-      operationId: get_prompt_detail_v1_custom_attacks_report__job_id__prompt__prompt_id__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PromptDetailResponse'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: prompt_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Id
-      tags:
-      - CustomAttack
-  /v1/custom-attacks/job/{job_id}/list-custom-attacks:
-    get:
-      summary: List custom attacks
-      description: List custom attacks with V2 features.
-      operationId: list_custom_attacks_v1_custom_attacks_job__job_id__list_custom_attacks_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomAttacksListResponse'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: skip
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          description: Number of records to skip
-          default: 0
-          title: Skip
-        description: Number of records to skip
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 1000
-          minimum: 1
-          description: Maximum number of records to return
-          default: 100
-          title: Limit
-        description: Maximum number of records to return
-      - name: threat
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: boolean
-          - type: 'null'
-          description: 'Filter by threat status: true for successful attacks, false
-            for failed attacks'
-          title: Threat
-        description: 'Filter by threat status: true for successful attacks, false
-          for failed attacks'
-      - name: prompt_set_id
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          description: Filter by prompt set ID
-          title: Prompt Set Id
-        description: Filter by prompt set ID
-      - name: property_value
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          description: JSON string of property filters
-          title: Property Value
-        description: JSON string of property filters
-      tags:
-      - CustomAttack
-  /v1/custom-attacks/job/{job_id}/attack/{attack_id}/list-outputs:
-    get:
-      summary: Get attack outputs
-      description: Get outputs for a specific attack.
-      operationId: get_attack_outputs_v1_custom_attacks_job__job_id__attack__attack_id__list_outputs_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CustomAttackOutputSchema'
-                title: Response Get Attack Outputs V1 Custom Attacks Job  Job Id  Attack  Attack
-                  Id  List Outputs Get
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: attack_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Attack Id
-      tags:
-      - CustomAttack
-  /v1/custom-attacks/job/{job_id}/property-stats:
-    get:
-      summary: Get property stats
-      description: Get property-based statistics for custom attacks.
-      operationId: get_property_stats_v1_custom_attacks_job__job_id__property_stats_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  additionalProperties: true
-                title: Response Get Property Stats V1 Custom Attacks Job  Job Id  Property
-                  Stats Get
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - CustomAttack
-  /v1/error-log/job/{job_id}:
-    get:
-      summary: List error logs for a scan
-      description: List error logs for a specific job.
-      operationId: list_error_logs_for_job_v1_error_log_job__job_id__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorLogListResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 100
-          minimum: 1
-          description: Number of attacks to return (1-100)
-          default: 5
-          title: Limit
-        description: Number of attacks to return (1-100)
-      - name: skip
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          description: Number of attacks to skip for pagination
-          default: 0
-          title: Skip
-        description: Number of attacks to skip for pagination
-      tags:
-      - ErrorLogs
-  /v1/dashboard/scan-statistics:
-    get:
-      summary: Get scan statistics and risk profile
-      description: Returns scan counts, target statistics, status breakdown, and risk
-        profile for dashboard display.
-      operationId: get_scan_statistics_v1_dashboard_scan_statistics_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScanStatisticsResponseSchema'
-        401:
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - Dashboard
-  /v1/dashboard/score-trend:
-    get:
-      summary: Get score trend for a target
-      description: Returns time-series risk scores grouped by job type for chart display.
-      operationId: get_score_trend_v1_dashboard_score_trend_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScoreTrendResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: target_id
-        in: query
-        required: true
-        schema:
-          type: string
-          format: uuid
-          description: Target UUID to fetch scores for
-          title: Target Id
-        description: Target UUID to fetch scores for
-      - name: date_range
-        in: query
-        required: false
-        schema:
-          $ref: '#/components/schemas/DateRangeFilter'
-          description: Predefined date range filter
-          default: LAST_7_DAYS
-        description: Predefined date range filter
-      - name: start_date
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-            format: date
-          - type: 'null'
-          description: Custom start date (overrides date_range if both provided)
-          title: Start Date
-        description: Custom start date (overrides date_range if both provided)
-      - name: end_date
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-            format: date
-          - type: 'null'
-          description: Custom end date (overrides date_range if both provided)
-          title: End Date
-        description: Custom end date (overrides date_range if both provided)
-      tags:
-      - Dashboard
-  /v1/sentiment:
-    post:
-      summary: Update sentiment scan report
-      description: Create or update sentiment for a job report.
-      operationId: create_or_update_sentiment_v1_sentiment_post
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SentimentResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - Sentiment
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SentimentRequestSchema'
-        required: true
-  /v1/sentiment/{job_id}:
-    get:
-      summary: Get sentiment for a scan report
-      description: Guardrail configuration for toxic content with severity levels.
-      operationId: get_job_sentiment_v1_sentiment__job_id__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SentimentResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: job_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Job Id
-      tags:
-      - Sentiment

--- a/specs/PaloAltoNetworks-AIRS-RedTeam-management.yaml
+++ b/specs/PaloAltoNetworks-AIRS-RedTeam-management.yaml
@@ -1,24 +1,1369 @@
 openapi: 3.1.0
 info:
   title: Prisma AIRS Red Teaming Management API
-  version: 0.5.20
-  description: "Red Teaming Management API - Configure and manage security groups\
-    \ and rules for AI/ML model scanning. \xA9 2025 Palo Alto Networks, Inc This Open\
-    \ API spec file was created on February 25, 2026. \xA9 2026 Palo Alto Networks,\
-    \ Inc. Palo Alto Networks is a registered trademark of Palo Alto Networks. A list\
-    \ of our trademarks can be found at [https://www.paloaltonetworks.com/company/trademarks.html](https://www.paloaltonetworks.com/company/trademarks.html).\
-    \ All other marks mentioned herein may be trademarks of their respective companies."
+  description: 'Red Teaming Management API - Configure and manage security groups and rules for AI/ML model scanning.'
+  version: 0.6.88
+  termsOfService: https://www.paloaltonetworks.com/content/dam/pan/en_US/assets/pdf/legal/palo-alto-networks-end-user-license-agreement-eula.pdf
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+  contact:
+    email: support@paloaltonetworks.com
+    name: Palo Alto Networks Technical Support
+    url: https://support.paloaltonetworks.com
 servers:
 - url: https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane
 security:
-- bearerAuth: []
+  - bearerAuth: []
+
+tags:
+ - name: CustomAttack
+   description: Operations for managing custom prompt sets, prompts, and properties.
+ - name: Dashboard
+   description: Operations for retrieving dashboard overview and statistics.
+ - name: Languages
+   description: List Languages
+ - name: Target
+   description: Operations for managing scan targets (create, update, delete, list).
+
+paths:
+  /v1/target:
+    post:
+      tags:
+      - Target
+      summary: Create target
+      description: Create a new scan target.
+      operationId: create_target_v1_target_post
+      parameters:
+      -
+        name: validate
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Whether to validate target configuration
+          examples:
+          - true
+          title: Validate
+        description: Whether to validate target configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TargetCreateRequestSchema'
+      responses:
+        201:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Target
+      summary: List targets
+      description: List all scan targets with pagination and filtering support.
+      operationId: list_targets_v1_target_get
+      parameters:
+      -
+        name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Maximum records to return
+          default: 10
+          title: Limit
+        description: Maximum records to return
+      -
+        name: target_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/TargetType'
+          - type: 'null'
+          description: Filter by target type
+          title: Target Type
+        description: Filter by target type
+      -
+        name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - $ref: '#/components/schemas/TargetStatusFilter'
+          - type: 'null'
+          description: Filter by target status or profiling status
+          title: Status
+        description: Filter by target status or profiling status
+      -
+        name: search
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Search target by name
+          title: Search
+        description: Search target by name
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetListSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/target/{target_uuid}:
+    get:
+      tags:
+      - Target
+      summary: Get target details
+      description: Retrieve a specific target by UUID with complete configuration details and masked connection parameters.
+      operationId: get_target_v1_target__target_uuid__get
+      parameters:
+      -
+        name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetRedactSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - Target
+      summary: Update target
+      description: Update an existing target with new configuration and optional validation control.
+      operationId: update_target_v1_target__target_uuid__put
+      parameters:
+      -
+        name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      -
+        name: validate
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Whether to validate target configuration
+          default: true
+          title: Validate
+        description: Whether to validate target configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TargetUpdateRequestSchema'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Target
+      summary: Delete target
+      description: Permanently delete a target and its encrypted configuration data.
+      operationId: delete_target_v1_target__target_uuid__delete
+      parameters:
+      -
+        name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      responses:
+        204:
+          description: Successful Response
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/target/{target_uuid}/profile:
+    post:
+      tags:
+      - Target
+      summary: Start target profiling
+      description: Manually trigger target profiling. Target must be active with industry and use_case.
+      operationId: start_profiling_v1_target__target_uuid__profile_post
+      parameters:
+      -
+        name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StartProfilingResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - Target
+      summary: Update target profile
+      description: Update target background and additional context fields without connection validation.
+      operationId: update_target_profile_v1_target__target_uuid__profile_put
+      parameters:
+      -
+        name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TargetContextUpdateSchema'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Target
+      summary: Get profiling results
+      description: Get profiling results including merged user and profiler data.
+      operationId: get_profiling_results_v1_target__target_uuid__profile_get
+      parameters:
+      -
+        name: target_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Target Uuid
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetProfileResponse'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/target/probe:
+    post:
+      tags:
+      - Target
+      summary: Run profiling probes on target
+      description: Send profiling questions to a target using provided connection parameters. Returns TargetResponseSchema with target_background and additional_context populated from probe responses.
+      operationId: run_target_probes_v1_target_probe_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TargetProbeRequest'
+        required: true
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/target/validate-auth:
+    post:
+      tags:
+      - Target
+      summary: Validate authentication configuration
+      description: 'Validate OAuth2 credentials by fetching a test token. For HEADERS and BASIC_AUTH, validates field presence only.'
+      operationId: validate_auth_v1_target_validate_auth_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TargetAuthValidationRequestSchema'
+        required: true
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TargetAuthValidationResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/target/ms-copilot-studio/auth-url:
+    post:
+      tags:
+      - Target
+      summary: Generate Copilot Studio auth URL
+      description: Generate MS Copilot Studio OAuth authorization URL.
+      operationId: generate_ms_copilot_studio_auth_url_v1_target_ms_copilot_studio_auth_url_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MSCopilotStudioAuthUrlRequestSchema'
+        required: true
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MSCopilotStudioAuthUrlResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/target/ms-copilot-studio/token:
+    post:
+      tags:
+      - Target
+      summary: Exchange Copilot Studio auth code
+      description: 'Exchange auth code for tokens via MSAL, store token cache in GSM.'
+      operationId: exchange_ms_copilot_studio_token_v1_target_ms_copilot_studio_token_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MSCopilotStudioTokenRequestSchema'
+        required: true
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MSCopilotStudioTokenResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/target/ms-copilot-studio/token/{token_json_uuid}:
+    delete:
+      tags:
+      - Target
+      summary: Delete MS Copilot Studio token records
+      description: Delete both auth flow and token cache GSM records (cancel cleanup).
+      operationId: delete_ms_copilot_studio_token_v1_target_ms_copilot_studio_token__token_json_uuid__delete
+      parameters:
+      -
+        name: token_json_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Token Json Uuid
+      responses:
+        204:
+          description: Successful Response
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/custom-prompt-set:
+    post:
+      tags:
+      - CustomAttack
+      summary: Create a new custom prompt set
+      description: Create a new custom prompt set.
+      operationId: create_prompt_set_v1_custom_attack_custom_prompt_set_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomPromptSetCreateRequestSchema'
+        required: true
+      responses:
+        201:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/list-custom-prompt-sets:
+    get:
+      tags:
+      - CustomAttack
+      summary: List custom prompt sets
+      description: List all custom prompt sets with pagination and filtering support.
+      operationId: list_prompt_sets_v1_custom_attack_list_custom_prompt_sets_get
+      parameters:
+      -
+        name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Maximum records to return
+          default: 10
+          title: Limit
+        description: Maximum records to return
+      -
+        name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by status
+          title: Status
+        description: Filter by status
+      -
+        name: active
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Filter by active status
+          title: Active
+        description: Filter by active status
+      -
+        name: archive
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: 'Filter by archive status (None=non-archived only, True=archived only, False=non-archived only)'
+          title: Archive
+        description: 'Filter by archive status (None=non-archived only, True=archived only, False=non-archived only)'
+      -
+        name: search
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Search in name and description
+          title: Search
+        description: Search in name and description
+      -
+        name: language
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by language code (ISO 639-1)
+          title: Language
+        description: Filter by language code (ISO 639-1)
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetListSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get prompt set details
+      description: Retrieve a specific prompt set by UUID with complete details including properties.
+      operationId: get_prompt_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__get
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - CustomAttack
+      summary: Update prompt set
+      description: 'Update prompt set details including name, description, and properties.'
+      operationId: update_prompt_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__put
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomPromptSetUpdateRequestSchema'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/archive:
+    put:
+      tags:
+      - CustomAttack
+      summary: Archive or unarchive a prompt set
+      description: Archive or unarchive a prompt set to manage its lifecycle.
+      operationId: archive_prompt_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__archive_put
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomPromptSetArchiveRequestSchema'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/custom-prompt-set/custom-prompt:
+    post:
+      tags:
+      - CustomAttack
+      summary: Create prompt in a prompt set
+      description: Create a new prompt in a prompt set.
+      operationId: create_prompt_v1_custom_attack_custom_prompt_set_custom_prompt_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomPromptCreateRequestSchema'
+        required: true
+      responses:
+        201:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/list-custom-prompts:
+    get:
+      tags:
+      - CustomAttack
+      summary: List prompts in a prompt set
+      description: List all prompts within a specific prompt set with pagination and filtering.
+      operationId: list_prompts_in_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__list_custom_prompts_get
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      -
+        name: skip
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          description: Number of records to skip
+          default: 0
+          title: Skip
+        description: Number of records to skip
+      -
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          description: Maximum records to return
+          default: 10
+          title: Limit
+        description: Maximum records to return
+      -
+        name: status
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Filter by status
+          title: Status
+        description: Filter by status
+      -
+        name: active
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Filter by active status
+          title: Active
+        description: Filter by active status
+      -
+        name: search
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Search in prompt text
+          title: Search
+        description: Search in prompt text
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptListSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/custom-prompt/{prompt_uuid}:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get prompt details
+      description: Get a specific prompt by UUID.
+      operationId: get_prompt_v1_custom_attack_custom_prompt_set__prompt_set_uuid__custom_prompt__prompt_uuid__get
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      -
+        name: prompt_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Uuid
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - CustomAttack
+      summary: Update prompt
+      description: Update an existing prompt.
+      operationId: update_prompt_v1_custom_attack_custom_prompt_set__prompt_set_uuid__custom_prompt__prompt_uuid__put
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      -
+        name: prompt_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomPromptUpdateRequestSchema'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - CustomAttack
+      summary: Delete prompt
+      description: Delete a prompt.
+      operationId: delete_prompt_v1_custom_attack_custom_prompt_set__prompt_set_uuid__custom_prompt__prompt_uuid__delete
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      -
+        name: prompt_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Uuid
+      responses:
+        204:
+          description: Successful Response
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/property-names:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get property names
+      description: Get all available property names for use in prompt sets.
+      operationId: get_property_names_v1_custom_attack_property_names_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PropertyNamesListResponseSchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - CustomAttack
+      summary: Create property name
+      description: Create a new property name that can be used in prompt sets.
+      operationId: create_property_name_v1_custom_attack_property_names_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PropertyNameCreateRequestSchema'
+        required: true
+      responses:
+        201:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PropertyNamesListResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/property-values/{property_name}:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get property name
+      description: Get all available values for a specific property name.
+      operationId: get_property_values_v1_custom_attack_property_values__property_name__get
+      parameters:
+      -
+        name: property_name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Property Name
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PropertyValuesResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/property-values:
+    post:
+      tags:
+      - CustomAttack
+      summary: Create property value
+      description: Create a new value for an existing property name.
+      operationId: create_property_value_v1_custom_attack_property_values_post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PropertyValueCreateRequestSchema'
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - CustomAttack
+      summary: Get values for multiple property names
+      description: Get values for multiple property names in a single request.
+      operationId: get_property_values_multiple_v1_custom_attack_property_values_get
+      parameters:
+      -
+        name: property_names
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Comma-separated list of property names
+          title: Property Names
+        description: Comma-separated list of property names
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PropertyValuesMultipleResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/upload-custom-prompts-csv:
+    post:
+      tags:
+      - CustomAttack
+      summary: Upload custom prompts
+      description: Upload a CSV file containing custom prompts with properties for a specific prompt set.
+      operationId: upload_prompts_csv_v1_custom_attack_upload_custom_prompts_csv_post
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: query
+        required: true
+        schema:
+          type: string
+          format: uuid
+          description: UUID of the prompt set
+          title: Prompt Set Uuid
+        description: UUID of the prompt set
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Body_upload_prompts_csv_v1_custom_attack_upload_custom_prompts_csv_post'
+      responses:
+        201:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponseSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/download-template/{prompt_set_uuid}:
+    get:
+      tags:
+      - CustomAttack
+      summary: Download template for a prompt set
+      description: Download a CSV template with columns for the prompt set's properties.
+      operationId: download_template_v1_custom_attack_download_template__prompt_set_uuid__get
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/active-custom-prompt-sets:
+    get:
+      tags:
+      - CustomAttack
+      summary: List active custom prompt sets
+      description: List all active custom prompt sets available for use by data plane. Returns only sets with snapshots.
+      operationId: list_active_prompt_sets_v1_custom_attack_active_custom_prompt_sets_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetListActiveSchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/reference:
+    get:
+      tags:
+      - CustomAttack
+      summary: Resolve prompt set reference
+      description: Get current reference information for a prompt set including latest version.
+      operationId: resolve_prompt_set_reference_v1_custom_attack_custom_prompt_set__prompt_set_uuid__reference_get
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetReferenceSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/version-info:
+    get:
+      tags:
+      - CustomAttack
+      summary: Get prompt set version information
+      description: Get detailed version information for a specific prompt set version.
+      operationId: get_prompt_set_version_info_v1_custom_attack_custom_prompt_set__prompt_set_uuid__version_info_get
+      parameters:
+      -
+        name: prompt_set_uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Prompt Set Uuid
+      -
+        name: version
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Specific version ID
+          title: Version
+        description: Specific version ID
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomPromptSetVersionInfoSchema'
+        422:
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/dashboard/overview:
+    get:
+      tags:
+      - Dashboard
+      summary: Get dashboard overview
+      description: Returns target counts by type for dashboard display.
+      operationId: get_overview_v1_dashboard_overview_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardOverviewResponseSchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/languages:
+    get:
+      tags:
+      - Languages
+      summary: Get available languages
+      description: Return allowed languages for the requesting tenant.
+      operationId: get_languages_v1_languages_get
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantLanguagesResponseSchema'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
+      bearerAuth:
+        type: http
+        scheme: bearer
+        bearerFormat: JWT
   schemas:
+    AiGeneratedItems:
+      properties:
+        languages_supported:
+          anyOf:
+          - $ref: '#/components/schemas/AiGeneratedLanguageListFieldInfo'
+          - type: 'null'
+        tools_accessible:
+          anyOf:
+          - $ref: '#/components/schemas/AiGeneratedListFieldInfo'
+          - type: 'null'
+        banned_keywords:
+          anyOf:
+          - $ref: '#/components/schemas/AiGeneratedListFieldInfo'
+          - type: 'null'
+        competitors:
+          anyOf:
+          - $ref: '#/components/schemas/AiGeneratedListFieldInfo'
+          - type: 'null'
+        base_model:
+          anyOf:
+          - $ref: '#/components/schemas/AiGeneratedStringFieldInfo'
+          - type: 'null'
+        core_architecture:
+          anyOf:
+          - $ref: '#/components/schemas/AiGeneratedStringFieldInfo'
+          - type: 'null'
+        system_prompt:
+          anyOf:
+          - $ref: '#/components/schemas/AiGeneratedStringFieldInfo'
+          - type: 'null'
+      type: object
+      title: AiGeneratedItems
+      description: Per-field AI tracking with item-level tags and counts.
+    AiGeneratedLanguageListFieldInfo:
+      properties:
+        ai_discovered_items:
+          items:
+            type: string
+          type: array
+          title: Ai Discovered Items
+        current_items:
+          items:
+            $ref: '#/components/schemas/AiLanguageItemTag'
+          type: array
+          title: Current Items
+        ai_count:
+          type: integer
+          title: Ai Count
+          default: 0
+        user_count:
+          type: integer
+          title: User Count
+          default: 0
+      type: object
+      required:
+      - ai_discovered_items
+      - current_items
+      title: AiGeneratedLanguageListFieldInfo
+      description: AI tracking for the languages_supported list field.
+    AiGeneratedListFieldInfo:
+      properties:
+        ai_discovered_items:
+          items:
+            type: string
+          type: array
+          title: Ai Discovered Items
+        current_items:
+          items:
+            $ref: '#/components/schemas/AiItemTag'
+          type: array
+          title: Current Items
+        ai_count:
+          type: integer
+          title: Ai Count
+          default: 0
+        user_count:
+          type: integer
+          title: User Count
+          default: 0
+      type: object
+      required:
+      - ai_discovered_items
+      - current_items
+      title: AiGeneratedListFieldInfo
+      description: 'AI tracking for a list field (tools, keywords, competitors).'
+    AiGeneratedStringFieldInfo:
+      properties:
+        ai_discovered_value:
+          type: string
+          title: Ai Discovered Value
+        is_ai_generated:
+          type: boolean
+          title: Is Ai Generated
+          default: false
+      type: object
+      required:
+      - ai_discovered_value
+      title: AiGeneratedStringFieldInfo
+      description: 'AI tracking for a string field (base_model, core_architecture, system_prompt).'
+    AiItemTag:
+      properties:
+        value:
+          type: string
+          title: Value
+        is_ai_generated:
+          type: boolean
+          title: Is Ai Generated
+      type: object
+      required:
+      - value
+      - is_ai_generated
+      title: AiItemTag
+      description: Single item with AI tracking tag. FE renders directly.
+    AiLanguageItemTag:
+      properties:
+        value:
+          type: string
+          title: Value
+        is_ai_generated:
+          type: boolean
+          title: Is Ai Generated
+        country_code:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Country Code
+      type: object
+      required:
+      - value
+      - is_ai_generated
+      title: AiLanguageItemTag
+      description: 'AI tracking tag for language items, includes ISO 639-1 code for flag display.'
     ApiEndpointType:
       type: string
       enum:
@@ -27,12 +1372,6 @@ components:
       - NETWORK_BROKER
       title: ApiEndpointType
       description: API endpoint accessibility type.
-    AuthType:
-      type: string
-      enum:
-      - OAUTH
-      - ACCESS_TOKEN
-      title: AuthType
     BaseResponseSchema:
       properties:
         message:
@@ -48,8 +1387,53 @@ components:
       - message
       - status
       title: BaseResponseSchema
-      description: Standard response schema for simple operations like create, update,
-        delete.
+      description: 'Standard response schema for simple operations like create, update, delete.'
+    BasicAuthAuthConfig:
+      properties:
+        basic_auth_location:
+          $ref: '#/components/schemas/BasicAuthLocation'
+          description: 'Where credentials are sent: HEADER or PAYLOAD'
+          default: HEADER
+        basic_auth_header:
+          anyOf:
+          -
+            additionalProperties:
+              type: string
+            type: object
+          - type: 'null'
+          title: Basic Auth Header
+          description: 'Auth header as {name: value} dict (required when location=HEADER)'
+          examples:
+          - Authorization: Basic dXNlcjpwYXNz
+      type: object
+      title: BasicAuthAuthConfig
+      description: Basic Auth credentials — header or payload location.
+    BasicAuthAuthConfigRedact:
+      properties:
+        basic_auth_location:
+          $ref: '#/components/schemas/BasicAuthLocation'
+          description: 'Where credentials are sent: HEADER or PAYLOAD'
+          default: HEADER
+        basic_auth_header:
+          anyOf:
+          -
+            additionalProperties:
+              type: string
+            type: object
+          - type: 'null'
+          title: Basic Auth Header
+          description: 'Auth header as {name: value} dict (required when location=HEADER)'
+          examples:
+          - Authorization: Basic dXNlcjpwYXNz
+      type: object
+      title: BasicAuthAuthConfigRedact
+    BasicAuthLocation:
+      type: string
+      enum:
+      - HEADER
+      - PAYLOAD
+      title: BasicAuthLocation
+      description: Where Basic Auth credentials are sent.
     BedrockAccessConnectionParams:
       properties:
         access_id:
@@ -98,7 +1482,8 @@ components:
           writeOnly: true
         session_token:
           anyOf:
-          - type: string
+          -
+            type: string
             format: password
             writeOnly: true
           - type: 'null'
@@ -135,7 +1520,7 @@ components:
         name:
           type: string
           title: Name
-          description: Name of the item (e.g., target type, status)
+          description: 'Name of the item (e.g., target type, status)'
         count:
           type: integer
           minimum: 0.0
@@ -146,15 +1531,11 @@ components:
       - name
       - count
       title: CountByNameSchema
-      description: 'Generic count schema with name field for extensible list structures.
-
-
-        Used in dashboard and other endpoints to provide counts grouped by a name
-        field.
-
+      description: |
+        Generic count schema with name field for extensible list structures.
+        
+        Used in dashboard and other endpoints to provide counts grouped by a name field.
         Frontend-friendly list format for easy iteration.
-
-        '
     CustomPromptCreateRequestSchema:
       properties:
         prompt:
@@ -299,7 +1680,8 @@ components:
           description: Whether the prompt is active
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
@@ -348,7 +1730,7 @@ components:
         archive:
           type: boolean
           title: Archive
-          description: True to archive, False to unarchive
+          description: 'True to archive, False to unarchive'
       additionalProperties: false
       type: object
       required:
@@ -368,7 +1750,7 @@ components:
           - type: 'null'
           title: Description
           description: Description of the custom prompt set
-          default: null
+          default: 
         property_names:
           items:
             type: string
@@ -376,6 +1758,10 @@ components:
           maxItems: 2
           title: Property Names
           description: Property names for this prompt set (max 2)
+        language:
+          $ref: '#/components/schemas/SupportedLanguage'
+          description: Language code (ISO 639-1) for prompts in this set
+          default: en
       additionalProperties: false
       type: object
       required:
@@ -392,12 +1778,10 @@ components:
           description: List of active custom prompt set references
       type: object
       title: CustomPromptSetListActiveSchema
-      description: 'Schema for listing active custom prompt sets available for use.
-
-
+      description: |
+        Schema for listing active custom prompt sets available for use.
+        
         Used by data plane to discover available prompt sets for job creation.
-
-        '
     CustomPromptSetListItemSchema:
       properties:
         uuid:
@@ -415,7 +1799,10 @@ components:
           - type: 'null'
           title: Description
           description: Description of the prompt set
-          default: null
+          default: 
+        language:
+          $ref: '#/components/schemas/LanguageOptionSchema'
+          description: Language of prompts in this set
         active:
           type: boolean
           title: Active
@@ -441,7 +1828,8 @@ components:
           description: Property names
         created_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Created By User Id
@@ -493,6 +1881,10 @@ components:
           type: string
           title: Name
           description: Name of the prompt set
+        language:
+          $ref: '#/components/schemas/SupportedLanguage'
+          description: Language of prompts in this set
+          default: en
         version:
           anyOf:
           - type: string
@@ -531,14 +1923,11 @@ components:
       - created_at
       - updated_at
       title: CustomPromptSetReferenceSchema
-      description: 'Reference schema for custom prompt sets used by data plane.
-
-
+      description: |
+        Reference schema for custom prompt sets used by data plane.
+        
         Contains minimal information needed for data plane to fetch
-
         configurations from GCS using the GCS-first pattern.
-
-        '
     CustomPromptSetResponseSchema:
       properties:
         uuid:
@@ -556,7 +1945,10 @@ components:
           - type: 'null'
           title: Description
           description: Description of the prompt set
-          default: null
+          default: 
+        language:
+          $ref: '#/components/schemas/LanguageOptionSchema'
+          description: Language of prompts in this set
         active:
           type: boolean
           title: Active
@@ -582,7 +1974,8 @@ components:
           description: Statistics about the prompt set
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
@@ -601,14 +1994,16 @@ components:
           description: Property definitions
         created_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Created By User Id
           description: User ID who created the prompt set
         updated_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Updated By User Id
@@ -638,7 +2033,8 @@ components:
       properties:
         name:
           anyOf:
-          - type: string
+          -
+            type: string
             maxLength: 255
           - type: 'null'
           title: Name
@@ -657,7 +2053,8 @@ components:
           description: Archive status
         property_names:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
             maxItems: 2
@@ -692,7 +2089,8 @@ components:
           description: Prompt statistics when version was created
         snapshot_created_at:
           anyOf:
-          - type: string
+          -
+            type: string
             format: date-time
           - type: 'null'
           title: Snapshot Created At
@@ -707,12 +2105,10 @@ components:
       - status
       - is_latest
       title: CustomPromptSetVersionInfoSchema
-      description: 'Version information for a custom prompt set snapshot.
-
-
+      description: |
+        Version information for a custom prompt set snapshot.
+        
         Provides metadata about a specific version without full configuration data.
-
-        '
     CustomPromptUpdateRequestSchema:
       properties:
         prompt:
@@ -729,7 +2125,8 @@ components:
           description: Updated goal
         properties:
           anyOf:
-          - additionalProperties:
+          -
+            additionalProperties:
               type: string
             type: object
           - type: 'null'
@@ -751,23 +2148,20 @@ components:
             $ref: '#/components/schemas/CountByNameSchema'
           type: array
           title: Targets By Type
-          description: Target counts grouped by type (APPLICATION, AGENT, MODEL)
+          description: 'Target counts grouped by type (APPLICATION, AGENT, MODEL)'
       type: object
       required:
       - total_targets
       title: DashboardOverviewResponseSchema
-      description: 'Dashboard overview response with target counts.
-
-
+      description: |
+        Dashboard overview response with target counts.
+        
         Endpoint: GET /api/v1/dashboard/overview
-
         Returns target counts by type in list format for easy frontend iteration.
-
-        '
     DatabricksConnectionParams:
       properties:
         auth_type:
-          $ref: '#/components/schemas/AuthType'
+          $ref: '#/components/schemas/red_team_shared__schemas__databricks__AuthType'
           description: Auth type
         access_token:
           anyOf:
@@ -804,11 +2198,12 @@ components:
     DatabricksConnectionRedactParams:
       properties:
         auth_type:
-          $ref: '#/components/schemas/AuthType'
+          $ref: '#/components/schemas/red_team_shared__schemas__databricks__AuthType'
           description: Auth type
         access_token:
           anyOf:
-          - type: string
+          -
+            type: string
             format: password
             writeOnly: true
           - type: 'null'
@@ -822,7 +2217,8 @@ components:
           description: Databricks client_id
         secret:
           anyOf:
-          - type: string
+          -
+            type: string
             format: password
             writeOnly: true
           - type: 'null'
@@ -851,6 +2247,37 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
+    HeadersAuthConfig:
+      properties:
+        auth_header:
+          additionalProperties:
+            type: string
+          type: object
+          title: Auth Header
+          description: 'Auth header as {name: value} dict'
+          examples:
+          - Authorization: Bearer sk-xxxxxxxxxxxx
+          - x-api-key: my-api-key
+      type: object
+      required:
+      - auth_header
+      title: HeadersAuthConfig
+      description: 'Static header injection (API keys, bearer tokens).'
+    HeadersAuthConfigRedact:
+      properties:
+        auth_header:
+          additionalProperties:
+            type: string
+          type: object
+          title: Auth Header
+          description: 'Auth header as {name: value} dict'
+          examples:
+          - Authorization: Bearer sk-xxxxxxxxxxxx
+          - x-api-key: my-api-key
+      type: object
+      required:
+      - auth_header
+      title: HeadersAuthConfigRedact
     HuggingfaceConnectionParams:
       properties:
         api_key:
@@ -893,6 +2320,225 @@ components:
       - model_name
       title: HuggingfaceConnectionRedactParams
       description: Connection parameters specific to huggingface targets
+    LanguageOptionSchema:
+      properties:
+        code:
+          type: string
+          title: Code
+        name:
+          type: string
+          title: Name
+      type: object
+      required:
+      - code
+      - name
+      title: LanguageOptionSchema
+      description: Language representation with code and display name.
+    MSCopilotStudioAuthUrlRequestSchema:
+      properties:
+        client_id:
+          type: string
+          title: Client Id
+          description: Azure App Registration Client ID
+        client_secret:
+          type: string
+          title: Client Secret
+          description: Azure App Registration Client Secret
+        tenant_id:
+          type: string
+          title: Tenant Id
+          description: Azure AD Tenant ID
+        target_uuid:
+          anyOf:
+          -
+            type: string
+            format: uuid
+          - type: 'null'
+          title: Target Uuid
+          description: Existing target UUID for resolving redacted client_secret on re-auth.
+        token_json_uuid:
+          anyOf:
+          -
+            type: string
+            format: uuid
+          - type: 'null'
+          title: Token Json Uuid
+          description: 'Existing token_json_uuid for re-auth. If omitted, a new UUID is generated.'
+      additionalProperties: false
+      type: object
+      required:
+      - client_id
+      - client_secret
+      - tenant_id
+      title: MSCopilotStudioAuthUrlRequestSchema
+      description: |
+        Request body for generating MS Copilot Studio OAuth auth URL (POST /auth-url).
+        
+        If token_json_uuid is provided, reuses existing UUID (re-auth).
+        If omitted, generates a new UUID (new target).
+    MSCopilotStudioAuthUrlResponseSchema:
+      properties:
+        auth_url:
+          type: string
+          title: Auth Url
+          description: OAuth authorization URL for user login
+        token_json_uuid:
+          type: string
+          format: uuid
+          title: Token Json Uuid
+          description: UUID referencing MSAL token cache in GSM
+        state:
+          type: string
+          title: State
+          description: MSAL-generated state for frontend session tracking (correlate auth callback with original request)
+      type: object
+      required:
+      - auth_url
+      - token_json_uuid
+      - state
+      title: MSCopilotStudioAuthUrlResponseSchema
+      description: Response containing the generated OAuth auth URL.
+    MSCopilotStudioConnectionParams:
+      properties:
+        client_id:
+          type: string
+          title: Client Id
+          description: Azure App Registration Client ID
+        client_secret:
+          type: string
+          title: Client Secret
+          description: Azure App Registration Client Secret
+        tenant_id:
+          type: string
+          title: Tenant Id
+          description: Azure AD Tenant ID
+        schema_name:
+          type: string
+          title: Schema Name
+          description: Copilot Agent schema/identifier
+        environment_id:
+          type: string
+          title: Environment Id
+          description: Power Platform Environment ID
+        token_json_uuid:
+          anyOf:
+          -
+            type: string
+            format: uuid
+          - type: 'null'
+          title: Token Json Uuid
+          description: UUID referencing MSAL token cache in GSM. Set after POST /ms-copilot-studio/token.
+        token_cache_json:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Token Cache Json
+          description: Serialized MSAL token cache. Injected at POST/PUT /target time from standalone GSM record.
+      type: object
+      required:
+      - client_id
+      - client_secret
+      - tenant_id
+      - schema_name
+      - environment_id
+      title: MSCopilotStudioConnectionParams
+      description: Microsoft Copilot Studio Agent connection parameters.
+    MSCopilotStudioConnectionRedactParams:
+      properties:
+        client_id:
+          type: string
+          title: Client Id
+          description: Azure App Registration Client ID
+        client_secret:
+          type: string
+          format: password
+          title: Client Secret
+          description: Azure App Registration Client Secret
+          writeOnly: true
+        tenant_id:
+          type: string
+          title: Tenant Id
+          description: Azure AD Tenant ID
+        schema_name:
+          type: string
+          title: Schema Name
+          description: Copilot Agent schema/identifier
+        environment_id:
+          type: string
+          title: Environment Id
+          description: Power Platform Environment ID
+        token_json_uuid:
+          anyOf:
+          -
+            type: string
+            format: uuid
+          - type: 'null'
+          title: Token Json Uuid
+          description: UUID referencing MSAL token cache in GSM. Set after POST /ms-copilot-studio/token.
+      type: object
+      required:
+      - client_id
+      - client_secret
+      - tenant_id
+      - schema_name
+      - environment_id
+      title: MSCopilotStudioConnectionRedactParams
+      description: Redacted version with SecretStr for sensitive fields.
+    MSCopilotStudioTokenRequestSchema:
+      properties:
+        auth_response:
+          additionalProperties:
+            type: string
+          type: object
+          title: Auth Response
+          description: 'Full redirect query params from Microsoft (code, state, session_state, etc.)'
+        token_json_uuid:
+          type: string
+          format: uuid
+          title: Token Json Uuid
+          description: UUID from POST /auth-url response
+        client_id:
+          type: string
+          title: Client Id
+          description: Azure App Registration Client ID
+        client_secret:
+          type: string
+          title: Client Secret
+          description: Azure App Registration Client Secret
+        tenant_id:
+          type: string
+          title: Tenant Id
+          description: Azure AD Tenant ID
+        target_uuid:
+          anyOf:
+          -
+            type: string
+            format: uuid
+          - type: 'null'
+          title: Target Uuid
+          description: Existing target UUID for resolving redacted client_secret on re-auth.
+      additionalProperties: false
+      type: object
+      required:
+      - auth_response
+      - token_json_uuid
+      - client_id
+      - client_secret
+      - tenant_id
+      title: MSCopilotStudioTokenRequestSchema
+      description: Request body for exchanging auth code for tokens (POST /token).
+    MSCopilotStudioTokenResponseSchema:
+      properties:
+        token_json_uuid:
+          type: string
+          format: uuid
+          title: Token Json Uuid
+          description: UUID referencing MSAL token cache in GSM
+      type: object
+      required:
+      - token_json_uuid
+      title: MSCopilotStudioTokenResponseSchema
+      description: Response after successful token exchange (POST/PUT /token).
     MultiTurnStatefulConfig:
       properties:
         type:
@@ -903,8 +2549,7 @@ components:
         response_id_field:
           type: string
           title: Response Id Field
-          description: JSON path to extract session ID from target response (e.g.,
-            'id' for OpenAI responses API)
+          description: 'JSON path to extract session ID from target response (e.g., ''id'' for OpenAI responses API)'
           examples:
           - id
           - conversation_id
@@ -912,8 +2557,7 @@ components:
         request_id_field:
           type: string
           title: Request Id Field
-          description: JSON path to inject session ID in next request (e.g., 'previous_response_id'
-            for OpenAI)
+          description: 'JSON path to inject session ID in next request (e.g., ''previous_response_id'' for OpenAI)'
           examples:
           - previous_response_id
           - conversation_id
@@ -923,15 +2567,11 @@ components:
       - response_id_field
       - request_id_field
       title: MultiTurnStatefulConfig
-      description: 'Configuration for stateful multi-turn targets (session_supported=true).
-
-
-        Stateful targets maintain conversation state on the server side using session
-        IDs.
-
+      description: |
+        Configuration for stateful multi-turn targets (session_supported=true).
+        
+        Stateful targets maintain conversation state on the server side using session IDs.
         The session ID is extracted from responses and injected into subsequent requests.
-
-        '
     MultiTurnStatelessConfig:
       properties:
         type:
@@ -944,8 +2584,7 @@ components:
           - type: string
           - type: 'null'
           title: Assistant Role
-          description: Role name for assistant messages in conversation history (e.g.,
-            'assistant', 'bot', 'model')
+          description: 'Role name for assistant messages in conversation history (e.g., ''assistant'', ''bot'', ''model'')'
           examples:
           - assistant
           - bot
@@ -953,15 +2592,225 @@ components:
           - ai
       type: object
       title: MultiTurnStatelessConfig
-      description: 'Configuration for stateless multi-turn targets (session_supported=false).
-
-
+      description: |
+        Configuration for stateless multi-turn targets (session_supported=false).
+        
         Stateless targets require the client to maintain and send conversation history.
-
-        The assistant_role specifies the role name used for assistant messages in
-        the history.
-
-        '
+        The assistant_role specifies the role name used for assistant messages in the history.
+    NativeConnectionParamsBase-Input:
+      properties:
+        target_connection_config:
+          anyOf:
+          - $ref: '#/components/schemas/OpenAIConnectionParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionParams'
+          - $ref: '#/components/schemas/DatabricksConnectionParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionParams'
+          - type: 'null'
+          title: Target Connection Config
+          description: Provider-specific connection config
+        multi_turn_config:
+          anyOf:
+          -
+            oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi-turn config for stateful or stateless target
+      type: object
+      title: NativeConnectionParamsBase
+      description: |
+        Base connection parameters for native/SDK-based targets (no HTTP endpoint).
+        
+        Used for no-code agent platforms like Microsoft Copilot Studio where
+        interaction is via a provider's client library, not HTTP REST/streaming.
+        
+        # TODO: Consider refactoring RestConnectionParamsBase and StreamingConnectionParamsBase
+        # to share a common base with this class (e.g., extract target_connection_config and
+        # multi_turn_config into a shared parent).
+    NativeConnectionParamsBase-Output:
+      properties:
+        target_connection_config:
+          anyOf:
+          - $ref: '#/components/schemas/OpenAIConnectionParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionParams'
+          - $ref: '#/components/schemas/DatabricksConnectionParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionParams'
+          - type: 'null'
+          title: Target Connection Config
+          description: Provider-specific connection config
+        multi_turn_config:
+          anyOf:
+          -
+            oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi-turn config for stateful or stateless target
+      type: object
+      title: NativeConnectionParamsBase
+      description: |
+        Base connection parameters for native/SDK-based targets (no HTTP endpoint).
+        
+        Used for no-code agent platforms like Microsoft Copilot Studio where
+        interaction is via a provider's client library, not HTTP REST/streaming.
+        
+        # TODO: Consider refactoring RestConnectionParamsBase and StreamingConnectionParamsBase
+        # to share a common base with this class (e.g., extract target_connection_config and
+        # multi_turn_config into a shared parent).
+    NativeConnectionParamsRedactBase:
+      properties:
+        target_connection_config:
+          anyOf:
+          - $ref: '#/components/schemas/OpenAIConnectionRedactParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionRedactParams'
+          - $ref: '#/components/schemas/DatabricksConnectionRedactParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionRedactParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionRedactParams'
+          - type: 'null'
+          title: Target Connection Config
+          description: Provider-specific connection config (redacted)
+        multi_turn_config:
+          anyOf:
+          -
+            oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi-turn config for stateful or stateless target
+      type: object
+      title: NativeConnectionParamsRedactBase
+      description: Redacted version of NativeConnectionParamsBase.
+    OAuth2AuthConfig:
+      properties:
+        oauth2_token_url:
+          type: string
+          title: Oauth2 Token Url
+          description: OAuth2 token endpoint URL
+          examples:
+          - https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token
+        oauth2_expiry_minutes:
+          type: integer
+          minimum: 0.0
+          title: Oauth2 Expiry Minutes
+          description: Token validity in minutes. System refreshes at expiry - 1 min.
+          default: 60
+        oauth2_headers:
+          additionalProperties: true
+          type: object
+          title: Oauth2 Headers
+          description: HTTP headers for the token request
+          examples:
+          -
+            Authorization: Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=
+            Content-Type: application/x-www-form-urlencoded
+        oauth2_body_params:
+          additionalProperties: true
+          type: object
+          title: Oauth2 Body Params
+          description: Body parameters for the token request (nested JSON dict)
+          examples:
+          -
+            client_id: my-client-id
+            client_secret: my-client-secret
+            grant_type: client_credentials
+            scope: api-access
+        oauth2_token_response_key:
+          type: string
+          title: Oauth2 Token Response Key
+          description: Dot-notation path to token in response JSON
+          default: access_token
+          examples:
+          - access_token
+          - data.credentials.access_token
+        oauth2_inject_header:
+          additionalProperties:
+            type: string
+          type: object
+          title: Oauth2 Inject Header
+          description: 'Header template with {TOKEN} placeholder'
+          examples:
+          - Authorization: 'Bearer {TOKEN}'
+      type: object
+      required:
+      - oauth2_token_url
+      - oauth2_inject_header
+      title: OAuth2AuthConfig
+      description: OAuth2 client credentials with proactive token refresh.
+    OAuth2AuthConfigRedact:
+      properties:
+        oauth2_token_url:
+          type: string
+          title: Oauth2 Token Url
+          description: OAuth2 token endpoint URL
+          examples:
+          - https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token
+        oauth2_expiry_minutes:
+          type: integer
+          minimum: 0.0
+          title: Oauth2 Expiry Minutes
+          description: Token validity in minutes. System refreshes at expiry - 1 min.
+          default: 60
+        oauth2_headers:
+          additionalProperties: true
+          type: object
+          title: Oauth2 Headers
+          description: HTTP headers for the token request
+          examples:
+          -
+            Authorization: Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=
+            Content-Type: application/x-www-form-urlencoded
+        oauth2_body_params:
+          additionalProperties: true
+          type: object
+          title: Oauth2 Body Params
+          description: Body parameters for the token request (nested JSON dict)
+          examples:
+          -
+            client_id: my-client-id
+            client_secret: my-client-secret
+            grant_type: client_credentials
+            scope: api-access
+        oauth2_token_response_key:
+          type: string
+          title: Oauth2 Token Response Key
+          description: Dot-notation path to token in response JSON
+          default: access_token
+          examples:
+          - access_token
+          - data.credentials.access_token
+        oauth2_inject_header:
+          additionalProperties:
+            type: string
+          type: object
+          title: Oauth2 Inject Header
+          description: 'Header template with {TOKEN} placeholder'
+          examples:
+          - Authorization: 'Bearer {TOKEN}'
+      type: object
+      required:
+      - oauth2_token_url
+      - oauth2_inject_header
+      title: OAuth2AuthConfigRedact
     OpenAIConnectionParams:
       properties:
         api_key:
@@ -1012,12 +2861,43 @@ components:
           title: Items
       type: object
       title: OtherDetails
-      description: 'Additional profiler discoveries. Read-only key-value pairs.
-
-
+      description: |
+        Additional profiler discoveries. Read-only key-value pairs.
+        
         Examples: code_execution_capability, internet_access, etc.
-
-        '
+    OtherDetailsPrettified:
+      properties:
+        execution_environment:
+          additionalProperties: true
+          type: object
+          title: Execution Environment
+        core_architecture_and_identity:
+          additionalProperties: true
+          type: object
+          title: Core Architecture And Identity
+        tools_and_integrations:
+          additionalProperties: true
+          type: object
+          title: Tools And Integrations
+        audience_and_governance:
+          additionalProperties: true
+          type: object
+          title: Audience And Governance
+        performance_and_metrics:
+          additionalProperties: true
+          type: object
+          title: Performance And Metrics
+        content_policy:
+          additionalProperties: true
+          type: object
+          title: Content Policy
+        other_discoveries:
+          additionalProperties: true
+          type: object
+          title: Other Discoveries
+      type: object
+      title: OtherDetailsPrettified
+      description: Categorized view of profiler discoveries for FE display.
     PaginationSchema:
       properties:
         total_items:
@@ -1035,6 +2915,7 @@ components:
       - IN_PROGRESS
       - COMPLETED
       - FAILED
+      - PARTIALLY_COMPLETE
       title: ProfilingStatus
       description: Status of target profiling workflow.
     PromptSetStatsSchema:
@@ -1073,11 +2954,11 @@ components:
         property_name:
           type: string
           title: Property Name
-          description: Property name (e.g., 'industry', 'role')
+          description: 'Property name (e.g., ''industry'', ''role'')'
         property_value:
           type: string
           title: Property Value
-          description: Property value (e.g., 'healthcare', 'CEO')
+          description: 'Property value (e.g., ''healthcare'', ''CEO'')'
       type: object
       required:
       - property_name
@@ -1178,6 +3059,8 @@ components:
       enum:
       - REST
       - STREAMING
+      - WEBSOCKET
+      - WEBSOCKET_STREAMING
       title: ResponseMode
       description: Response mode for target interactions.
     RestConnectionParamsBase-Input:
@@ -1195,20 +3078,24 @@ components:
           type: object
           title: Request Headers
           description: Request headers
-          default: null
+          default: {}
           examples:
-          - Authorization: Bearer sk-xxx
+          -
+            Authorization: Bearer sk-xxx
             Content-Type: application/json
         request_json:
           additionalProperties: true
           type: object
           title: Request Json
           description: Request JSON
-          default: null
+          default: {}
           examples:
-          - input:
-            - content:
-              - text: '{INPUT}'
+          -
+            input:
+            -
+              content:
+              -
+                text: '{INPUT}'
                 type: input_text
               role: user
             model: gpt-4.1-nano
@@ -1217,14 +3104,14 @@ components:
           type: object
           title: Response Json
           description: Response JSON
-          default: null
+          default: {}
           examples:
           - content: '{RESPONSE}'
         response_key:
           type: string
           title: Response Key
           description: Response key
-          default: null
+          default: 
           examples:
           - content
         target_connection_config:
@@ -1233,6 +3120,7 @@ components:
           - $ref: '#/components/schemas/HuggingfaceConnectionParams'
           - $ref: '#/components/schemas/DatabricksConnectionParams'
           - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionParams'
           - type: 'null'
           title: Target Connection Config
           description: Target Connection config of type openai/huggingface ..
@@ -1243,11 +3131,11 @@ components:
           title: Curl
           description: Generated cURL command ready to use (redacted for security)
           examples:
-          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
-            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
         multi_turn_config:
           anyOf:
-          - oneOf:
+          -
+            oneOf:
             - $ref: '#/components/schemas/MultiTurnStatefulConfig'
             - $ref: '#/components/schemas/MultiTurnStatelessConfig'
             discriminator:
@@ -1278,20 +3166,24 @@ components:
           type: object
           title: Request Headers
           description: Request headers
-          default: null
+          default: {}
           examples:
-          - Authorization: Bearer sk-xxx
+          -
+            Authorization: Bearer sk-xxx
             Content-Type: application/json
         request_json:
           additionalProperties: true
           type: object
           title: Request Json
           description: Request JSON
-          default: null
+          default: {}
           examples:
-          - input:
-            - content:
-              - text: '{INPUT}'
+          -
+            input:
+            -
+              content:
+              -
+                text: '{INPUT}'
                 type: input_text
               role: user
             model: gpt-4.1-nano
@@ -1300,14 +3192,14 @@ components:
           type: object
           title: Response Json
           description: Response JSON
-          default: null
+          default: {}
           examples:
           - content: '{RESPONSE}'
         response_key:
           type: string
           title: Response Key
           description: Response key
-          default: null
+          default: 
           examples:
           - content
         target_connection_config:
@@ -1316,6 +3208,7 @@ components:
           - $ref: '#/components/schemas/HuggingfaceConnectionParams'
           - $ref: '#/components/schemas/DatabricksConnectionParams'
           - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionParams'
           - type: 'null'
           title: Target Connection Config
           description: Target Connection config of type openai/huggingface ..
@@ -1326,11 +3219,11 @@ components:
           title: Curl
           description: Generated cURL command ready to use (redacted for security)
           examples:
-          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
-            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
         multi_turn_config:
           anyOf:
-          - oneOf:
+          -
+            oneOf:
             - $ref: '#/components/schemas/MultiTurnStatefulConfig'
             - $ref: '#/components/schemas/MultiTurnStatelessConfig'
             discriminator:
@@ -1361,20 +3254,24 @@ components:
           type: object
           title: Request Headers
           description: Request headers
-          default: null
+          default: {}
           examples:
-          - Authorization: Bearer sk-xxx
+          -
+            Authorization: Bearer sk-xxx
             Content-Type: application/json
         request_json:
           additionalProperties: true
           type: object
           title: Request Json
           description: Request JSON
-          default: null
+          default: {}
           examples:
-          - input:
-            - content:
-              - text: '{INPUT}'
+          -
+            input:
+            -
+              content:
+              -
+                text: '{INPUT}'
                 type: input_text
               role: user
             model: gpt-4.1-nano
@@ -1383,14 +3280,14 @@ components:
           type: object
           title: Response Json
           description: Response JSON
-          default: null
+          default: {}
           examples:
           - content: '{RESPONSE}'
         response_key:
           type: string
           title: Response Key
           description: Response key
-          default: null
+          default: 
           examples:
           - content
         target_connection_config:
@@ -1399,6 +3296,7 @@ components:
           - $ref: '#/components/schemas/HuggingfaceConnectionRedactParams'
           - $ref: '#/components/schemas/DatabricksConnectionRedactParams'
           - $ref: '#/components/schemas/BedrockAccessConnectionRedactParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionRedactParams'
           - type: 'null'
           title: Target Connection Config
           description: Target Connection config of type openai/huggingface ..
@@ -1409,11 +3307,11 @@ components:
           title: Curl
           description: Generated cURL command ready to use (redacted for security)
           examples:
-          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
-            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
         multi_turn_config:
           anyOf:
-          - oneOf:
+          -
+            oneOf:
             - $ref: '#/components/schemas/MultiTurnStatefulConfig'
             - $ref: '#/components/schemas/MultiTurnStatelessConfig'
             discriminator:
@@ -1428,6 +3326,17 @@ components:
           - 'assistant_role: assistant'
       type: object
       title: RestConnectionParamsRedactBase
+    StartProfilingResponseSchema:
+      properties:
+        message:
+          type: string
+          title: Message
+          description: Status message
+      type: object
+      required:
+      - message
+      title: StartProfilingResponseSchema
+      description: Response schema for start profiling action.
     StreamingConnectionParamsBase-Input:
       properties:
         api_endpoint:
@@ -1443,20 +3352,24 @@ components:
           type: object
           title: Request Headers
           description: Request headers
-          default: null
+          default: {}
           examples:
-          - Authorization: Bearer sk-xxx
+          -
+            Authorization: Bearer sk-xxx
             Content-Type: application/json
         request_json:
           additionalProperties: true
           type: object
           title: Request Json
           description: Request JSON
-          default: null
+          default: {}
           examples:
-          - input:
-            - content:
-              - text: '{INPUT}'
+          -
+            input:
+            -
+              content:
+              -
+                text: '{INPUT}'
                 type: input_text
               role: user
             model: gpt-4.1-nano
@@ -1465,14 +3378,14 @@ components:
           type: object
           title: Response Json
           description: Response JSON
-          default: null
+          default: {}
           examples:
           - content: '{RESPONSE}'
         response_key:
           type: string
           title: Response Key
           description: Response key
-          default: null
+          default: 
           examples:
           - content
         target_connection_config:
@@ -1481,6 +3394,7 @@ components:
           - $ref: '#/components/schemas/HuggingfaceConnectionParams'
           - $ref: '#/components/schemas/DatabricksConnectionParams'
           - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionParams'
           - type: 'null'
           title: Target Connection Config
           description: Target Connection config of type openai/huggingface ..
@@ -1491,11 +3405,11 @@ components:
           title: Curl
           description: Generated cURL command ready to use (redacted for security)
           examples:
-          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
-            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
         multi_turn_config:
           anyOf:
-          - oneOf:
+          -
+            oneOf:
             - $ref: '#/components/schemas/MultiTurnStatefulConfig'
             - $ref: '#/components/schemas/MultiTurnStatelessConfig'
             discriminator:
@@ -1535,20 +3449,24 @@ components:
           type: object
           title: Request Headers
           description: Request headers
-          default: null
+          default: {}
           examples:
-          - Authorization: Bearer sk-xxx
+          -
+            Authorization: Bearer sk-xxx
             Content-Type: application/json
         request_json:
           additionalProperties: true
           type: object
           title: Request Json
           description: Request JSON
-          default: null
+          default: {}
           examples:
-          - input:
-            - content:
-              - text: '{INPUT}'
+          -
+            input:
+            -
+              content:
+              -
+                text: '{INPUT}'
                 type: input_text
               role: user
             model: gpt-4.1-nano
@@ -1557,14 +3475,14 @@ components:
           type: object
           title: Response Json
           description: Response JSON
-          default: null
+          default: {}
           examples:
           - content: '{RESPONSE}'
         response_key:
           type: string
           title: Response Key
           description: Response key
-          default: null
+          default: 
           examples:
           - content
         target_connection_config:
@@ -1573,6 +3491,7 @@ components:
           - $ref: '#/components/schemas/HuggingfaceConnectionParams'
           - $ref: '#/components/schemas/DatabricksConnectionParams'
           - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionParams'
           - type: 'null'
           title: Target Connection Config
           description: Target Connection config of type openai/huggingface ..
@@ -1583,11 +3502,11 @@ components:
           title: Curl
           description: Generated cURL command ready to use (redacted for security)
           examples:
-          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
-            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
         multi_turn_config:
           anyOf:
-          - oneOf:
+          -
+            oneOf:
             - $ref: '#/components/schemas/MultiTurnStatefulConfig'
             - $ref: '#/components/schemas/MultiTurnStatelessConfig'
             discriminator:
@@ -1627,20 +3546,24 @@ components:
           type: object
           title: Request Headers
           description: Request headers
-          default: null
+          default: {}
           examples:
-          - Authorization: Bearer sk-xxx
+          -
+            Authorization: Bearer sk-xxx
             Content-Type: application/json
         request_json:
           additionalProperties: true
           type: object
           title: Request Json
           description: Request JSON
-          default: null
+          default: {}
           examples:
-          - input:
-            - content:
-              - text: '{INPUT}'
+          -
+            input:
+            -
+              content:
+              -
+                text: '{INPUT}'
                 type: input_text
               role: user
             model: gpt-4.1-nano
@@ -1649,14 +3572,14 @@ components:
           type: object
           title: Response Json
           description: Response JSON
-          default: null
+          default: {}
           examples:
           - content: '{RESPONSE}'
         response_key:
           type: string
           title: Response Key
           description: Response key
-          default: null
+          default: 
           examples:
           - content
         target_connection_config:
@@ -1665,6 +3588,7 @@ components:
           - $ref: '#/components/schemas/HuggingfaceConnectionRedactParams'
           - $ref: '#/components/schemas/DatabricksConnectionRedactParams'
           - $ref: '#/components/schemas/BedrockAccessConnectionRedactParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionRedactParams'
           - type: 'null'
           title: Target Connection Config
           description: Target Connection config of type openai/huggingface ..
@@ -1675,11 +3599,11 @@ components:
           title: Curl
           description: Generated cURL command ready to use (redacted for security)
           examples:
-          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json"
-            -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
         multi_turn_config:
           anyOf:
-          - oneOf:
+          -
+            oneOf:
             - $ref: '#/components/schemas/MultiTurnStatefulConfig'
             - $ref: '#/components/schemas/MultiTurnStatelessConfig'
             discriminator:
@@ -1703,6 +3627,31 @@ components:
       - response_stop_key
       - response_stop_value
       title: StreamingConnectionParamsRedactBase
+    SupportedLanguage:
+      type: string
+      enum:
+      - ar
+      - bn
+      - zh-CN
+      - zh-TW
+      - nl
+      - en
+      - fr
+      - de
+      - hi
+      - id
+      - it
+      - ja
+      - ko
+      - pl
+      - pt
+      - ru
+      - es
+      - sv
+      - th
+      - tr
+      - vi
+      title: SupportedLanguage
     TargetAdditionalContext:
       properties:
         base_model:
@@ -1710,7 +3659,7 @@ components:
           - type: string
           - type: 'null'
           title: Base Model
-          description: Base model name (e.g., GPT-4, Claude)
+          description: 'Base model name (e.g., GPT-4, Claude)'
         core_architecture:
           anyOf:
           - type: string
@@ -1725,7 +3674,8 @@ components:
           description: System prompt
         languages_supported:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
@@ -1733,7 +3683,8 @@ components:
           description: Supported languages
         banned_keywords:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
@@ -1741,7 +3692,8 @@ components:
           description: Banned keywords/phrases
         tools_accessible:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
@@ -1749,15 +3701,72 @@ components:
           description: Accessible tools/capabilities
       type: object
       title: TargetAdditionalContext
-      description: 'Additional context - used in create/update API requests and stored
-        in DB/GCS.
-
-
+      description: |
+        Additional context - used in create/update API requests and stored in DB/GCS.
+        
         Single value fields are strings.
-
         List fields are lists of strings.
-
-        '
+    TargetAuthValidationRequestSchema:
+      properties:
+        auth_type:
+          $ref: '#/components/schemas/red_team_shared__schemas__auth_config__AuthType'
+          description: Authentication method type
+        auth_config:
+          anyOf:
+          - $ref: '#/components/schemas/HeadersAuthConfig'
+          - $ref: '#/components/schemas/BasicAuthAuthConfig'
+          - $ref: '#/components/schemas/OAuth2AuthConfig'
+          title: Auth Config
+          description: Authentication configuration to validate
+        target_id:
+          anyOf:
+          -
+            type: string
+            format: uuid
+          - type: 'null'
+          title: Target Id
+          description: 'Existing target UUID. When provided and auth_config contains redacted values, actual credentials are fetched from secrets manager.'
+        network_broker_channel_uuid:
+          anyOf:
+          -
+            type: string
+            format: uuid
+          - type: 'null'
+          title: Network Broker Channel Uuid
+          description: 'Network broker channel UUID. When provided, OAuth2 token requests are routed via network broker.'
+      type: object
+      required:
+      - auth_type
+      - auth_config
+      title: TargetAuthValidationRequestSchema
+      description: Request schema to validate target authentication configuration.
+    TargetAuthValidationResponseSchema:
+      properties:
+        validated:
+          type: boolean
+          title: Validated
+          description: Whether auth validation passed
+        token_preview:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Token Preview
+          description: First 20 chars of token (OAuth2 only)
+        expires_in:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Expires In
+          description: Token expiry from response (OAuth2 only)
+      type: object
+      required:
+      - validated
+      title: TargetAuthValidationResponseSchema
+      description: |
+        Response schema from target authentication validation.
+        
+        On failure, the service raises airs_common exceptions (ValidationError,
+        AuthError, etc.) which are converted to HTTP error responses by middleware.
     TargetBackground:
       properties:
         industry:
@@ -1765,39 +3774,38 @@ components:
           - type: string
           - type: 'null'
           title: Industry
-          description: Target's industry (e.g., Healthcare, Finance)
+          description: 'Target''s industry (e.g., Healthcare, Finance)'
         use_case:
           anyOf:
           - type: string
           - type: 'null'
           title: Use Case
-          description: Primary use case (e.g., Customer Support, Code Assistant)
+          description: 'Primary use case (e.g., Customer Support, Code Assistant)'
         competitors:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
           title: Competitors
           description: Known competitor products
+        agentic_profiling_enabled:
+          type: boolean
+          title: Agentic Profiling Enabled
+          description: Whether agentic profiling is enabled for this target
+          default: true
       type: object
       title: TargetBackground
-      description: 'Target background - used in create/update API requests and stored
-        in DB/GCS.
-
-
+      description: |
+        Target background - used in create/update API requests and stored in DB/GCS.
+        
         Required fields for activation:
-
         - industry (string, required)
-
         - use_case (string, required)
-
-
+        
         Optional field:
-
         - competitors (list of strings)
-
-        '
     TargetConnectionType:
       type: string
       enum:
@@ -1808,6 +3816,9 @@ components:
       - CUSTOM
       - REST
       - STREAMING
+      - WEBSOCKET
+      - WEBSOCKET_STREAMING
+      - MS_COPILOT_STUDIO
       title: TargetConnectionType
       description: Connection type/provider for the target.
     TargetContextUpdateSchema:
@@ -1821,36 +3832,60 @@ components:
           anyOf:
           - $ref: '#/components/schemas/TargetAdditionalContext'
           - type: 'null'
-          description: 'Additional context: base_model, system_prompt, languages,
-            etc.'
+          description: 'Additional context: base_model, system_prompt, languages, etc.'
       type: object
       title: TargetContextUpdateSchema
-      description: 'Request schema for updating target profile (background + additional
-        context).
-
-
+      description: |
+        Request schema for updating target profile (background + additional context).
+        
         Used by PUT /{target_uuid}/profile endpoint.
-
         User provides plain values which are saved directly to DB and GCS.
-
-        '
     TargetCreateRequestSchema:
       properties:
         connection_params:
           anyOf:
-          - $ref: '#/components/schemas/RestConnectionParamsBase-Input'
-          - $ref: '#/components/schemas/StreamingConnectionParamsBase-Input'
+          - oneOf:
+              - $ref: '#/components/schemas/NativeConnectionParamsBase-Input'
+              - $ref: '#/components/schemas/WebSocketConnectionParamsBase-Input'
+              - $ref: '#/components/schemas/StreamingConnectionParamsBase-Input'
+              - $ref: '#/components/schemas/RestConnectionParamsBase-Input'
           - type: 'null'
           title: Connection Params
           description: API connection parameters (sensitive data masked for security)
+          examples:
+          -
+            api_endpoint: https://api.openai.com/v1/responses
+            request_headers:
+              Authorization: Bearer sk-xxx
+              Content-Type: application/json
+            request_json:
+              input:
+              -
+                content:
+                -
+                  text: '{INPUT}'
+                  type: input_text
+                role: user
+              model: gpt-4.1-nano
+            response_json:
+              content: '{RESPONSE}'
+            response_key: content
+        auth_config:
+          anyOf:
+          - $ref: '#/components/schemas/HeadersAuthConfig'
+          - $ref: '#/components/schemas/BasicAuthAuthConfig'
+          - $ref: '#/components/schemas/OAuth2AuthConfig'
+          - type: 'null'
+          title: Auth Config
+          description: Authentication configuration (resolved based on auth_type)
         network_broker_channel_uuid:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Network Broker Channel Uuid
-          description: Network broker channel UUID for routing requests. Required
-            when api_endpoint_type is NETWORK_BROKER.
+          description: Network broker channel UUID for routing requests. Required when api_endpoint_type is NETWORK_BROKER.
           examples:
           - 550e8400-e29b-41d4-a716-446655440000
         name:
@@ -1865,7 +3900,7 @@ components:
           - type: 'null'
           title: Description
           description: Optional target description
-          default: null
+          default: 
           examples:
           - AI model for testing
         target_type:
@@ -1899,6 +3934,16 @@ components:
           examples:
           - REST
           - STREAMING
+          - WEBSOCKET
+        auth_type:
+          anyOf:
+          - $ref: '#/components/schemas/red_team_shared__schemas__auth_config__AuthType'
+          - type: 'null'
+          description: Authentication method for target API access
+          examples:
+          - HEADERS
+          - BASIC_AUTH
+          - OAUTH2
         session_supported:
           type: boolean
           title: Session Supported
@@ -1906,12 +3951,13 @@ components:
           default: false
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
           description: Additional configuration or metadata for the target
-          default: null
+          default: {}
           examples:
           - custom_key: custom_value
         target_metadata:
@@ -1926,15 +3972,21 @@ components:
           anyOf:
           - $ref: '#/components/schemas/TargetAdditionalContext'
           - type: 'null'
-          description: 'Additional context: base_model, system_prompt, languages,
-            etc.'
+          description: 'Additional context: base_model, system_prompt, languages, etc.'
+        canonical_id:
+          anyOf:
+          -
+            type: string
+            maxLength: 512
+          - type: 'null'
+          title: Canonical Id
+          description: Partner-supplied stable identifier (e.g. Discovery's id). Free-form opaque string; immutable once set.
       additionalProperties: false
       type: object
       required:
       - name
       title: TargetCreateRequestSchema
-      description: Target create request schema for validating and defining target
-        creation parameters.
+      description: Target create request schema for validating and defining target creation parameters.
     TargetListItemSchema:
       properties:
         uuid:
@@ -1956,7 +4008,7 @@ components:
           - type: 'null'
           title: Description
           description: Optional target description
-          default: null
+          default: 
           examples:
           - AI model for testing
         target_type:
@@ -1990,6 +4042,16 @@ components:
           examples:
           - REST
           - STREAMING
+          - WEBSOCKET
+        auth_type:
+          anyOf:
+          - $ref: '#/components/schemas/red_team_shared__schemas__auth_config__AuthType'
+          - type: 'null'
+          description: Authentication method for target API access
+          examples:
+          - HEADERS
+          - BASIC_AUTH
+          - OAUTH2
         session_supported:
           type: boolean
           title: Session Supported
@@ -1997,12 +4059,13 @@ components:
           default: false
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
           description: Additional configuration or metadata for the target
-          default: null
+          default: {}
           examples:
           - custom_key: custom_value
         status:
@@ -2027,19 +4090,19 @@ components:
           - type: string
           - type: 'null'
           title: Secret Version
-          description: Secret Manager version for connection_params. When present,
-            sensitive connection data is stored in Secret Manager. When None, connection_params
-            are stored in GCS (legacy).
+          description: 'Secret Manager version for connection_params. When present, sensitive connection data is stored in Secret Manager. When None, connection_params are stored in GCS (legacy).'
         created_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Created By User Id
           description: User ID of target creator
         updated_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Updated By User Id
@@ -2054,6 +4117,17 @@ components:
           format: date-time
           title: Updated At
           description: Last update timestamp
+        profiling_status:
+          anyOf:
+          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: 'null'
+          description: Status of the profiling workflow
+        canonical_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Canonical Id
+          description: Partner-supplied stable identifier. Null for targets without partner integration metadata (most targets).
       type: object
       required:
       - uuid
@@ -2119,7 +4193,8 @@ components:
           - 429
         rate_limit_error_json:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Rate Limit Error Json
@@ -2127,9 +4202,7 @@ components:
           examples:
           - error:
               code: rate_limit_exceeded
-              message: 'Rate limit reached for o1-preview on requests per min (RPM):
-                Limit 20, Used 20, Requested 1. Please try again in 3s. Visit https://platform.openai.com/account/rate-limits
-                to learn more.'
+              message: 'Rate limit reached for o1-preview on requests per min (RPM): Limit 20, Used 20, Requested 1. Please try again in 3s. Visit https://platform.openai.com/account/rate-limits to learn more.'
               param: 'null'
               type: requests
         rate_limit_error_message:
@@ -2139,8 +4212,7 @@ components:
           title: Rate Limit Error Message
           description: Raw error message string for rate limit errors
           examples:
-          - 'Rate limit reached for o1-preview on requests per min (RPM): Limit 20,
-            Used 20, Requested 1. Please try again in 3s.'
+          - 'Rate limit reached for o1-preview on requests per min (RPM): Limit 20, Used 20, Requested 1. Please try again in 3s.'
         content_filter_enabled:
           type: boolean
           title: Content Filter Enabled
@@ -2156,7 +4228,8 @@ components:
           - 400
         content_filter_error_json:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Content Filter Error Json
@@ -2164,8 +4237,7 @@ components:
           examples:
           - error:
               code: invalid_prompt
-              message: 'Invalid prompt: your prompt was flagged as potentially violating
-                our usage policy. Please try again with a different prompt.'
+              message: 'Invalid prompt: your prompt was flagged as potentially violating our usage policy. Please try again with a different prompt.'
               type: invalid_request_error
         content_filter_error_message:
           anyOf:
@@ -2174,12 +4246,11 @@ components:
           title: Content Filter Error Message
           description: Raw error message string for content filter errors
           examples:
-          - 'Invalid prompt: your prompt was flagged as potentially violating our
-            usage policy. Please try again with a different prompt.'
+          - 'Invalid prompt: your prompt was flagged as potentially violating our usage policy. Please try again with a different prompt.'
         probe_message:
           type: string
           title: Probe Message
-          default: Hello, this is a test message from the red team validation system.
+          default: 'Hello, this is a test message from the red team validation system.'
         request_timeout:
           type: number
           title: Request Timeout
@@ -2189,25 +4260,53 @@ components:
           - 110
       type: object
       title: TargetMetadata
-      description: Metadata stored in the database for targets (user-provided + computed
-        fields).
+      description: Metadata stored in the database for targets (user-provided + computed fields).
     TargetProbeRequest:
       properties:
         connection_params:
           anyOf:
-          - $ref: '#/components/schemas/RestConnectionParamsBase-Input'
-          - $ref: '#/components/schemas/StreamingConnectionParamsBase-Input'
+          - oneOf:
+              - $ref: '#/components/schemas/NativeConnectionParamsBase-Input'
+              - $ref: '#/components/schemas/WebSocketConnectionParamsBase-Input'
+              - $ref: '#/components/schemas/StreamingConnectionParamsBase-Input'
+              - $ref: '#/components/schemas/RestConnectionParamsBase-Input'
           - type: 'null'
           title: Connection Params
           description: API connection parameters (sensitive data masked for security)
+          examples:
+          -
+            api_endpoint: https://api.openai.com/v1/responses
+            request_headers:
+              Authorization: Bearer sk-xxx
+              Content-Type: application/json
+            request_json:
+              input:
+              -
+                content:
+                -
+                  text: '{INPUT}'
+                  type: input_text
+                role: user
+              model: gpt-4.1-nano
+            response_json:
+              content: '{RESPONSE}'
+            response_key: content
+        auth_config:
+          anyOf:
+          - $ref: '#/components/schemas/HeadersAuthConfig'
+          - $ref: '#/components/schemas/BasicAuthAuthConfig'
+          - $ref: '#/components/schemas/OAuth2AuthConfig'
+          - type: 'null'
+          title: Auth Config
+          description: Authentication configuration (resolved based on auth_type)
         network_broker_channel_uuid:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Network Broker Channel Uuid
-          description: Network broker channel UUID for routing requests. Required
-            when api_endpoint_type is NETWORK_BROKER.
+          description: Network broker channel UUID for routing requests. Required when api_endpoint_type is NETWORK_BROKER.
           examples:
           - 550e8400-e29b-41d4-a716-446655440000
         name:
@@ -2222,7 +4321,7 @@ components:
           - type: 'null'
           title: Description
           description: Optional target description
-          default: null
+          default: 
           examples:
           - AI model for testing
         target_type:
@@ -2256,6 +4355,16 @@ components:
           examples:
           - REST
           - STREAMING
+          - WEBSOCKET
+        auth_type:
+          anyOf:
+          - $ref: '#/components/schemas/red_team_shared__schemas__auth_config__AuthType'
+          - type: 'null'
+          description: Authentication method for target API access
+          examples:
+          - HEADERS
+          - BASIC_AUTH
+          - OAUTH2
         session_supported:
           type: boolean
           title: Session Supported
@@ -2263,12 +4372,13 @@ components:
           default: false
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
           description: Additional configuration or metadata for the target
-          default: null
+          default: {}
           examples:
           - custom_key: custom_value
         target_metadata:
@@ -2283,39 +4393,42 @@ components:
           anyOf:
           - $ref: '#/components/schemas/TargetAdditionalContext'
           - type: 'null'
-          description: 'Additional context: base_model, system_prompt, languages,
-            etc.'
+          description: 'Additional context: base_model, system_prompt, languages, etc.'
+        canonical_id:
+          anyOf:
+          -
+            type: string
+            maxLength: 512
+          - type: 'null'
+          title: Canonical Id
+          description: Partner-supplied stable identifier (e.g. Discovery's id). Free-form opaque string; immutable once set.
         uuid:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Uuid
-          description: Target UUID. If provided, will be returned in response.
+          description: 'Target UUID. If provided, will be returned in response.'
         probe_fields:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
           title: Probe Fields
-          description: 'Specific probes to run. If None, runs all probes. Valid: industry,
-            use_case, competitors, base_model, core_architecture, languages_supported,
-            tools_accessible, system_prompt, banned_keywords'
+          description: 'Specific probes to run. If None, runs all probes. Valid: industry, use_case, competitors, base_model, core_architecture, languages_supported, tools_accessible, system_prompt, banned_keywords'
       additionalProperties: false
       type: object
       required:
       - name
       title: TargetProbeRequest
-      description: 'Request to run profiling probes on a target.
-
-
+      description: |
+        Request to run profiling probes on a target.
+        
         Inherits all target creation fields (connection params, metadata, etc.)
-
-        If probe_fields is None, runs all 9 probes. Otherwise runs only specified
-        probes.
-
-        '
+        If probe_fields is None, runs all 9 probes. Otherwise runs only specified probes.
     TargetProfileResponse:
       properties:
         target_id:
@@ -2340,21 +4453,43 @@ components:
           anyOf:
           - $ref: '#/components/schemas/OtherDetails'
           - type: 'null'
+        other_details_prettified:
+          anyOf:
+          - $ref: '#/components/schemas/OtherDetailsPrettified'
+          - type: 'null'
         ai_generated_fields:
           anyOf:
-          - items:
+          -
+            items:
               type: string
             type: array
           - type: 'null'
           title: Ai Generated Fields
-          description: Field names populated by AI profiler (e.g., competitors, base_model,
-            system_prompt)
+          description: 'Field names populated by AI profiler (e.g., competitors, base_model, system_prompt)'
+        ai_generated_items:
+          anyOf:
+          - $ref: '#/components/schemas/AiGeneratedItems'
+          - type: 'null'
+        profiling_completed_at:
+          anyOf:
+          -
+            type: string
+            format: date-time
+          - type: 'null'
+          title: Profiling Completed At
+          description: When profiling finished
         profiling_status:
           anyOf:
           - type: string
           - type: 'null'
           title: Profiling Status
           description: Status of the profiling workflow
+        profiling_progress:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Profiling Progress
+          description: Profiling progress percentage (0–100)
       type: object
       required:
       - target_id
@@ -2366,19 +4501,30 @@ components:
       properties:
         connection_params:
           anyOf:
-          - $ref: '#/components/schemas/RestConnectionParamsRedactBase'
-          - $ref: '#/components/schemas/StreamingConnectionParamsRedactBase'
+          - oneOf:
+              - $ref: '#/components/schemas/NativeConnectionParamsRedactBase'
+              - $ref: '#/components/schemas/WebSocketConnectionParamsRedactBase'
+              - $ref: '#/components/schemas/StreamingConnectionParamsRedactBase'
+              - $ref: '#/components/schemas/RestConnectionParamsRedactBase'
           - type: 'null'
           title: Connection Params
           description: API connection parameters (sensitive data masked for security)
+        auth_config:
+          anyOf:
+          - $ref: '#/components/schemas/HeadersAuthConfigRedact'
+          - $ref: '#/components/schemas/BasicAuthAuthConfigRedact'
+          - $ref: '#/components/schemas/OAuth2AuthConfigRedact'
+          - type: 'null'
+          title: Auth Config
+          description: Authentication configuration (sensitive data masked for security)
         network_broker_channel_uuid:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Network Broker Channel Uuid
-          description: Network broker channel UUID for routing requests. Required
-            when api_endpoint_type is NETWORK_BROKER.
+          description: Network broker channel UUID for routing requests. Required when api_endpoint_type is NETWORK_BROKER.
           examples:
           - 550e8400-e29b-41d4-a716-446655440000
         uuid:
@@ -2400,7 +4546,7 @@ components:
           - type: 'null'
           title: Description
           description: Optional target description
-          default: null
+          default: 
           examples:
           - AI model for testing
         target_type:
@@ -2434,6 +4580,16 @@ components:
           examples:
           - REST
           - STREAMING
+          - WEBSOCKET
+        auth_type:
+          anyOf:
+          - $ref: '#/components/schemas/red_team_shared__schemas__auth_config__AuthType'
+          - type: 'null'
+          description: Authentication method for target API access
+          examples:
+          - HEADERS
+          - BASIC_AUTH
+          - OAUTH2
         session_supported:
           type: boolean
           title: Session Supported
@@ -2441,12 +4597,13 @@ components:
           default: false
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
           description: Additional configuration or metadata for the target
-          default: null
+          default: {}
           examples:
           - custom_key: custom_value
         status:
@@ -2471,19 +4628,19 @@ components:
           - type: string
           - type: 'null'
           title: Secret Version
-          description: Secret Manager version for connection_params. When present,
-            sensitive connection data is stored in Secret Manager. When None, connection_params
-            are stored in GCS (legacy).
+          description: 'Secret Manager version for connection_params. When present, sensitive connection data is stored in Secret Manager. When None, connection_params are stored in GCS (legacy).'
         created_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Created By User Id
           description: User ID of target creator
         updated_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Updated By User Id
@@ -2498,6 +4655,17 @@ components:
           format: date-time
           title: Updated At
           description: Last update timestamp
+        profiling_status:
+          anyOf:
+          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: 'null'
+          description: Status of the profiling workflow
+        canonical_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Canonical Id
+          description: Partner-supplied stable identifier. Null for targets without partner integration metadata (most targets).
         target_metadata:
           $ref: '#/components/schemas/TargetMetadata'
           description: Target metadata and configuration options
@@ -2506,11 +4674,12 @@ components:
           - $ref: '#/components/schemas/TargetBackground'
           - type: 'null'
           description: 'Target background info: industry, use_case, competitors'
-        profiling_status:
+        profiling_progress:
           anyOf:
-          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: integer
           - type: 'null'
-          description: Status of the profiling workflow
+          title: Profiling Progress
+          description: Profiling progress percentage (0–100)
         additional_context:
           anyOf:
           - $ref: '#/components/schemas/TargetAdditionalContext'
@@ -2549,7 +4718,7 @@ components:
           - type: 'null'
           title: Description
           description: Optional target description
-          default: null
+          default: 
           examples:
           - AI model for testing
         target_type:
@@ -2583,6 +4752,16 @@ components:
           examples:
           - REST
           - STREAMING
+          - WEBSOCKET
+        auth_type:
+          anyOf:
+          - $ref: '#/components/schemas/red_team_shared__schemas__auth_config__AuthType'
+          - type: 'null'
+          description: Authentication method for target API access
+          examples:
+          - HEADERS
+          - BASIC_AUTH
+          - OAUTH2
         session_supported:
           type: boolean
           title: Session Supported
@@ -2590,12 +4769,13 @@ components:
           default: false
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
           description: Additional configuration or metadata for the target
-          default: null
+          default: {}
           examples:
           - custom_key: custom_value
         status:
@@ -2620,19 +4800,19 @@ components:
           - type: string
           - type: 'null'
           title: Secret Version
-          description: Secret Manager version for connection_params. When present,
-            sensitive connection data is stored in Secret Manager. When None, connection_params
-            are stored in GCS (legacy).
+          description: 'Secret Manager version for connection_params. When present, sensitive connection data is stored in Secret Manager. When None, connection_params are stored in GCS (legacy).'
         created_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Created By User Id
           description: User ID of target creator
         updated_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Updated By User Id
@@ -2647,6 +4827,17 @@ components:
           format: date-time
           title: Updated At
           description: Last update timestamp
+        profiling_status:
+          anyOf:
+          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: 'null'
+          description: Status of the profiling workflow
+        canonical_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Canonical Id
+          description: Partner-supplied stable identifier. Null for targets without partner integration metadata (most targets).
         target_metadata:
           $ref: '#/components/schemas/TargetMetadata'
           description: Target metadata and configuration options
@@ -2655,11 +4846,12 @@ components:
           - $ref: '#/components/schemas/TargetBackground'
           - type: 'null'
           description: 'Target background info: industry, use_case, competitors'
-        profiling_status:
+        profiling_progress:
           anyOf:
-          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: integer
           - type: 'null'
-          description: Status of the profiling workflow
+          title: Profiling Progress
+          description: Profiling progress percentage (0–100)
         additional_context:
           anyOf:
           - $ref: '#/components/schemas/TargetAdditionalContext'
@@ -2680,19 +4872,48 @@ components:
       properties:
         connection_params:
           anyOf:
-          - $ref: '#/components/schemas/RestConnectionParamsBase-Output'
-          - $ref: '#/components/schemas/StreamingConnectionParamsBase-Output'
+          - oneOf:
+              - $ref: '#/components/schemas/NativeConnectionParamsBase-Output'
+              - $ref: '#/components/schemas/WebSocketConnectionParamsBase-Output'
+              - $ref: '#/components/schemas/StreamingConnectionParamsBase-Output'
+              - $ref: '#/components/schemas/RestConnectionParamsBase-Output'
           - type: 'null'
           title: Connection Params
           description: API connection parameters (sensitive data masked for security)
+          examples:
+          -
+            api_endpoint: https://api.openai.com/v1/responses
+            request_headers:
+              Authorization: Bearer sk-xxx
+              Content-Type: application/json
+            request_json:
+              input:
+              -
+                content:
+                -
+                  text: '{INPUT}'
+                  type: input_text
+                role: user
+              model: gpt-4.1-nano
+            response_json:
+              content: '{RESPONSE}'
+            response_key: content
+        auth_config:
+          anyOf:
+          - $ref: '#/components/schemas/HeadersAuthConfig'
+          - $ref: '#/components/schemas/BasicAuthAuthConfig'
+          - $ref: '#/components/schemas/OAuth2AuthConfig'
+          - type: 'null'
+          title: Auth Config
+          description: Authentication configuration (resolved based on auth_type)
         network_broker_channel_uuid:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Network Broker Channel Uuid
-          description: Network broker channel UUID for routing requests. Required
-            when api_endpoint_type is NETWORK_BROKER.
+          description: Network broker channel UUID for routing requests. Required when api_endpoint_type is NETWORK_BROKER.
           examples:
           - 550e8400-e29b-41d4-a716-446655440000
         uuid:
@@ -2714,7 +4935,7 @@ components:
           - type: 'null'
           title: Description
           description: Optional target description
-          default: null
+          default: 
           examples:
           - AI model for testing
         target_type:
@@ -2748,6 +4969,16 @@ components:
           examples:
           - REST
           - STREAMING
+          - WEBSOCKET
+        auth_type:
+          anyOf:
+          - $ref: '#/components/schemas/red_team_shared__schemas__auth_config__AuthType'
+          - type: 'null'
+          description: Authentication method for target API access
+          examples:
+          - HEADERS
+          - BASIC_AUTH
+          - OAUTH2
         session_supported:
           type: boolean
           title: Session Supported
@@ -2755,12 +4986,13 @@ components:
           default: false
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
           description: Additional configuration or metadata for the target
-          default: null
+          default: {}
           examples:
           - custom_key: custom_value
         status:
@@ -2785,19 +5017,19 @@ components:
           - type: string
           - type: 'null'
           title: Secret Version
-          description: Secret Manager version for connection_params. When present,
-            sensitive connection data is stored in Secret Manager. When None, connection_params
-            are stored in GCS (legacy).
+          description: 'Secret Manager version for connection_params. When present, sensitive connection data is stored in Secret Manager. When None, connection_params are stored in GCS (legacy).'
         created_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Created By User Id
           description: User ID of target creator
         updated_by_user_id:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Updated By User Id
@@ -2812,6 +5044,17 @@ components:
           format: date-time
           title: Updated At
           description: Last update timestamp
+        profiling_status:
+          anyOf:
+          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: 'null'
+          description: Status of the profiling workflow
+        canonical_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Canonical Id
+          description: Partner-supplied stable identifier. Null for targets without partner integration metadata (most targets).
         target_metadata:
           $ref: '#/components/schemas/TargetMetadata'
           description: Target metadata and configuration options
@@ -2820,11 +5063,12 @@ components:
           - $ref: '#/components/schemas/TargetBackground'
           - type: 'null'
           description: 'Target background info: industry, use_case, competitors'
-        profiling_status:
+        profiling_progress:
           anyOf:
-          - $ref: '#/components/schemas/ProfilingStatus'
+          - type: integer
           - type: 'null'
-          description: Status of the profiling workflow
+          title: Profiling Progress
+          description: Profiling progress percentage (0–100)
         additional_context:
           anyOf:
           - $ref: '#/components/schemas/TargetAdditionalContext'
@@ -2841,18 +5085,13 @@ components:
       - created_at
       - updated_at
       title: TargetSchema
-      description: 'Target Get Schema with profiling fields.
-
-
+      description: |
+        Target Get Schema with profiling fields.
+        
         Inherits from TargetDetailSchema which includes:
-
         - target_background: industry, use_case, competitors
-
         - profiling_status: INIT, QUEUED, IN_PROGRESS, COMPLETED, FAILED
-
         - additional_context: merged user + profiler values with source tracking
-
-        '
     TargetStatus:
       type: string
       enum:
@@ -2865,6 +5104,26 @@ components:
       - PENDING_AUTH
       title: TargetStatus
       description: Status enumeration for scan targets.
+    TargetStatusFilter:
+      type: string
+      enum:
+      - DRAFT
+      - ACTIVE
+      - FAILED
+      - QUEUED
+      - IN_PROGRESS
+      - COMPLETED
+      - PARTIALLY_COMPLETE
+      title: TargetStatusFilter
+      description: |
+        Status values accepted by the list-targets ``status`` filter.
+        
+        Unions the target status and profiling status values so a single ``status``
+        filter can match on either. A supplied value matches a target whose target
+        status or profiling status equals it.
+        
+        Note (internal): keep members in sync with :class:`TargetStatus` and
+        :class:`ProfilingStatus`. ``FAILED`` is shared by both and defined once.
     TargetType:
       type: string
       enum:
@@ -2877,19 +5136,48 @@ components:
       properties:
         connection_params:
           anyOf:
-          - $ref: '#/components/schemas/RestConnectionParamsBase-Input'
-          - $ref: '#/components/schemas/StreamingConnectionParamsBase-Input'
+          - oneOf:
+              - $ref: '#/components/schemas/NativeConnectionParamsBase-Input'
+              - $ref: '#/components/schemas/WebSocketConnectionParamsBase-Input'
+              - $ref: '#/components/schemas/StreamingConnectionParamsBase-Input'
+              - $ref: '#/components/schemas/RestConnectionParamsBase-Input'
           - type: 'null'
           title: Connection Params
           description: API connection parameters (sensitive data masked for security)
+          examples:
+          -
+            api_endpoint: https://api.openai.com/v1/responses
+            request_headers:
+              Authorization: Bearer sk-xxx
+              Content-Type: application/json
+            request_json:
+              input:
+              -
+                content:
+                -
+                  text: '{INPUT}'
+                  type: input_text
+                role: user
+              model: gpt-4.1-nano
+            response_json:
+              content: '{RESPONSE}'
+            response_key: content
+        auth_config:
+          anyOf:
+          - $ref: '#/components/schemas/HeadersAuthConfig'
+          - $ref: '#/components/schemas/BasicAuthAuthConfig'
+          - $ref: '#/components/schemas/OAuth2AuthConfig'
+          - type: 'null'
+          title: Auth Config
+          description: Authentication configuration (resolved based on auth_type)
         network_broker_channel_uuid:
           anyOf:
-          - type: string
+          -
+            type: string
             format: uuid
           - type: 'null'
           title: Network Broker Channel Uuid
-          description: Network broker channel UUID for routing requests. Required
-            when api_endpoint_type is NETWORK_BROKER.
+          description: Network broker channel UUID for routing requests. Required when api_endpoint_type is NETWORK_BROKER.
           examples:
           - 550e8400-e29b-41d4-a716-446655440000
         name:
@@ -2904,7 +5192,7 @@ components:
           - type: 'null'
           title: Description
           description: Optional target description
-          default: null
+          default: 
           examples:
           - AI model for testing
         target_type:
@@ -2938,6 +5226,16 @@ components:
           examples:
           - REST
           - STREAMING
+          - WEBSOCKET
+        auth_type:
+          anyOf:
+          - $ref: '#/components/schemas/red_team_shared__schemas__auth_config__AuthType'
+          - type: 'null'
+          description: Authentication method for target API access
+          examples:
+          - HEADERS
+          - BASIC_AUTH
+          - OAUTH2
         session_supported:
           type: boolean
           title: Session Supported
@@ -2945,12 +5243,13 @@ components:
           default: false
         extra_info:
           anyOf:
-          - additionalProperties: true
+          -
+            additionalProperties: true
             type: object
           - type: 'null'
           title: Extra Info
           description: Additional configuration or metadata for the target
-          default: null
+          default: {}
           examples:
           - custom_key: custom_value
         target_metadata:
@@ -2965,14 +5264,43 @@ components:
           anyOf:
           - $ref: '#/components/schemas/TargetAdditionalContext'
           - type: 'null'
-          description: 'Additional context: base_model, system_prompt, languages,
-            etc.'
+          description: 'Additional context: base_model, system_prompt, languages, etc.'
+        canonical_id:
+          anyOf:
+          -
+            type: string
+            maxLength: 512
+          - type: 'null'
+          title: Canonical Id
+          description: Partner-supplied stable identifier (e.g. Discovery's id). Free-form opaque string; immutable once set.
       additionalProperties: false
       type: object
       required:
       - name
       title: TargetUpdateRequestSchema
       description: Schema for both create and update operations.
+    TenantLanguagesResponseSchema:
+      properties:
+        multilingual_enabled:
+          type: boolean
+          title: Multilingual Enabled
+        supported_job_types:
+          items:
+            type: string
+          type: array
+          title: Supported Job Types
+        languages:
+          items:
+            $ref: '#/components/schemas/LanguageOptionSchema'
+          type: array
+          title: Languages
+      type: object
+      required:
+      - multilingual_enabled
+      - supported_job_types
+      - languages
+      title: TenantLanguagesResponseSchema
+      description: Response for GET /v1/languages — tenant-facing language dropdown.
     ValidationError:
       properties:
         loc:
@@ -2994,1088 +5322,313 @@ components:
       - msg
       - type
       title: ValidationError
-ExternalTags:
-  CustomAttack:
-    title: CustomAttack
-    description: Operations for managing custom prompt sets, prompts, and properties.
-    tags:
-    - CustomAttack
-  Dashboard:
-    title: Dashboard
-    description: Operations for retrieving dashboard overview and statistics.
-    tags:
-    - Dashboard
-  HealthChecks:
-    title: HealthChecks
-    description: Operations related to health checks of the management plane service.
-    tags:
-    - HealthChecks
-  Target:
-    title: Target
-    description: Operations for managing scan targets (create, update, delete, list).
-    tags:
-    - Target
-paths:
-  /ready:
-    get:
-      summary: Readiness
-      description: Retrieve the ready details through this Application Programming
-        Interface endpoint.
-      operationId: readiness_ready_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                title: Response Readiness Ready Get
-        401:
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - HealthChecks
-  /liveness:
-    get:
-      summary: Liveness
-      description: Retrieve the liveness details through this Application Programming
-        Interface endpoint.
-      operationId: liveness_liveness_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                additionalProperties:
-                  type: boolean
-                type: object
-                title: Response Liveness Liveness Get
-        401:
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - HealthChecks
-  /v1/target:
-    post:
-      summary: Create target
-      description: Create a new scan target.
-      operationId: create_target_v1_target_post
-      responses:
-        201:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TargetResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: validate
-        in: query
-        required: false
-        schema:
-          type: boolean
-          description: Whether to validate target configuration
+    WebSocketConnectionParamsBase-Input:
+      properties:
+        api_endpoint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Api Endpoint
+          description: API endpoint URL
           examples:
-          - true
-          title: Validate
-        description: Whether to validate target configuration
-      tags:
-      - Target
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TargetCreateRequestSchema'
-    get:
-      summary: List targets
-      description: List all scan targets with pagination and filtering support.
-      operationId: list_targets_v1_target_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TargetListSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: skip
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          description: Number of records to skip
-          default: 0
-          title: Skip
-        description: Number of records to skip
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 100
-          minimum: 1
-          description: Maximum records to return
-          default: 10
-          title: Limit
-        description: Maximum records to return
-      - name: target_type
-        in: query
-        required: false
-        schema:
+          - https://api.openai.com/v1/responses
+        request_headers:
+          additionalProperties: true
+          type: object
+          title: Request Headers
+          description: Request headers
+          default: {}
+          examples:
+          -
+            Authorization: Bearer sk-xxx
+            Content-Type: application/json
+        request_json:
+          additionalProperties: true
+          type: object
+          title: Request Json
+          description: Request JSON
+          default: {}
+          examples:
+          -
+            input:
+            -
+              content:
+              -
+                text: '{INPUT}'
+                type: input_text
+              role: user
+            model: gpt-4.1-nano
+        response_json:
+          additionalProperties: true
+          type: object
+          title: Response Json
+          description: Response JSON
+          default: {}
+          examples:
+          - content: '{RESPONSE}'
+        response_key:
+          type: string
+          title: Response Key
+          description: Response key
+          default: 
+          examples:
+          - content
+        target_connection_config:
           anyOf:
-          - $ref: '#/components/schemas/TargetType'
+          - $ref: '#/components/schemas/OpenAIConnectionParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionParams'
+          - $ref: '#/components/schemas/DatabricksConnectionParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionParams'
           - type: 'null'
-          description: Filter by target type
-          title: Target Type
-        description: Filter by target type
-      - name: status
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - $ref: '#/components/schemas/TargetStatus'
-          - type: 'null'
-          description: Filter by status
-          title: Status
-        description: Filter by status
-      - name: search
-        in: query
-        required: false
-        schema:
+          title: Target Connection Config
+          description: Target Connection config of type openai/huggingface ..
+        curl:
           anyOf:
           - type: string
           - type: 'null'
-          description: Search target by name
-          title: Search
-        description: Search target by name
-      tags:
-      - Target
-  /v1/target/{target_uuid}:
-    get:
-      summary: Get target details
-      description: Retrieve a specific target by UUID with complete configuration
-        details and masked connection parameters.
-      operationId: get_target_v1_target__target_uuid__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TargetRedactSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: target_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Target Uuid
-      tags:
-      - Target
-    put:
-      summary: Update target
-      description: Update an existing target with new configuration and optional validation
-        control.
-      operationId: update_target_v1_target__target_uuid__put
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TargetSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: target_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Target Uuid
-      - name: validate
-        in: query
-        required: false
-        schema:
-          type: boolean
-          description: Whether to validate target configuration
-          default: true
-          title: Validate
-        description: Whether to validate target configuration
-      tags:
-      - Target
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TargetUpdateRequestSchema'
-    delete:
-      summary: Delete target
-      description: Permanently delete a target and its encrypted configuration data.
-      operationId: delete_target_v1_target__target_uuid__delete
-      responses:
-        204:
-          description: Successful Response
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: target_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Target Uuid
-      tags:
-      - Target
-  /v1/target/{target_uuid}/profile:
-    put:
-      summary: Update target profile
-      description: Update target background and additional context fields without
-        connection validation.
-      operationId: update_target_profile_v1_target__target_uuid__profile_put
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TargetSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: target_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Target Uuid
-      tags:
-      - Target
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TargetContextUpdateSchema'
-    get:
-      summary: Get profiling results
-      description: Get profiling results including merged user and profiler data.
-      operationId: get_profiling_results_v1_target__target_uuid__profile_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TargetProfileResponse'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: target_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Target Uuid
-      tags:
-      - Target
-  /v1/target/probe:
-    post:
-      summary: Run profiling probes on target
-      description: Send profiling questions to a target using provided connection
-        parameters. Returns TargetResponseSchema with target_background and additional_context
-        populated from probe responses.
-      operationId: run_target_probes_v1_target_probe_post
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TargetResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - Target
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TargetProbeRequest'
-        required: true
-  /v1/custom-attack/custom-prompt-set:
-    post:
-      summary: Create a new custom prompt set
-      description: Create a new custom prompt set.
-      operationId: create_prompt_set_v1_custom_attack_custom_prompt_set_post
-      responses:
-        201:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - CustomAttack
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CustomPromptSetCreateRequestSchema'
-        required: true
-  /v1/custom-attack/list-custom-prompt-sets:
-    get:
-      summary: List custom prompt sets
-      description: List all custom prompt sets with pagination and filtering support.
-      operationId: list_prompt_sets_v1_custom_attack_list_custom_prompt_sets_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptSetListSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: skip
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          description: Number of records to skip
-          default: 0
-          title: Skip
-        description: Number of records to skip
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 100
-          minimum: 1
-          description: Maximum records to return
-          default: 10
-          title: Limit
-        description: Maximum records to return
-      - name: status
-        in: query
-        required: false
-        schema:
+          title: Curl
+          description: Generated cURL command ready to use (redacted for security)
+          examples:
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+        multi_turn_config:
+          anyOf:
+          -
+            oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi turn config for stateful or stateless target
+          examples:
+          - 'assistant_role: assistant'
+        ws_response_timeout:
+          type: number
+          title: Ws Response Timeout
+          description: Timeout in seconds for waiting for a WebSocket response message
+          default: 110.0
+          examples:
+          - 60.0
+          - 110.0
+      type: object
+      title: WebSocketConnectionParamsBase
+      description: Connection parameters for WebSocket targets.
+    WebSocketConnectionParamsBase-Output:
+      properties:
+        api_endpoint:
           anyOf:
           - type: string
           - type: 'null'
-          description: Filter by status
-          title: Status
-        description: Filter by status
-      - name: active
-        in: query
-        required: false
-        schema:
+          title: Api Endpoint
+          description: API endpoint URL
+          examples:
+          - https://api.openai.com/v1/responses
+        request_headers:
+          additionalProperties: true
+          type: object
+          title: Request Headers
+          description: Request headers
+          default: {}
+          examples:
+          -
+            Authorization: Bearer sk-xxx
+            Content-Type: application/json
+        request_json:
+          additionalProperties: true
+          type: object
+          title: Request Json
+          description: Request JSON
+          default: {}
+          examples:
+          -
+            input:
+            -
+              content:
+              -
+                text: '{INPUT}'
+                type: input_text
+              role: user
+            model: gpt-4.1-nano
+        response_json:
+          additionalProperties: true
+          type: object
+          title: Response Json
+          description: Response JSON
+          default: {}
+          examples:
+          - content: '{RESPONSE}'
+        response_key:
+          type: string
+          title: Response Key
+          description: Response key
+          default: 
+          examples:
+          - content
+        target_connection_config:
           anyOf:
-          - type: boolean
+          - $ref: '#/components/schemas/OpenAIConnectionParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionParams'
+          - $ref: '#/components/schemas/DatabricksConnectionParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionParams'
           - type: 'null'
-          description: Filter by active status
-          title: Active
-        description: Filter by active status
-      - name: archive
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: boolean
-          - type: 'null'
-          description: Filter by archive status (None=non-archived only, True=archived
-            only, False=non-archived only)
-          title: Archive
-        description: Filter by archive status (None=non-archived only, True=archived
-          only, False=non-archived only)
-      - name: search
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          description: Search in name and description
-          title: Search
-        description: Search in name and description
-      tags:
-      - CustomAttack
-  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}:
-    get:
-      summary: Get prompt set details
-      description: Retrieve a specific prompt set by UUID with complete details including
-        properties.
-      operationId: get_prompt_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Uuid
-      tags:
-      - CustomAttack
-    put:
-      summary: Update prompt set
-      description: Update prompt set details including name, description, and properties.
-      operationId: update_prompt_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__put
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Uuid
-      tags:
-      - CustomAttack
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CustomPromptSetUpdateRequestSchema'
-  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/archive:
-    put:
-      summary: Archive or unarchive a prompt set
-      description: Archive or unarchive a prompt set to manage its lifecycle.
-      operationId: archive_prompt_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__archive_put
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptSetResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Uuid
-      tags:
-      - CustomAttack
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CustomPromptSetArchiveRequestSchema'
-  /v1/custom-attack/custom-prompt-set/custom-prompt:
-    post:
-      summary: Create prompt in a prompt set
-      description: Create a new prompt in a prompt set.
-      operationId: create_prompt_v1_custom_attack_custom_prompt_set_custom_prompt_post
-      responses:
-        201:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - CustomAttack
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CustomPromptCreateRequestSchema'
-        required: true
-  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/list-custom-prompts:
-    get:
-      summary: List prompts in a prompt set
-      description: List all prompts within a specific prompt set with pagination and
-        filtering.
-      operationId: list_prompts_in_set_v1_custom_attack_custom_prompt_set__prompt_set_uuid__list_custom_prompts_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptListSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Uuid
-      - name: skip
-        in: query
-        required: false
-        schema:
-          type: integer
-          minimum: 0
-          description: Number of records to skip
-          default: 0
-          title: Skip
-        description: Number of records to skip
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          maximum: 100
-          minimum: 1
-          description: Maximum records to return
-          default: 10
-          title: Limit
-        description: Maximum records to return
-      - name: status
-        in: query
-        required: false
-        schema:
+          title: Target Connection Config
+          description: Target Connection config of type openai/huggingface ..
+        curl:
           anyOf:
           - type: string
           - type: 'null'
-          description: Filter by status
-          title: Status
-        description: Filter by status
-      - name: active
-        in: query
-        required: false
-        schema:
+          title: Curl
+          description: Generated cURL command ready to use (redacted for security)
+          examples:
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+        multi_turn_config:
           anyOf:
-          - type: boolean
+          -
+            oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
           - type: 'null'
-          description: Filter by active status
-          title: Active
-        description: Filter by active status
-      - name: search
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          description: Search in prompt text
-          title: Search
-        description: Search in prompt text
-      tags:
-      - CustomAttack
-  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/custom-prompt/{prompt_uuid}:
-    get:
-      summary: Get prompt details
-      description: Get a specific prompt by UUID.
-      operationId: get_prompt_v1_custom_attack_custom_prompt_set__prompt_set_uuid__custom_prompt__prompt_uuid__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Uuid
-      - name: prompt_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Uuid
-      tags:
-      - CustomAttack
-    put:
-      summary: Update prompt
-      description: Update an existing prompt.
-      operationId: update_prompt_v1_custom_attack_custom_prompt_set__prompt_set_uuid__custom_prompt__prompt_uuid__put
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Uuid
-      - name: prompt_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Uuid
-      tags:
-      - CustomAttack
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CustomPromptUpdateRequestSchema'
-    delete:
-      summary: Delete prompt
-      description: Delete a prompt.
-      operationId: delete_prompt_v1_custom_attack_custom_prompt_set__prompt_set_uuid__custom_prompt__prompt_uuid__delete
-      responses:
-        204:
-          description: Successful Response
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Uuid
-      - name: prompt_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Uuid
-      tags:
-      - CustomAttack
-  /v1/custom-attack/property-names:
-    get:
-      summary: Get property names
-      description: Get all available property names for use in prompt sets.
-      operationId: get_property_names_v1_custom_attack_property_names_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PropertyNamesListResponseSchema'
-        401:
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - CustomAttack
-    post:
-      summary: Create property name
-      description: Create a new property name that can be used in prompt sets.
-      operationId: create_property_name_v1_custom_attack_property_names_post
-      responses:
-        201:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PropertyNamesListResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - CustomAttack
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PropertyNameCreateRequestSchema'
-        required: true
-  /v1/custom-attack/property-values/{property_name}:
-    get:
-      summary: Get property name
-      description: Get all available values for a specific property name.
-      operationId: get_property_values_v1_custom_attack_property_values__property_name__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PropertyValuesResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: property_name
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Property Name
-      tags:
-      - CustomAttack
-  /v1/custom-attack/property-values:
-    post:
-      summary: Create property value
-      description: Create a new value for an existing property name.
-      operationId: create_property_value_v1_custom_attack_property_values_post
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - CustomAttack
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PropertyValueCreateRequestSchema'
-    get:
-      summary: Get values for multiple property names
-      description: Get values for multiple property names in a single request.
-      operationId: get_property_values_multiple_v1_custom_attack_property_values_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PropertyValuesMultipleResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: property_names
-        in: query
-        required: true
-        schema:
-          type: string
-          description: Comma-separated list of property names
-          title: Property Names
-        description: Comma-separated list of property names
-      tags:
-      - CustomAttack
-  /v1/custom-attack/upload-custom-prompts-csv:
-    post:
-      summary: Upload custom prompts
-      description: Upload a CSV file containing custom prompts with properties for
-        a specific prompt set.
-      operationId: upload_prompts_csv_v1_custom_attack_upload_custom_prompts_csv_post
-      responses:
-        201:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseResponseSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: query
-        required: true
-        schema:
-          type: string
-          format: uuid
-          description: UUID of the prompt set
-          title: Prompt Set Uuid
-        description: UUID of the prompt set
-      tags:
-      - CustomAttack
-      requestBody:
-        required: true
-        content:
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Body_upload_prompts_csv_v1_custom_attack_upload_custom_prompts_csv_post'
-  /v1/custom-attack/download-template/{prompt_set_uuid}:
-    get:
-      summary: Download template for a prompt set
-      description: Download a CSV template with columns for the prompt set's properties.
-      operationId: download_template_v1_custom_attack_download_template__prompt_set_uuid__get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Uuid
-      tags:
-      - CustomAttack
-  /v1/custom-attack/active-custom-prompt-sets:
-    get:
-      summary: List active custom prompt sets
-      description: List all active custom prompt sets available for use by data plane.
-        Returns only sets with snapshots.
-      operationId: list_active_prompt_sets_v1_custom_attack_active_custom_prompt_sets_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptSetListActiveSchema'
-        401:
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - CustomAttack
-  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/reference:
-    get:
-      summary: Resolve prompt set reference
-      description: Get current reference information for a prompt set including latest
-        version.
-      operationId: resolve_prompt_set_reference_v1_custom_attack_custom_prompt_set__prompt_set_uuid__reference_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptSetReferenceSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Uuid
-      tags:
-      - CustomAttack
-  /v1/custom-attack/custom-prompt-set/{prompt_set_uuid}/version-info:
-    get:
-      summary: Get prompt set version information
-      description: Get detailed version information for a specific prompt set version.
-      operationId: get_prompt_set_version_info_v1_custom_attack_custom_prompt_set__prompt_set_uuid__version_info_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CustomPromptSetVersionInfoSchema'
-        422:
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters:
-      - name: prompt_set_uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Prompt Set Uuid
-      - name: version
-        in: query
-        required: false
-        schema:
+          title: Multi Turn Config
+          description: Multi turn config for stateful or stateless target
+          examples:
+          - 'assistant_role: assistant'
+        ws_response_timeout:
+          type: number
+          title: Ws Response Timeout
+          description: Timeout in seconds for waiting for a WebSocket response message
+          default: 110.0
+          examples:
+          - 60.0
+          - 110.0
+      type: object
+      title: WebSocketConnectionParamsBase
+      description: Connection parameters for WebSocket targets.
+    WebSocketConnectionParamsRedactBase:
+      properties:
+        api_endpoint:
           anyOf:
           - type: string
           - type: 'null'
-          description: Specific version ID
-          title: Version
-        description: Specific version ID
-      tags:
-      - CustomAttack
-  /v1/dashboard/overview:
-    get:
-      summary: Get dashboard
-      description: Returns target counts by type for dashboard display.
-      operationId: get_overview_v1_dashboard_overview_get
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DashboardOverviewResponseSchema'
-        401:
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      parameters: []
-      tags:
-      - Dashboard
+          title: Api Endpoint
+          description: API endpoint URL
+          examples:
+          - https://api.openai.com/v1/responses
+        request_headers:
+          additionalProperties: true
+          type: object
+          title: Request Headers
+          description: Request headers
+          default: {}
+          examples:
+          -
+            Authorization: Bearer sk-xxx
+            Content-Type: application/json
+        request_json:
+          additionalProperties: true
+          type: object
+          title: Request Json
+          description: Request JSON
+          default: {}
+          examples:
+          -
+            input:
+            -
+              content:
+              -
+                text: '{INPUT}'
+                type: input_text
+              role: user
+            model: gpt-4.1-nano
+        response_json:
+          additionalProperties: true
+          type: object
+          title: Response Json
+          description: Response JSON
+          default: {}
+          examples:
+          - content: '{RESPONSE}'
+        response_key:
+          type: string
+          title: Response Key
+          description: Response key
+          default: 
+          examples:
+          - content
+        target_connection_config:
+          anyOf:
+          - $ref: '#/components/schemas/OpenAIConnectionRedactParams'
+          - $ref: '#/components/schemas/HuggingfaceConnectionRedactParams'
+          - $ref: '#/components/schemas/DatabricksConnectionRedactParams'
+          - $ref: '#/components/schemas/BedrockAccessConnectionRedactParams'
+          - $ref: '#/components/schemas/MSCopilotStudioConnectionRedactParams'
+          - type: 'null'
+          title: Target Connection Config
+          description: Target Connection config of type openai/huggingface ..
+        curl:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Curl
+          description: Generated cURL command ready to use (redacted for security)
+          examples:
+          - 'curl "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer ***" -d ''{"model":"gpt-4","messages":[{"role":"user","content":"{INPUT}"}]}'''
+        multi_turn_config:
+          anyOf:
+          -
+            oneOf:
+            - $ref: '#/components/schemas/MultiTurnStatefulConfig'
+            - $ref: '#/components/schemas/MultiTurnStatelessConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                stateful: '#/components/schemas/MultiTurnStatefulConfig'
+                stateless: '#/components/schemas/MultiTurnStatelessConfig'
+          - type: 'null'
+          title: Multi Turn Config
+          description: Multi turn config for stateful or stateless target
+          examples:
+          - 'assistant_role: assistant'
+        ws_response_timeout:
+          type: number
+          title: Ws Response Timeout
+          description: Timeout in seconds for waiting for a WebSocket response message
+          default: 110.0
+          examples:
+          - 60.0
+          - 110.0
+      type: object
+      title: WebSocketConnectionParamsRedactBase
+      description: |
+        Redacted connection parameters for WebSocket targets.
+        
+        MRO: WebSocketConnectionParamsRedactBase → RestConnectionParamsRedactBase
+             → WebSocketConnectionParamsBase → RestConnectionParamsBase.
+        Both RestConnectionParamsRedactBase and WebSocketConnectionParamsBase inherit
+        from RestConnectionParamsBase (diamond). Pydantic v2 deduplicates field validators
+        by name, so WebSocketConnectionParamsBase.validate_url (ws/wss) overrides
+        RestConnectionParamsBase.validate_url (http/https) — ws:// URLs are accepted.
+    red_team_shared__schemas__auth_config__AuthType:
+      type: string
+      enum:
+      - HEADERS
+      - BASIC_AUTH
+      - OAUTH2
+      title: AuthType
+      description: Authentication method for target API access.
+    red_team_shared__schemas__databricks__AuthType:
+      type: string
+      enum:
+      - OAUTH
+      - ACCESS_TOKEN
+      title: AuthType

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -149,6 +149,8 @@ export const RED_TEAM_DASHBOARD_PATH = '/v1/dashboard';
 export const RED_TEAM_QUOTA_PATH = '/v1/metering/quota';
 export const RED_TEAM_ERROR_LOG_PATH = '/v1/error-log/job';
 export const RED_TEAM_SENTIMENT_PATH = '/v1/sentiment';
+export const RED_TEAM_LANGUAGES_PATH = '/v1/languages';
+export const RED_TEAM_ERROR_LOG_TARGET_PROFILE_PATH = '/v1/error-log/target-profile';
 
 // API paths — red team management plane
 export const RED_TEAM_TARGET_PATH = '/v1/target';

--- a/src/models/red-team.ts
+++ b/src/models/red-team.ts
@@ -1031,6 +1031,24 @@ export const ErrorLogListResponseSchema = z
 export type ErrorLogListResponse = z.infer<typeof ErrorLogListResponseSchema>;
 
 // ---------------------------------------------------------------------------
+// Supported languages (data plane & management plane)
+// ---------------------------------------------------------------------------
+
+/** A single language option (code + display name). */
+export const LanguageOptionSchema = z.object({ code: z.string(), name: z.string() }).passthrough();
+export type LanguageOption = z.infer<typeof LanguageOptionSchema>;
+
+/** Tenant's allowed languages for Red Team scans. */
+export const TenantLanguagesResponseSchema = z
+  .object({
+    multilingual_enabled: z.boolean(),
+    supported_job_types: z.array(z.string()),
+    languages: z.array(LanguageOptionSchema),
+  })
+  .passthrough();
+export type TenantLanguagesResponse = z.infer<typeof TenantLanguagesResponseSchema>;
+
+// ---------------------------------------------------------------------------
 // Management — Target schemas
 // ---------------------------------------------------------------------------
 

--- a/src/red-team/client.ts
+++ b/src/red-team/client.ts
@@ -8,6 +8,8 @@ import {
   RED_TEAM_DASHBOARD_PATH,
   RED_TEAM_QUOTA_PATH,
   RED_TEAM_ERROR_LOG_PATH,
+  RED_TEAM_ERROR_LOG_TARGET_PROFILE_PATH,
+  RED_TEAM_LANGUAGES_PATH,
   RED_TEAM_SENTIMENT_PATH,
   RED_TEAM_MGMT_DASHBOARD_PATH,
 } from '../constants.js';
@@ -32,6 +34,7 @@ import {
   ErrorLogListResponseSchema,
   SentimentResponseSchema,
   DashboardOverviewResponseSchema,
+  TenantLanguagesResponseSchema,
   type ScanStatisticsResponse,
   type ScoreTrendResponse,
   type QuotaSummary,
@@ -39,6 +42,7 @@ import {
   type SentimentRequest,
   type SentimentResponse,
   type DashboardOverviewResponse,
+  type TenantLanguagesResponse,
 } from '../models/red-team.js';
 
 /** Options for constructing a {@link RedTeamClient}. */
@@ -258,6 +262,88 @@ export class RedTeamClient {
       path: `${RED_TEAM_ERROR_LOG_PATH}/${jobId}`,
       params: serializeListing(opts),
       responseSchema: ErrorLogListResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * List profiling error logs for a target (data plane).
+   * @param targetId - The target UUID.
+   * @param opts - Optional pagination/search options (the endpoint honors `limit`).
+   * @returns The paginated list of target-profile error logs.
+   * @example
+   * ```ts
+   * import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
+   * const rt = new RedTeamClient();
+   *
+   * const logs = await rt.getTargetProfileErrorLogs('550e8400-e29b-41d4-a716-446655440000', { limit: 10 });
+   * // logs =>
+   * // { pagination: { total_items: 1 }, data: [{ target_id: '550e8400-...', error_type: 'PROBE', error_message: '...', created_at: '2025-01-01T00:00:00Z' }] }
+   * ```
+   */
+  async getTargetProfileErrorLogs(
+    targetId: string,
+    opts?: RedTeamListOptions,
+  ): Promise<ErrorLogListResponse> {
+    assertUuid(targetId, 'target id');
+    return request({
+      method: 'GET',
+      baseUrl: this.dataEndpoint,
+      path: `${RED_TEAM_ERROR_LOG_TARGET_PROFILE_PATH}/${targetId}`,
+      params: serializeListing(opts),
+      responseSchema: ErrorLogListResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Get the tenant's allowed languages for Red Team scans (data plane).
+   * @returns The supported-languages response.
+   * @example
+   * ```ts
+   * import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
+   * const rt = new RedTeamClient();
+   *
+   * const langs = await rt.getLanguages();
+   * // langs =>
+   * // { multilingual_enabled: true, supported_job_types: ['STATIC', 'DYNAMIC'],
+   * //   languages: [{ code: 'en', name: 'English' }, { code: 'es', name: 'Spanish' }] }
+   * ```
+   */
+  async getLanguages(): Promise<TenantLanguagesResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.dataEndpoint,
+      path: RED_TEAM_LANGUAGES_PATH,
+      responseSchema: TenantLanguagesResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Get the tenant's allowed languages from the management plane.
+   * Same response shape as {@link RedTeamClient.getLanguages}, served from the management endpoint.
+   * @returns The supported-languages response.
+   * @example
+   * ```ts
+   * import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
+   * const rt = new RedTeamClient();
+   *
+   * const langs = await rt.getManagementLanguages();
+   * // langs =>
+   * // { multilingual_enabled: true, supported_job_types: ['STATIC', 'DYNAMIC'],
+   * //   languages: [{ code: 'en', name: 'English' }] }
+   * ```
+   */
+  async getManagementLanguages(): Promise<TenantLanguagesResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.mgmtEndpoint,
+      path: RED_TEAM_LANGUAGES_PATH,
+      responseSchema: TenantLanguagesResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/test/models/red-team.spec.ts
+++ b/test/models/red-team.spec.ts
@@ -58,6 +58,8 @@ import {
   InstanceResponseSchema,
   InstanceGetResponseSchema,
   RegistryCredentialsSchema,
+  LanguageOptionSchema,
+  TenantLanguagesResponseSchema,
 } from '../../src/models/red-team.js';
 
 // ---------------------------------------------------------------------------
@@ -1786,5 +1788,35 @@ describe('RegistryCredentialsSchema', () => {
   it('passes through unknown fields', () => {
     const parsed = RegistryCredentialsSchema.parse({ token: 't', expiry: 'e', extra: 1 });
     expect((parsed as Record<string, unknown>).extra).toBe(1);
+  });
+});
+
+describe('TenantLanguagesResponseSchema', () => {
+  it('parses an upstream-shaped languages response', () => {
+    const parsed = TenantLanguagesResponseSchema.parse({
+      multilingual_enabled: true,
+      supported_job_types: ['STATIC', 'DYNAMIC'],
+      languages: [
+        { code: 'en', name: 'English' },
+        { code: 'es', name: 'Spanish' },
+      ],
+      future_field: 'kept',
+    });
+    expect(parsed.multilingual_enabled).toBe(true);
+    expect(parsed.languages).toHaveLength(2);
+    expect(parsed.languages[0]).toEqual({ code: 'en', name: 'English' });
+    expect((parsed as Record<string, unknown>).future_field).toBe('kept');
+  });
+
+  it('requires code and name on each language', () => {
+    expect(() => LanguageOptionSchema.parse({ code: 'en' })).toThrow();
+    expect(LanguageOptionSchema.parse({ code: 'en', name: 'English' })).toEqual({
+      code: 'en',
+      name: 'English',
+    });
+  });
+
+  it('requires the top-level fields', () => {
+    expect(() => TenantLanguagesResponseSchema.parse({ multilingual_enabled: true })).toThrow();
   });
 });

--- a/test/red-team/client.spec.ts
+++ b/test/red-team/client.spec.ts
@@ -310,4 +310,66 @@ describe('RedTeamClient', () => {
       expect(url).toContain('/v1/dashboard/overview');
     });
   });
+
+  const languagesResponse = {
+    multilingual_enabled: true,
+    supported_job_types: ['STATIC', 'DYNAMIC'],
+    languages: [
+      { code: 'en', name: 'English' },
+      { code: 'es', name: 'Spanish' },
+    ],
+  };
+
+  describe('getLanguages', () => {
+    it('GETs /v1/languages on the data plane', async () => {
+      mockTwoFetches(languagesResponse);
+      const client = makeClient();
+      const result = await client.getLanguages();
+      expect(result.multilingual_enabled).toBe(true);
+      expect(result.languages[0]).toEqual({ code: 'en', name: 'English' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain('/v1/languages');
+      expect(url).toContain('data-plane');
+    });
+  });
+
+  describe('getManagementLanguages', () => {
+    it('GETs /v1/languages on the management plane', async () => {
+      mockTwoFetches(languagesResponse);
+      const client = makeClient();
+      const result = await client.getManagementLanguages();
+      expect(result.supported_job_types).toEqual(['STATIC', 'DYNAMIC']);
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain('/v1/languages');
+      expect(url).toContain('mgmt-plane');
+    });
+  });
+
+  describe('getTargetProfileErrorLogs', () => {
+    it('GETs /v1/error-log/target-profile/:targetId', async () => {
+      mockTwoFetches({ pagination: { total_items: 0 }, data: [] });
+      const client = makeClient();
+      const result = await client.getTargetProfileErrorLogs(validUuid);
+      expect(result.data).toEqual([]);
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain(`/v1/error-log/target-profile/${validUuid}`);
+    });
+
+    it('serializes the limit option', async () => {
+      mockTwoFetches({ pagination: { total_items: 0 }, data: [] });
+      const client = makeClient();
+      await client.getTargetProfileErrorLogs(validUuid, { limit: 25 });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url).toContain('limit=25');
+    });
+
+    it('rejects invalid UUID', async () => {
+      const client = makeClient();
+      await expect(client.getTargetProfileErrorLogs('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
 });


### PR DESCRIPTION
Closes #190
Closes #191

## What

Two Red Team endpoints from the latest OpenAPI specs, added as `RedTeamClient` convenience methods:

- **Supported languages** — `getLanguages()` (data plane) and `getManagementLanguages()` (management plane), both `GET /v1/languages`. Returns `TenantLanguagesResponse` = `{ multilingual_enabled, supported_job_types, languages: { code, name }[] }`. New `TenantLanguagesResponseSchema` / `LanguageOptionSchema`.
- **Target-profile error log** — `getTargetProfileErrorLogs(targetId, opts?)` → `GET /v1/error-log/target-profile/{target_id}`. Reuses the existing `ErrorLogListResponse` (same upstream component as the job error-log). UUID-validated.

## Specs

Refreshes the committed Red Team OpenAPI specs (`PaloAltoNetworks-AIRS-RedTeam-DataPlane.yaml`, `-management.yaml`) to the latest upstream — **0 preflight drift** after refresh.

## Tests

`test/red-team/client.spec.ts` — path/plane assertions for both language methods and the target error-log (incl. `limit` serialization + UUID rejection). `test/models/red-team.spec.ts` — language schema parsing + required fields + passthrough.

## Verification

`format:check`, `lint`, `typecheck`, `preflight` (0 unacknowledged drift), `docs:check`, full Vitest (1336) pass locally.

## Notes

- The two new language schemas remain preflight-*unmatched* because the upstream component names carry a `Schema` suffix the resolver doesn't try. Improving that (and the 4 pre-existing divergences it would surface) is filed separately as #192 to keep this PR feature-focused.
- Non-breaking; ships **minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)