### PR TITLE
chore(preflight): match OpenAPI components with a 'Schema' name suffix

### DIFF
--- a/.changeset/0192-preflight-schema-suffix.md
+++ b/.changeset/0192-preflight-schema-suffix.md
@@ -1,0 +1,9 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Align a few Model Security schemas with the latest OpenAPI spec (surfaced by an improved preflight schema matcher):
+
+- `ScanCreateRequest.scan_origin` is now optional (the server defaults it).
+- `ScanBaseResponse.model_version_uuid` is now optional/nullable (a scan may not have a resolved model version yet).
+- `ViolationResponse` now types the `remediation` field (new `ViolationRemediation` schema: `steps` + `url`) instead of only passing it through.

--- a/scripts/preflight/allowlist.ts
+++ b/scripts/preflight/allowlist.ts
@@ -431,6 +431,37 @@ export const PREFLIGHT_ALLOWLIST: AllowlistEntry[] = [
     kind: 'extra-field',
     reason: 'Combined passthrough union of all 4 OpenAPI subtypes — see schema JSDoc.',
   },
+
+  // ── z.unknown() fields the spec marks required ───────────────────────────────
+  // These fields ARE modeled in Zod, but as `z.unknown()`, which zod-to-json-schema
+  // cannot emit as `required`. The field is present and accepted; the divergence is a
+  // modeling-expressiveness artifact, not a missing field. Surfaced once the preflight
+  // resolver began matching `*Schema`-suffixed OpenAPI components (issue #192).
+  {
+    schema: 'JobResponseSchema',
+    pathSubstring: 'job_metadata',
+    kind: 'missing-required-field',
+    reason: 'job_metadata is modeled as z.unknown() (arbitrary shape); cannot be marked required.',
+  },
+  {
+    schema: 'TargetAuthValidationRequestSchema',
+    pathSubstring: 'auth_config',
+    kind: 'missing-required-field',
+    reason:
+      'auth_config is modeled as z.unknown() (union of auth shapes); cannot be marked required.',
+  },
+  {
+    schema: 'TargetResponseSchema',
+    pathSubstring: 'status',
+    kind: 'missing-required-field',
+    reason: 'status is modeled as z.unknown(); cannot be marked required.',
+  },
+  {
+    schema: 'TargetListItemSchema',
+    pathSubstring: 'status',
+    kind: 'missing-required-field',
+    reason: 'status is modeled as z.unknown(); cannot be marked required.',
+  },
 ];
 
 /**

--- a/scripts/preflight/resolve-name.ts
+++ b/scripts/preflight/resolve-name.ts
@@ -14,6 +14,10 @@ export const NAME_SUFFIXES = [
   'Detail',
   'List',
   'Item',
+  // Some upstream components carry a literal `Schema` suffix in their name
+  // (e.g. `LanguageOptionSchema`, `ModelResponseSchema`). Try it last so a bare
+  // or conventionally-suffixed match still wins.
+  'Schema',
 ];
 
 /**

--- a/src/models/model-security.ts
+++ b/src/models/model-security.ts
@@ -150,7 +150,8 @@ export const ScanCreateRequestSchema = z
   .object({
     model_uri: z.string(),
     security_group_uuid: z.string(),
-    scan_origin: z.string(),
+    // Optional per the OpenAPI spec (server defaults it); the scans-client example still sets it.
+    scan_origin: z.string().optional(),
     allow_patterns: z.array(z.string()).nullable().optional(),
     ignore_patterns: z.array(z.string()).nullable().optional(),
     labels: z.array(LabelSchema).nullable().optional(),
@@ -180,7 +181,8 @@ export const ScanBaseResponseSchema = z
     scan_origin: z.string(),
     security_group_uuid: z.string(),
     security_group_name: z.string(),
-    model_version_uuid: z.string(),
+    // Optional per the OpenAPI spec — a scan may not have a resolved model version yet.
+    model_version_uuid: z.string().nullable().optional(),
     eval_outcome: z.string(),
     source_type: z.string(),
     created_by: z.string().nullable().optional(),
@@ -361,6 +363,15 @@ export type RuleEvaluationList = z.infer<typeof RuleEvaluationListSchema>;
 // DataPlane — Violation response
 // ---------------------------------------------------------------------------
 
+/** Remediation returned on a violation — steps and a reference URL. */
+export const ViolationRemediationSchema = z
+  .object({
+    steps: z.array(z.string()),
+    url: z.string(),
+  })
+  .passthrough();
+export type ViolationRemediation = z.infer<typeof ViolationRemediationSchema>;
+
 /** Zod schema for a single violation response. */
 export const ViolationResponseSchema = z
   .object({
@@ -373,6 +384,7 @@ export const ViolationResponseSchema = z
     rule_name: z.string(),
     rule_description: z.string(),
     rule_instance_state: z.string(),
+    remediation: ViolationRemediationSchema,
     file: z.string().nullable().optional(),
     hash: z.string().nullable().optional(),
     module: z.string().nullable().optional(),

--- a/test/model-security/scans-client.spec.ts
+++ b/test/model-security/scans-client.spec.ts
@@ -397,6 +397,7 @@ describe('ModelSecurityScansClient', () => {
         rule_name: 'r',
         rule_description: 'rd',
         rule_instance_state: 'BLOCKING',
+        remediation: { steps: ['Remove the file'], url: 'https://example.com/fix' },
       };
       mockFetch(violation);
       const result = await client.getViolation(validUuid);

--- a/test/models/model-security.spec.ts
+++ b/test/models/model-security.spec.ts
@@ -339,6 +339,7 @@ describe('ViolationResponseSchema', () => {
       rule_name: 'rule-1',
       rule_description: 'desc',
       rule_instance_state: 'BLOCKING',
+      remediation: { steps: ['Remove the file'], url: 'https://example.com/fix' },
     };
     expect(ViolationResponseSchema.parse(v).description).toBe('Malicious op found');
   });
@@ -354,6 +355,7 @@ describe('ViolationResponseSchema', () => {
       rule_name: 'r',
       rule_description: 'rd',
       rule_instance_state: 'BLOCKING',
+      remediation: { steps: ['Remove the file'], url: 'https://example.com/fix' },
       file: 'model.pkl',
       hash: 'abc',
       threat: 'PAIT-PKL-100',

--- a/test/preflight/resolve-name.spec.ts
+++ b/test/preflight/resolve-name.spec.ts
@@ -15,6 +15,11 @@ describe('resolveOpenApiName', () => {
     expect(resolveOpenApiName('DbsEntry', map)?.matchedName).toBe('DbsEntryObject');
   });
 
+  it('falls back to <Name>Schema suffix (upstream components named *Schema)', () => {
+    const map = new Map([['LanguageOptionSchema', obj]]);
+    expect(resolveOpenApiName('LanguageOption', map)?.matchedName).toBe('LanguageOptionSchema');
+  });
+
   it('prefers bare name over a suffixed alternate when both exist', () => {
     const map = new Map([
       ['Item', obj],


### PR DESCRIPTION
Closes #192

## What

The preflight name resolver strips the trailing `Schema` from a Zod export to derive its shortName, then tries `NAME_SUFFIXES` — but not `Schema`. Several upstream components are literally named `…Schema` (e.g. `LanguageOptionSchema`, `ModelResponseSchema`, `JobResponseSchema`), so those Zod schemas were treated as unmatched local helpers and skipped validation. Adding `'Schema'` to the suffix list fixes that.

**Matched Zod↔OpenAPI schemas: 128 → 232.**

## Divergences this surfaced (all resolved)

Real fixes (Zod now matches the latest spec):
- `ScanCreateRequest.scan_origin` → optional (spec makes it optional; server defaults it).
- `ScanBaseResponse.model_version_uuid` → optional/nullable (spec optional; a scan may not have a resolved version).
- `ViolationResponse.remediation` → now typed via a new `ViolationRemediation` schema (`steps`, `url`) instead of only passthrough.

Allowlisted (modeling-expressiveness artifact, not a real gap): four fields typed `z.unknown()` that the spec marks required — `JobResponse.job_metadata`, `TargetAuthValidationRequest.auth_config`, `TargetResponse.status`, `TargetListItem.status`. `z.unknown()` fields are present and accepted but can't be emitted as `required` in JSON Schema.

## Tests

- `test/preflight/resolve-name.spec.ts` — new case for the `Schema` suffix (written red-first).
- Model/scan/violation fixtures updated for the now-typed `remediation`.

## Verification

`format:check`, `lint`, `typecheck`, `preflight` (0 unacknowledged drift; 93 acknowledged), `docs:check`, full Vitest (1351) pass locally.

Patch — schema-accuracy fixes + internal tooling; no new client methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)