### PR TITLE
feat(model-security): add read-only models sub-client (model & model-version endpoints)

### DIFF
--- a/.changeset/0194-model-security-models.md
+++ b/.changeset/0194-model-security-models.md
@@ -1,0 +1,13 @@
+---
+'@cdot65/prisma-airs-sdk': minor
+---
+
+Add a read-only `models` sub-client to `ModelSecurityClient` covering the model and model-version endpoints:
+
+- `models.listModels(opts?)` — `GET /v1/models` with search, sort, and latest-version filters.
+- `models.getModel(uuid)` — `GET /v1/models/{uuid}`.
+- `models.listModelVersions(modelUuid, opts?)` — `GET /v1/models/{uuid}/model-versions`.
+- `models.getModelVersion(uuid)` — `GET /v1/model-versions/{uuid}`.
+- `models.listModelVersionFiles(modelVersionUuid, opts?)` — `GET /v1/model-versions/{uuid}/files`.
+
+Adds `Model`, `ModelVersion`, and their list schemas (reusing the existing pagination, eval-summary, and file schemas). Also refreshes the committed Model Security data-plane OpenAPI spec to the latest upstream revision.

--- a/docs-site/docs/guides/model-security-api.md
+++ b/docs-site/docs/guides/model-security-api.md
@@ -74,9 +74,10 @@ Token fetch, caching, and refresh are handled automatically. A single OAuth2 tok
 
 ### Architecture
 
-The client exposes three sub-clients:
+The client exposes four sub-clients:
 
 - `client.scans` -- data plane scan operations (create, list, get, evaluations, files, labels, violations)
+- `client.models` -- data plane read-only access to models and their versions/files
 - `client.securityGroups` -- management plane CRUD for security groups and their rule instances
 - `client.securityRules` -- management plane read-only access to security rules
 
@@ -203,6 +204,36 @@ const keys = await client.scans.getLabelKeys();
 
 // Get distinct values for a label key
 const values = await client.scans.getLabelValues('team');
+```
+
+## Models
+
+Where a scan is a single point-in-time job, a **model** is the persistent resource that aggregates every scan/version of a given model. The `models` sub-client is read-only and lives on the data plane.
+
+```ts
+// List models — supports search, sort, and latest-version filters
+const models = await client.models.listModels({
+  limit: 10,
+  search_query: 'llama',
+  sort_field: 'created_at',
+  sort_order: 'desc',
+  latest_version_outcomes: ['PASSED', 'FAILED'],
+});
+for (const m of models.models) {
+  console.log(m.uuid, m.name, m.latest_version_outcome);
+}
+
+// Get one model
+const model = await client.models.getModel('model-uuid');
+
+// List a model's versions
+const versions = await client.models.listModelVersions('model-uuid', { sort_order: 'desc' });
+
+// Get one version (carries an eval summary: rules_passed/rules_failed/total_rules)
+const version = await client.models.getModelVersion('model-version-uuid');
+
+// List the files in a version (same shape as scan files)
+const files = await client.models.listModelVersionFiles('model-version-uuid', { limit: 50 });
 ```
 
 ## Walkthrough: define a security group (your scan policy)

--- a/specs/AIRS-Model-Security-DataPlane.yaml
+++ b/specs/AIRS-Model-Security-DataPlane.yaml
@@ -2,10 +2,10 @@ openapi: 3.1.0
 info:
   title: Prisma AIRS AI Model Security API
   version: 0.1.0
-  description: "Use the Model Security Data Plane API to execute scans and manage\
-    \ your model data securely. This Open API spec file was created on February 24,\
-    \ 2026. \xA9 2026 Palo Alto Networks, Inc. Palo Alto Networks is a registered\
-    \ trademark of Palo Alto Networks. A list of our trademarks can be found at [https://www.paloaltonetworks.com/company/trademarks.html](https://www.paloaltonetworks.com/company/trademarks.html).\
+  description: "Model Security Data Plane API - Execute scans and manage model data\
+    \ This Open API spec file was created on May 04, 2026. \xA9 2026 Palo Alto Networks,\
+    \ Inc. Palo Alto Networks is a registered trademark of Palo Alto Networks. A list\
+    \ of our trademarks can be found at [https://www.paloaltonetworks.com/company/trademarks.html](https://www.paloaltonetworks.com/company/trademarks.html).\
     \ All other marks mentioned herein may be trademarks of their respective companies."
 components:
   schemas:
@@ -27,6 +27,8 @@ components:
       - MISSING_ARTIFACTS
       - WORKER_ERROR
       - POLICY_EVAL_ERROR
+      - RESOURCE_NOT_FOUND
+      - SCAN_DATA_PENDING
       title: ErrorCodes
       type: string
     EvalOutcome:
@@ -101,7 +103,10 @@ components:
           title: Path
           type: string
         result:
-          $ref: '#/components/schemas/FileScanResult'
+          anyOf:
+          - $ref: '#/components/schemas/FileScanResult'
+          - type: string
+          title: Result
         scan_uuid:
           anyOf:
           - format: uuid
@@ -113,7 +118,10 @@ components:
           title: Tsg Id
           type: string
         type:
-          $ref: '#/components/schemas/FileType'
+          anyOf:
+          - $ref: '#/components/schemas/FileType'
+          - type: string
+          title: Type
         updated_at:
           format: date-time
           title: Updated At
@@ -168,6 +176,17 @@ components:
           title: Issues Detected
         modelscan_status:
           $ref: '#/components/schemas/ModelScanStatus'
+        sha256:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Sha256
+        size_bytes:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Size Bytes
       required:
       - file_path
       - modelscan_status
@@ -269,6 +288,101 @@ components:
       properties: {}
       title: LabelsResponseSchema
       type: object
+    ModelListSchema:
+      description: Schema for listing models.
+      properties:
+        models:
+          items:
+            $ref: '#/components/schemas/ModelResponseSchema'
+          title: Models
+          type: array
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+      required:
+      - pagination
+      - models
+      title: ModelListSchema
+      type: object
+    ModelResponseSchema:
+      description: Schema for model responses.
+      properties:
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        latest_version_fingerprint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Latest Version Fingerprint
+        latest_version_formats:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Latest Version Formats
+        latest_version_hf_commit_sha:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Latest Version Hf Commit Sha
+        latest_version_outcome:
+          anyOf:
+          - $ref: '#/components/schemas/EvalOutcome'
+          - type: string
+          - type: 'null'
+          title: Latest Version Outcome
+        latest_version_revision:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Latest Version Revision
+        latest_version_scan_time:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Latest Version Scan Time
+        latest_version_source_types:
+          anyOf:
+          - items:
+              anyOf:
+              - $ref: '#/components/schemas/SourceType'
+              - type: string
+            type: array
+          - type: 'null'
+          title: Latest Version Source Types
+        latest_version_uuid:
+          anyOf:
+          - format: uuid
+            type: string
+          - type: 'null'
+          title: Latest Version Uuid
+        name:
+          maxLength: 256
+          title: Name
+          type: string
+        tsg_id:
+          maxLength: 64
+          title: Tsg Id
+          type: string
+        updated_at:
+          format: date-time
+          title: Updated At
+          type: string
+        uuid:
+          format: uuid
+          title: Uuid
+          type: string
+      required:
+      - uuid
+      - tsg_id
+      - created_at
+      - updated_at
+      - name
+      title: ModelResponseSchema
+      type: object
     ModelScanIssue:
       properties:
         description:
@@ -307,6 +421,134 @@ components:
       - ERROR
       title: ModelScanStatus
       type: string
+    ModelVersionListSchema:
+      description: Schema for listing model versions.
+      properties:
+        model_versions:
+          items:
+            $ref: '#/components/schemas/ModelVersionResponseSchema'
+          title: Model Versions
+          type: array
+        pagination:
+          $ref: '#/components/schemas/PaginationSchema'
+      required:
+      - pagination
+      - model_versions
+      title: ModelVersionListSchema
+      type: object
+    ModelVersionResponseSchema:
+      description: Schema for model version responses.
+      properties:
+        created_at:
+          format: date-time
+          title: Created At
+          type: string
+        file_count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: File Count
+        fingerprint:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Fingerprint
+        hf_commit_authors:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Hf Commit Authors
+        hf_commit_sha:
+          anyOf:
+          - maxLength: 128
+            type: string
+          - type: 'null'
+          title: Hf Commit Sha
+        hf_commit_title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Hf Commit Title
+        hf_model_name:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Hf Model Name
+        hf_organization:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Hf Organization
+        last_eval_outcome:
+          anyOf:
+          - $ref: '#/components/schemas/EvalOutcome'
+          - type: string
+          - type: 'null'
+          title: Last Eval Outcome
+        last_eval_summary:
+          anyOf:
+          - $ref: '#/components/schemas/EvalSummarySchema'
+          - type: 'null'
+        latest_scan_time:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Latest Scan Time
+        license:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: License
+        model_formats:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Model Formats
+        model_uuid:
+          format: uuid
+          title: Model Uuid
+          type: string
+        revision:
+          title: Revision
+          type: string
+        source_types:
+          anyOf:
+          - items:
+              anyOf:
+              - $ref: '#/components/schemas/SourceType'
+              - type: string
+            type: array
+          - type: 'null'
+          title: Source Types
+        tsg_id:
+          maxLength: 64
+          title: Tsg Id
+          type: string
+        updated_at:
+          format: date-time
+          title: Updated At
+          type: string
+        uuid:
+          format: uuid
+          title: Uuid
+          type: string
+      required:
+      - uuid
+      - tsg_id
+      - created_at
+      - updated_at
+      - revision
+      - model_uuid
+      title: ModelVersionResponseSchema
+      type: object
     PaginationSchema:
       properties:
         total_items:
@@ -337,12 +579,18 @@ components:
           title: Created At
           type: string
         result:
-          $ref: '#/components/schemas/RuleEvaluationResult'
+          anyOf:
+          - $ref: '#/components/schemas/RuleEvaluationResult'
+          - type: string
+          title: Result
         rule_description:
           title: Rule Description
           type: string
         rule_instance_state:
-          $ref: '#/components/schemas/RuleState'
+          anyOf:
+          - $ref: '#/components/schemas/RuleState'
+          - type: string
+          title: Rule Instance State
         rule_instance_uuid:
           format: uuid
           title: Rule Instance Uuid
@@ -419,14 +667,19 @@ components:
         error_code:
           anyOf:
           - $ref: '#/components/schemas/ErrorCodes'
+          - type: string
           - type: 'null'
+          title: Error Code
         error_message:
           anyOf:
           - type: string
           - type: 'null'
           title: Error Message
         eval_outcome:
-          $ref: '#/components/schemas/EvalOutcome'
+          anyOf:
+          - $ref: '#/components/schemas/EvalOutcome'
+          - type: string
+          title: Eval Outcome
         eval_summary:
           anyOf:
           - $ref: '#/components/schemas/EvalSummarySchema'
@@ -447,15 +700,20 @@ components:
           title: Model Uri
           type: string
         model_version_uuid:
-          format: uuid
+          anyOf:
+          - format: uuid
+            type: string
+          - type: 'null'
           title: Model Version Uuid
-          type: string
         owner:
           maxLength: 256
           title: Owner
           type: string
         scan_origin:
-          $ref: '#/components/schemas/ScanOrigin'
+          anyOf:
+          - $ref: '#/components/schemas/ScanOrigin'
+          - type: string
+          title: Scan Origin
         scanner_version:
           anyOf:
           - maxLength: 256
@@ -511,7 +769,6 @@ components:
       - scan_origin
       - security_group_uuid
       - security_group_name
-      - model_version_uuid
       - eval_outcome
       - source_type
       title: ScanBaseResponseSchema
@@ -566,7 +823,9 @@ components:
           - $ref: '#/components/schemas/ScanDetails'
           - type: 'null'
         scan_origin:
-          $ref: '#/components/schemas/ScanOrigin'
+          anyOf:
+          - $ref: '#/components/schemas/ScanOrigin'
+          - type: 'null'
         security_group_uuid:
           format: uuid
           title: Security Group Uuid
@@ -574,7 +833,6 @@ components:
       required:
       - model_uri
       - security_group_uuid
-      - scan_origin
       title: ScanCreateRequestSchema
       type: object
     ScanDetails:
@@ -636,6 +894,10 @@ components:
       type: object
     ScanListSchema:
       properties:
+        count_capped:
+          default: false
+          title: Count Capped
+          type: boolean
         pagination:
           $ref: '#/components/schemas/PaginationSchema'
         scans:
@@ -651,6 +913,8 @@ components:
     ScanOrigin:
       enum:
       - MODEL_SECURITY_SDK
+      - MODEL_SECURITY_API
+      - MODEL_SECURITY_FRONTEND
       - HUGGING_FACE
       title: ScanOrigin
       type: string
@@ -764,6 +1028,25 @@ components:
       - violations
       title: ViolationListSchema
       type: object
+    ViolationRemediationSchema:
+      description: "Remediation returned on violations \u2014 steps and reference\
+        \ URL only."
+      properties:
+        steps:
+          items:
+            maxLength: 1024
+            type: string
+          title: Steps
+          type: array
+        url:
+          maxLength: 256
+          title: Url
+          type: string
+      required:
+      - steps
+      - url
+      title: ViolationRemediationSchema
+      type: object
     ViolationResponseSchema:
       description: Schema for violation responses with enhanced rule details.
       properties:
@@ -786,6 +1069,12 @@ components:
             type: string
           - type: 'null'
           title: Hash
+        insights_url:
+          anyOf:
+          - maxLength: 1024
+            type: string
+          - type: 'null'
+          title: Insights Url
         module:
           anyOf:
           - type: string
@@ -796,11 +1085,16 @@ components:
           - type: string
           - type: 'null'
           title: Operator
+        remediation:
+          $ref: '#/components/schemas/ViolationRemediationSchema'
         rule_description:
           title: Rule Description
           type: string
         rule_instance_state:
-          $ref: '#/components/schemas/RuleState'
+          anyOf:
+          - $ref: '#/components/schemas/RuleState'
+          - type: string
+          title: Rule Instance State
         rule_instance_uuid:
           format: uuid
           title: Rule Instance Uuid
@@ -811,13 +1105,21 @@ components:
         threat:
           anyOf:
           - $ref: '#/components/schemas/ThreatCategory'
+          - type: string
           - type: 'null'
+          title: Threat
         threat_description:
           anyOf:
           - maxLength: 256
             type: string
           - type: 'null'
           title: Threat Description
+        threat_kb_url:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Threat Kb Url
         tsg_id:
           maxLength: 64
           title: Tsg Id
@@ -840,6 +1142,7 @@ components:
       - rule_name
       - rule_description
       - rule_instance_state
+      - remediation
       title: ViolationResponseSchema
       type: object
 servers:
@@ -849,8 +1152,8 @@ ExternalTags: {}
 paths:
   /v1/evaluations/{uuid}:
     get:
-      summary: Retrieve Rule Evaluation
-      description: Retrieve a specific evaluation to view detailed rule information.
+      summary: Get Evaluation
+      description: Get a specific evaluation with detailed rule information.
       operationId: get_evaluation_v1_evaluations__uuid__get
       responses:
         '200':
@@ -875,10 +1178,302 @@ paths:
           type: string
       tags:
       - Evaluations
+  /v1/model-versions/{uuid}:
+    get:
+      summary: Get Model Version
+      description: Get a specific model version by UUID.
+      operationId: get_model_version_v1_model_versions__uuid__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelVersionResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      tags:
+      - Model Versions
+  /v1/model-versions/{uuid}/files:
+    get:
+      summary: List Model Version Files
+      description: Get a paginated list of files for a model version with their latest
+        scan status.
+      operationId: list_model_version_files_v1_model_versions__uuid__files_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileListSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          maximum: 100
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          title: Skip
+          type: integer
+      tags:
+      - Model Versions
+  /v1/models:
+    get:
+      summary: List Models
+      description: Get a paginated list of models.
+      operationId: list_models_v1_models_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelListSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - description: Search by model name or UUID
+        in: query
+        name: search_query
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          description: Search by model name or UUID
+          title: Search Query
+      - description: Number of items to return
+        in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          description: Number of items to return
+          maximum: 100
+          minimum: 1
+          title: Limit
+          type: integer
+      - description: number of items to skip
+        in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          description: number of items to skip
+          minimum: 0
+          title: Skip
+          type: integer
+      - description: Field to sort by
+        in: query
+        name: sort_field
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortByDateField'
+          default: created_at
+          description: Field to sort by
+      - description: Direction to sort by
+        in: query
+        name: sort_order
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortDirection'
+          default: desc
+          description: Direction to sort by
+      - description: Filter by latest version eval outcomes
+        in: query
+        name: latest_version_outcomes
+        required: false
+        schema:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/EvalOutcome'
+            type: array
+          - type: 'null'
+          description: Filter by latest version eval outcomes
+          title: Latest Version Outcomes
+      - description: Filter by formats (models whose latest version contains ANY of
+          these)
+        in: query
+        name: latest_version_formats
+        required: false
+        schema:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          description: Filter by formats (models whose latest version contains ANY
+            of these)
+          title: Latest Version Formats
+      - description: Filter by source types (models whose latest version contains
+          ANY of these)
+        in: query
+        name: latest_version_source_types
+        required: false
+        schema:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/SourceType'
+            type: array
+          - type: 'null'
+          description: Filter by source types (models whose latest version contains
+            ANY of these)
+          title: Latest Version Source Types
+      - description: Filter models whose latest version was scanned before this time
+        in: query
+        name: latest_version_scan_time_before
+        required: false
+        schema:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          description: Filter models whose latest version was scanned before this
+            time
+          title: Latest Version Scan Time Before
+      - in: query
+        name: start_time
+        required: false
+        schema:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: Start Time
+      - in: query
+        name: end_time
+        required: false
+        schema:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          title: End Time
+      tags:
+      - Models
+  /v1/models/{uuid}:
+    get:
+      summary: Get Model
+      description: Get a specific model by UUID.
+      operationId: get_model_v1_models__uuid__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelResponseSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      tags:
+      - Models
+  /v1/models/{uuid}/model-versions:
+    get:
+      summary: List Model Versions
+      description: Get a paginated list of model versions for a specific model.
+      operationId: list_model_versions_v1_models__uuid__model_versions_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelVersionListSchema'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          format: uuid
+          title: Uuid
+          type: string
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          maximum: 100
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          title: Skip
+          type: integer
+      - in: query
+        name: sort_order
+        required: false
+        schema:
+          $ref: '#/components/schemas/SortDirection'
+          default: desc
+      tags:
+      - Models
   /v1/scans:
     get:
-      summary: List All Scans
-      description: Retrieve a paginated list of model security scans.
+      summary: List Scans
+      description: List scans.
       operationId: list_scans_v1_scans_get
       responses:
         '200':
@@ -938,6 +1533,17 @@ paths:
           - type: 'null'
           description: Filter by security group UUID
           title: Security Group Uuid
+      - description: Filter by model version UUID
+        in: query
+        name: model_version_uuid
+        required: false
+        schema:
+          anyOf:
+          - format: uuid
+            type: string
+          - type: 'null'
+          description: Filter by model version UUID
+          title: Model Version Uuid
       - description: A list of source types to filter by
         in: query
         name: source_types
@@ -994,8 +1600,8 @@ paths:
       tags:
       - Scans
     post:
-      summary: Create New Scan
-      description: Initiate a new model security scan.
+      summary: Create Scan
+      description: Create a new scan.
       operationId: create_scan_v1_scans_post
       responses:
         '201':
@@ -1021,9 +1627,9 @@ paths:
         required: true
   /v1/scans/label-keys:
     get:
-      summary: Retrieve Label Keys
-      description: Retrieve a list of distinct label keys across all scans. Filter
-        the results by prefix using the search parameter.
+      summary: List Scan Label Keys
+      description: Returns the list of distinct label keys across all scans. Use the
+        search parameter to filter by prefix.
       operationId: list_scan_label_keys_v1_scans_label_keys_get
       responses:
         '200':
@@ -1071,9 +1677,9 @@ paths:
       - Scan Labels
   /v1/scans/label-keys/{key}/values:
     get:
-      summary: Retrieve Key Values
-      description: Retrieve a list of distinct values for a specific label key across
-        all scans. Filter the results by prefix using the search parameter.
+      summary: List Scan Label Key Values
+      description: Returns the list of distinct values for a label key across all
+        scans. Use the search parameter to filter by prefix.
       operationId: list_scan_label_key_values_v1_scans_label_keys__key__values_get
       responses:
         '200':
@@ -1131,7 +1737,7 @@ paths:
   /v1/scans/{scan_uuid}/evaluations:
     get:
       summary: Get Scan Evaluations
-      description: Retrieve rule evaluations and detailed rule information for a specific
+      description: Get rule evaluations with detailed rule information for a specific
         scan.
       operationId: get_scan_evaluations_v1_scans__scan_uuid__evaluations_get
       responses:
@@ -1208,8 +1814,8 @@ paths:
       - Scans
   /v1/scans/{scan_uuid}/files:
     get:
-      summary: Retrieve Scan Files
-      description: Retrieve files for a specific scan organized in a tree structure.
+      summary: Get Files
+      description: Get files for a specific scan in a tree structure.
       operationId: get_files_v1_scans__scan_uuid__files_get
       responses:
         '200':
@@ -1285,7 +1891,7 @@ paths:
   /v1/scans/{scan_uuid}/labels:
     delete:
       summary: Delete Scan Labels
-      description: Delete labels matching the specified keys from the scan.
+      description: Deletes labels with the specified keys from the scan.
       operationId: delete_scan_labels_v1_scans__scan_uuid__labels_delete
       responses:
         '204':
@@ -1321,9 +1927,8 @@ paths:
       - Scan Labels
     post:
       summary: Add Scan Labels
-      description: Add labels to the specified scan. The Application Programming Interface
-        overwrites the existing label value if you provide a label key that already
-        exists on the scan.
+      description: Add labels to the scan. If a label key in the input already exists
+        on the scan, the label value will be overwritten with the value in the input.
       operationId: add_scan_labels_v1_scans__scan_uuid__labels_post
       responses:
         '200':
@@ -1356,8 +1961,8 @@ paths:
         required: true
     put:
       summary: Set Scan Labels
-      description: Set the labels for a scan to match the provided input. This operation
-        completely removes and replaces any existing labels.
+      description: Set the labels for a scan to the input labels. Removes any existing
+        labels.
       operationId: set_scan_labels_v1_scans__scan_uuid__labels_put
       responses:
         '200':
@@ -1391,8 +1996,8 @@ paths:
   /v1/scans/{scan_uuid}/rule-violations:
     get:
       summary: Get Scan Violations
-      description: Retrieve rule violations and view detailed rule information for
-        a specific scan.
+      description: Get rule violations with detailed rule information for a specific
+        scan.
       operationId: get_scan_violations_v1_scans__scan_uuid__rule_violations_get
       responses:
         '200':
@@ -1435,9 +2040,8 @@ paths:
       - Scans
   /v1/scans/{uuid}:
     get:
-      summary: Retrieve Specific Scan
-      description: Retrieve a specific scan by its UUID. You can optionally paginate
-        the associated violations.
+      summary: Get Scan
+      description: Get a scan by UUID. Optionally paginate violations.
       operationId: get_scan_v1_scans__uuid__get
       responses:
         '200':
@@ -1464,8 +2068,8 @@ paths:
       - Scans
   /v1/violations/{uuid}:
     get:
-      summary: Retrieve Specific Violation
-      description: Retrieve a specific violation to view its detailed rule information.
+      summary: Get Violation
+      description: Get a specific violation with detailed rule information.
       operationId: get_violation_v1_violations__uuid__get
       responses:
         '200':

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -115,6 +115,8 @@ export const MODEL_SEC_TOKEN_ENDPOINT = 'PANW_MODEL_SEC_TOKEN_ENDPOINT';
 export const MODEL_SEC_SCANS_PATH = '/v1/scans';
 export const MODEL_SEC_EVALUATIONS_PATH = '/v1/evaluations';
 export const MODEL_SEC_VIOLATIONS_PATH = '/v1/violations';
+export const MODEL_SEC_MODELS_PATH = '/v1/models';
+export const MODEL_SEC_MODEL_VERSIONS_PATH = '/v1/model-versions';
 
 // API paths — model security management
 export const MODEL_SEC_SECURITY_GROUPS_PATH = '/v1/security-groups';

--- a/src/model-security/client.ts
+++ b/src/model-security/client.ts
@@ -12,6 +12,7 @@ import { resolveOAuthConfig } from '../oauth-config.js';
 import { ModelSecurityScansClient } from './scans-client.js';
 import { ModelSecurityGroupsClient } from './security-groups-client.js';
 import { ModelSecurityRulesClient } from './security-rules-client.js';
+import { ModelSecurityModelsClient } from './models-client.js';
 import { PyPIAuthResponseSchema, type PyPIAuthResponse } from '../models/model-security.js';
 
 /** Options for constructing a {@link ModelSecurityClient}. */
@@ -54,6 +55,8 @@ export class ModelSecurityClient {
   public readonly securityGroups: ModelSecurityGroupsClient;
   /** Management plane security rule operations (read-only). */
   public readonly securityRules: ModelSecurityRulesClient;
+  /** Data plane model and model-version operations (read-only). */
+  public readonly models: ModelSecurityModelsClient;
 
   private readonly mgmtEndpoint: string;
   private readonly auth: AuthAdapter;
@@ -82,6 +85,7 @@ export class ModelSecurityClient {
     this.numRetries = numRetries;
 
     this.scans = new ModelSecurityScansClient({ baseUrl: dataEndpoint, auth, numRetries });
+    this.models = new ModelSecurityModelsClient({ baseUrl: dataEndpoint, auth, numRetries });
     this.securityGroups = new ModelSecurityGroupsClient({
       baseUrl: mgmtEndpoint,
       auth,

--- a/src/model-security/index.ts
+++ b/src/model-security/index.ts
@@ -20,3 +20,10 @@ export {
   type ModelSecurityRulesClientOptions,
   type ModelSecurityRuleListOptions,
 } from './security-rules-client.js';
+export {
+  ModelSecurityModelsClient,
+  type ModelSecurityModelsClientOptions,
+  type ModelSecurityModelListOptions,
+  type ModelSecurityModelVersionListOptions,
+  type ModelSecurityModelVersionFileListOptions,
+} from './models-client.js';

--- a/src/model-security/models-client.ts
+++ b/src/model-security/models-client.ts
@@ -1,0 +1,234 @@
+import { MODEL_SEC_MODELS_PATH, MODEL_SEC_MODEL_VERSIONS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { serializeListing, type ListingOptions } from '../listing.js';
+import { assertUuid } from '../validators.js';
+import {
+  ModelResponseSchema,
+  ModelListSchema,
+  ModelVersionResponseSchema,
+  ModelVersionListSchema,
+  FileListSchema,
+  type Model,
+  type ModelList,
+  type ModelVersion,
+  type ModelVersionList,
+  type FileList,
+} from '../models/model-security.js';
+
+/** Pagination + filter options for listing models. */
+export interface ModelSecurityModelListOptions extends ListingOptions {
+  /** Search query (matches model UUID or name). */
+  search_query?: string;
+  /** Sort field: 'created_at' or 'updated_at'. */
+  sort_field?: string;
+  /** Sort order: 'asc' or 'desc'. */
+  sort_order?: string;
+  /** Filter by the latest version's evaluation outcomes (array). */
+  latest_version_outcomes?: string[];
+  /** Filter by the latest version's model formats (array). */
+  latest_version_formats?: string[];
+  /** Filter by the latest version's source types (array). */
+  latest_version_source_types?: string[];
+  /** Only models whose latest version was scanned before this ISO datetime. */
+  latest_version_scan_time_before?: string;
+  /** Filter by created start time (ISO datetime). */
+  start_time?: string;
+  /** Filter by created end time (ISO datetime). */
+  end_time?: string;
+}
+
+/** Pagination + sort options for listing a model's versions. */
+export interface ModelSecurityModelVersionListOptions extends ListingOptions {
+  /** Sort order: 'asc' or 'desc'. */
+  sort_order?: string;
+}
+
+/** Pagination options for listing a model version's files. */
+export type ModelSecurityModelVersionFileListOptions = ListingOptions;
+
+/** @internal */
+export interface ModelSecurityModelsClientOptions {
+  baseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+}
+
+function buildModelListParams(
+  opts?: ModelSecurityModelListOptions,
+): Record<string, string | string[]> {
+  const params: Record<string, string | string[]> = serializeListing(opts);
+  if (opts?.search_query !== undefined) params.search_query = opts.search_query;
+  if (opts?.sort_field !== undefined) params.sort_field = opts.sort_field;
+  if (opts?.sort_order !== undefined) params.sort_order = opts.sort_order;
+  if (opts?.latest_version_outcomes !== undefined)
+    params.latest_version_outcomes = opts.latest_version_outcomes;
+  if (opts?.latest_version_formats !== undefined)
+    params.latest_version_formats = opts.latest_version_formats;
+  if (opts?.latest_version_source_types !== undefined)
+    params.latest_version_source_types = opts.latest_version_source_types;
+  if (opts?.latest_version_scan_time_before !== undefined)
+    params.latest_version_scan_time_before = opts.latest_version_scan_time_before;
+  if (opts?.start_time !== undefined) params.start_time = opts.start_time;
+  if (opts?.end_time !== undefined) params.end_time = opts.end_time;
+  return params;
+}
+
+/** Client for Model Security data plane model and model-version operations (read-only). */
+export class ModelSecurityModelsClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: ModelSecurityModelsClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List models with optional search, sort, and latest-version filters.
+   * @param opts - Pagination and filter options.
+   * @returns Paginated list of models.
+   * @example
+   * ```ts
+   * import { ModelSecurityClient } from '@cdot65/prisma-airs-sdk';
+   * const ms = new ModelSecurityClient();
+   *
+   * const models = await ms.models.listModels({ limit: 10, search_query: 'llama' });
+   * // models =>
+   * // { pagination: { total_items: 3 }, models: [{ uuid: '550e8400-...', name: 'org/llama', latest_version_outcome: 'PASSED' }] }
+   * ```
+   */
+  async listModels(opts?: ModelSecurityModelListOptions): Promise<ModelList> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: MODEL_SEC_MODELS_PATH,
+      params: buildModelListParams(opts),
+      responseSchema: ModelListSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Get a single model by UUID.
+   * @param uuid - Model UUID.
+   * @returns The model.
+   * @example
+   * ```ts
+   * import { ModelSecurityClient } from '@cdot65/prisma-airs-sdk';
+   * const ms = new ModelSecurityClient();
+   *
+   * const model = await ms.models.getModel('550e8400-e29b-41d4-a716-446655440000');
+   * // model =>
+   * // { uuid: '550e8400-...', name: 'org/model', latest_version_uuid: '660e8400-...', latest_version_outcome: 'PASSED' }
+   * ```
+   */
+  async getModel(uuid: string): Promise<Model> {
+    assertUuid(uuid, 'model uuid');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_MODELS_PATH}/${uuid}`,
+      responseSchema: ModelResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * List the versions of a model.
+   * @param modelUuid - Model UUID.
+   * @param opts - Pagination and sort options.
+   * @returns Paginated list of model versions.
+   * @example
+   * ```ts
+   * import { ModelSecurityClient } from '@cdot65/prisma-airs-sdk';
+   * const ms = new ModelSecurityClient();
+   *
+   * const versions = await ms.models.listModelVersions('550e8400-e29b-41d4-a716-446655440000', {
+   *   sort_order: 'desc',
+   * });
+   * // versions =>
+   * // { pagination: { total_items: 2 }, model_versions: [{ uuid: '660e8400-...', revision: 'main', file_count: 12 }] }
+   * ```
+   */
+  async listModelVersions(
+    modelUuid: string,
+    opts?: ModelSecurityModelVersionListOptions,
+  ): Promise<ModelVersionList> {
+    assertUuid(modelUuid, 'model uuid');
+    const params = serializeListing(opts);
+    if (opts?.sort_order !== undefined) params.sort_order = opts.sort_order;
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_MODELS_PATH}/${modelUuid}/model-versions`,
+      params,
+      responseSchema: ModelVersionListSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Get a single model version by UUID.
+   * @param uuid - Model version UUID.
+   * @returns The model version.
+   * @example
+   * ```ts
+   * import { ModelSecurityClient } from '@cdot65/prisma-airs-sdk';
+   * const ms = new ModelSecurityClient();
+   *
+   * const version = await ms.models.getModelVersion('660e8400-e29b-41d4-a716-446655440000');
+   * // version =>
+   * // { uuid: '660e8400-...', revision: 'main', model_uuid: '550e8400-...', last_eval_outcome: 'PASSED' }
+   * ```
+   */
+  async getModelVersion(uuid: string): Promise<ModelVersion> {
+    assertUuid(uuid, 'model version uuid');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_MODEL_VERSIONS_PATH}/${uuid}`,
+      responseSchema: ModelVersionResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * List the files of a model version.
+   * @param modelVersionUuid - Model version UUID.
+   * @param opts - Pagination options.
+   * @returns Paginated list of files (same shape as scan files).
+   * @example
+   * ```ts
+   * import { ModelSecurityClient } from '@cdot65/prisma-airs-sdk';
+   * const ms = new ModelSecurityClient();
+   *
+   * const files = await ms.models.listModelVersionFiles('660e8400-e29b-41d4-a716-446655440000', {
+   *   limit: 50,
+   * });
+   * // files =>
+   * // { pagination: { total_items: 12 }, files: [{ uuid: '770e8400-...', path: '/model.safetensors', type: 'FILE', result: 'SUCCESS' }] }
+   * ```
+   */
+  async listModelVersionFiles(
+    modelVersionUuid: string,
+    opts?: ModelSecurityModelVersionFileListOptions,
+  ): Promise<FileList> {
+    assertUuid(modelVersionUuid, 'model version uuid');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${MODEL_SEC_MODEL_VERSIONS_PATH}/${modelVersionUuid}/files`,
+      params: serializeListing(opts),
+      responseSchema: FileListSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/models/model-security.ts
+++ b/src/models/model-security.ts
@@ -252,6 +252,77 @@ export const FileListSchema = z
 export type FileList = z.infer<typeof FileListSchema>;
 
 // ---------------------------------------------------------------------------
+// DataPlane — Model & model-version resources
+// ---------------------------------------------------------------------------
+
+/**
+ * A model resource (aggregate over its versions). Enum-typed fields are modeled as strings
+ * to tolerate new backend values, consistent with the rest of the Model Security schemas.
+ */
+export const ModelResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    name: z.string(),
+    latest_version_uuid: z.string().nullable().optional(),
+    latest_version_fingerprint: z.string().nullable().optional(),
+    latest_version_revision: z.string().nullable().optional(),
+    latest_version_hf_commit_sha: z.string().nullable().optional(),
+    latest_version_outcome: z.string().nullable().optional(),
+    latest_version_formats: z.array(z.string()).nullable().optional(),
+    latest_version_source_types: z.array(z.string()).nullable().optional(),
+    latest_version_scan_time: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type Model = z.infer<typeof ModelResponseSchema>;
+
+/** Paginated list of models. */
+export const ModelListSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    models: z.array(ModelResponseSchema),
+  })
+  .passthrough();
+export type ModelList = z.infer<typeof ModelListSchema>;
+
+/** A specific version (revision) of a model. */
+export const ModelVersionResponseSchema = z
+  .object({
+    uuid: z.string(),
+    tsg_id: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    revision: z.string(),
+    model_uuid: z.string(),
+    fingerprint: z.string().nullable().optional(),
+    file_count: z.number().int().nullable().optional(),
+    license: z.string().nullable().optional(),
+    latest_scan_time: z.string().nullable().optional(),
+    hf_commit_sha: z.string().nullable().optional(),
+    hf_commit_title: z.string().nullable().optional(),
+    hf_commit_authors: z.array(z.string()).nullable().optional(),
+    hf_model_name: z.string().nullable().optional(),
+    hf_organization: z.string().nullable().optional(),
+    model_formats: z.array(z.string()).nullable().optional(),
+    source_types: z.array(z.string()).nullable().optional(),
+    last_eval_outcome: z.string().nullable().optional(),
+    last_eval_summary: EvalSummarySchema.nullable().optional(),
+  })
+  .passthrough();
+export type ModelVersion = z.infer<typeof ModelVersionResponseSchema>;
+
+/** Paginated list of model versions. */
+export const ModelVersionListSchema = z
+  .object({
+    pagination: ModelSecurityPaginationSchema,
+    model_versions: z.array(ModelVersionResponseSchema),
+  })
+  .passthrough();
+export type ModelVersionList = z.infer<typeof ModelVersionListSchema>;
+
+// ---------------------------------------------------------------------------
 // DataPlane — Rule evaluation response
 // ---------------------------------------------------------------------------
 

--- a/test/model-security/client.spec.ts
+++ b/test/model-security/client.spec.ts
@@ -3,6 +3,7 @@ import { ModelSecurityClient } from '../../src/model-security/client.js';
 import { ModelSecurityScansClient } from '../../src/model-security/scans-client.js';
 import { ModelSecurityGroupsClient } from '../../src/model-security/security-groups-client.js';
 import { ModelSecurityRulesClient } from '../../src/model-security/security-rules-client.js';
+import { ModelSecurityModelsClient } from '../../src/model-security/models-client.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 describe('ModelSecurityClient', () => {
@@ -23,6 +24,7 @@ describe('ModelSecurityClient', () => {
     expect(client.scans).toBeInstanceOf(ModelSecurityScansClient);
     expect(client.securityGroups).toBeInstanceOf(ModelSecurityGroupsClient);
     expect(client.securityRules).toBeInstanceOf(ModelSecurityRulesClient);
+    expect(client.models).toBeInstanceOf(ModelSecurityModelsClient);
   });
 
   it('reads credentials from MODEL_SEC env vars', () => {

--- a/test/model-security/models-client.spec.ts
+++ b/test/model-security/models-client.spec.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ModelSecurityModelsClient } from '../../src/model-security/models-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+const now = '2025-01-01T00:00:00Z';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+function lastCall() {
+  return (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+}
+
+const sampleModel = {
+  uuid: validUuid,
+  tsg_id: '123',
+  created_at: now,
+  updated_at: now,
+  name: 'org/model',
+};
+
+const sampleVersion = {
+  uuid: validUuid,
+  tsg_id: '123',
+  created_at: now,
+  updated_at: now,
+  revision: 'main',
+  model_uuid: validUuid,
+};
+
+const sampleFile = {
+  uuid: validUuid,
+  tsg_id: '123',
+  created_at: now,
+  updated_at: now,
+  path: '/model.bin',
+  parent_path: '/',
+  type: 'FILE',
+  result: 'SUCCESS',
+  model_version_uuid: validUuid,
+};
+
+describe('ModelSecurityModelsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: ModelSecurityModelsClient;
+
+  beforeEach(() => {
+    client = new ModelSecurityModelsClient({
+      baseUrl: 'https://data.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('listModels', () => {
+    it('GETs /v1/models', async () => {
+      mockFetch({ pagination: { total_items: 1 }, models: [sampleModel] });
+      const result = await client.listModels();
+
+      expect(result.models).toHaveLength(1);
+      expect(result.models[0].name).toBe('org/model');
+      const [url, init] = lastCall();
+      expect(url).toBe('https://data.example.com/v1/models');
+      expect(init.method).toBe('GET');
+    });
+
+    it('serializes pagination, search_query, sort, and repeated array filters', async () => {
+      mockFetch({ pagination: { total_items: 0 }, models: [] });
+      await client.listModels({
+        limit: 10,
+        skip: 5,
+        search_query: 'llama',
+        sort_field: 'created_at',
+        sort_order: 'asc',
+        latest_version_outcomes: ['PASSED', 'FAILED'],
+        latest_version_source_types: ['HUGGING_FACE'],
+        start_time: '2025-01-01T00:00:00Z',
+      });
+
+      const [url] = lastCall();
+      const params = new URL(url).searchParams;
+      expect(params.get('limit')).toBe('10');
+      expect(params.get('skip')).toBe('5');
+      expect(params.get('search_query')).toBe('llama');
+      expect(params.get('sort_field')).toBe('created_at');
+      expect(params.get('sort_order')).toBe('asc');
+      expect(params.getAll('latest_version_outcomes')).toEqual(['PASSED', 'FAILED']);
+      expect(params.get('latest_version_source_types')).toBe('HUGGING_FACE');
+      expect(params.get('start_time')).toBe('2025-01-01T00:00:00Z');
+    });
+  });
+
+  describe('getModel', () => {
+    it('GETs /v1/models/{uuid}', async () => {
+      mockFetch(sampleModel);
+      const result = await client.getModel(validUuid);
+
+      expect(result.uuid).toBe(validUuid);
+      const [url] = lastCall();
+      expect(url).toBe(`https://data.example.com/v1/models/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getModel('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('listModelVersions', () => {
+    it('GETs /v1/models/{uuid}/model-versions', async () => {
+      mockFetch({ pagination: { total_items: 1 }, model_versions: [sampleVersion] });
+      const result = await client.listModelVersions(validUuid, { sort_order: 'desc', limit: 5 });
+
+      expect(result.model_versions).toHaveLength(1);
+      const [url] = lastCall();
+      expect(url).toContain(`/v1/models/${validUuid}/model-versions`);
+      expect(url).toContain('sort_order=desc');
+      expect(url).toContain('limit=5');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.listModelVersions('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('getModelVersion', () => {
+    it('GETs /v1/model-versions/{uuid}', async () => {
+      mockFetch(sampleVersion);
+      const result = await client.getModelVersion(validUuid);
+
+      expect(result.revision).toBe('main');
+      const [url] = lastCall();
+      expect(url).toBe(`https://data.example.com/v1/model-versions/${validUuid}`);
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.getModelVersion('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+
+  describe('listModelVersionFiles', () => {
+    it('GETs /v1/model-versions/{uuid}/files', async () => {
+      mockFetch({ pagination: { total_items: 1 }, files: [sampleFile] });
+      const result = await client.listModelVersionFiles(validUuid, { limit: 20 });
+
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0].path).toBe('/model.bin');
+      const [url] = lastCall();
+      expect(url).toContain(`/v1/model-versions/${validUuid}/files`);
+      expect(url).toContain('limit=20');
+    });
+
+    it('rejects invalid UUID', async () => {
+      await expect(client.listModelVersionFiles('bad')).rejects.toThrow(AISecSDKException);
+    });
+  });
+});

--- a/test/models/model-security.spec.ts
+++ b/test/models/model-security.spec.ts
@@ -33,6 +33,10 @@ import {
   ModelSecurityGroupUpdateRequestSchema,
   ListModelSecurityGroupsResponseSchema,
   PyPIAuthResponseSchema,
+  ModelResponseSchema,
+  ModelListSchema,
+  ModelVersionResponseSchema,
+  ModelVersionListSchema,
 } from '../../src/models/model-security.js';
 
 // ---------------------------------------------------------------------------
@@ -532,5 +536,63 @@ describe('PyPIAuthResponseSchema', () => {
     const data = { url: 'https://x.com', expires_at: now, extra: 'field' };
     const parsed = PyPIAuthResponseSchema.parse(data);
     expect((parsed as Record<string, unknown>).extra).toBe('field');
+  });
+});
+
+describe('Model / ModelVersion schemas', () => {
+  const now = '2025-01-01T00:00:00Z';
+  const uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+  it('ModelListSchema parses a populated list and passes through extras', () => {
+    const parsed = ModelListSchema.parse({
+      pagination: { total_items: 1 },
+      models: [
+        {
+          uuid,
+          tsg_id: '123',
+          created_at: now,
+          updated_at: now,
+          name: 'org/model',
+          latest_version_outcome: 'PASSED',
+          latest_version_formats: ['safetensors'],
+          latest_version_source_types: ['HUGGING_FACE'],
+          future_field: 1,
+        },
+      ],
+    });
+    expect(parsed.models[0].name).toBe('org/model');
+    expect(parsed.models[0].latest_version_outcome).toBe('PASSED');
+    expect((parsed.models[0] as Record<string, unknown>).future_field).toBe(1);
+  });
+
+  it('ModelResponseSchema requires the core fields', () => {
+    expect(() => ModelResponseSchema.parse({ uuid, tsg_id: '123' })).toThrow();
+  });
+
+  it('ModelVersionListSchema parses versions with an eval summary', () => {
+    const parsed = ModelVersionListSchema.parse({
+      pagination: { total_items: 1 },
+      model_versions: [
+        {
+          uuid,
+          tsg_id: '123',
+          created_at: now,
+          updated_at: now,
+          revision: 'main',
+          model_uuid: uuid,
+          file_count: 3,
+          last_eval_outcome: 'FAILED',
+          last_eval_summary: { rules_failed: 1, rules_passed: 2, total_rules: 3 },
+        },
+      ],
+    });
+    expect(parsed.model_versions[0].revision).toBe('main');
+    expect(parsed.model_versions[0].last_eval_summary?.rules_failed).toBe(1);
+  });
+
+  it('ModelVersionResponseSchema requires revision and model_uuid', () => {
+    expect(() =>
+      ModelVersionResponseSchema.parse({ uuid, tsg_id: '123', created_at: now, updated_at: now }),
+    ).toThrow();
   });
 });


### PR DESCRIPTION
Closes #194

## What

Adds a first-class **Models / Model Versions** resource to Model Security, from the latest data-plane spec. `ModelSecurityClient.models` (read-only, data plane):

- `listModels(opts?)` → `GET /v1/models` — search, sort, and `latest_version_*` array filters, pagination
- `getModel(uuid)` → `GET /v1/models/{uuid}`
- `listModelVersions(modelUuid, opts?)` → `GET /v1/models/{uuid}/model-versions`
- `getModelVersion(uuid)` → `GET /v1/model-versions/{uuid}`
- `listModelVersionFiles(modelVersionUuid, opts?)` → `GET /v1/model-versions/{uuid}/files` (reuses the existing `FileList` schema)

New schemas `Model` / `ModelList` / `ModelVersion` / `ModelVersionList`, reusing the existing pagination, eval-summary, and file schemas. Enum-ish fields modeled as `z.string()` for forward-compat, consistent with the rest of Model Security.

## Specs

Refreshes the committed `specs/AIRS-Model-Security-DataPlane.yaml` to the latest upstream — **0 preflight drift**.

## Tests

`test/model-security/models-client.spec.ts` — per-method path/verb, query serialization (incl. repeated `latest_version_*`), UUID validation. `client.spec.ts` — `models` sub-client wiring. `test/models/model-security.spec.ts` — schema parsing (required fields, eval summary, passthrough).

## Verification

`format:check`, `lint`, `typecheck`, `preflight` (0 unacknowledged drift), `docs:check`, full Vitest (1350) pass locally.

Non-breaking; ships **minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)