### PR TITLE
docs: refresh docs site for the new features

### DIFF
--- a/.changeset/0197-docs-refresh-new-features.md
+++ b/.changeset/0197-docs-refresh-new-features.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Docs: add release-notes coverage for the Red Team Network Broker, supported-languages, target-profile error-log, and Model Security models features; note the `models` sub-client in the Model Security guide; fix a stale sub-client count in the Red Team guide.

--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -1,5 +1,34 @@
 # Release Notes
 
+## Unreleased
+
+### New Features — Red Team Network Broker
+
+Adds `RedTeamClient.networkBroker` (new `RedTeamNetworkBrokerClient`) for discovering and managing the broker channels that Red Team targets reference via `network_broker_channel_uuid`. It uses a distinct network broker data-plane base URL, overridable with the `networkBrokerEndpoint` constructor option or `PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT`, and shares the existing Red Team OAuth credentials.
+
+**New methods:** `listChannels(opts?)` (`GET /v1/channels`, with `status` / `search` / `include_all_if_empty` / `limit` / `skip`), `createChannel(body)`, `getChannel(channelId)`, `updateChannel(channelId, body)`, `getChannelStats()`.
+
+**New exports:** `RedTeamNetworkBrokerClient`, `RedTeamNetworkBrokerClientOptions`, `ChannelListOptions`, and the `Channel`, `ChannelStats`, `ChannelStatus`, `CreateChannelRequest`, `UpdateChannelRequest`, and channel-list schemas/types.
+
+### New Features — Red Team supported languages & target-profile error logs
+
+- **`getLanguages()` / `getManagementLanguages()`** — the tenant's allowed languages for scans (`GET /v1/languages`, data plane and management plane). Returns `TenantLanguagesResponse` (`multilingual_enabled`, `supported_job_types`, `languages: { code, name }[]`).
+- **`getTargetProfileErrorLogs(targetId, opts?)`** — profiling errors for a target (`GET /v1/error-log/target-profile/{target_id}`), reusing the existing `ErrorLogListResponse` shape.
+
+### New Features — Model Security models sub-client
+
+Adds a read-only `ModelSecurityClient.models` (new `ModelSecurityModelsClient`) for browsing models and their versions/files on the data plane, complementing point-in-time scans.
+
+**New methods:** `listModels(opts?)` (`GET /v1/models`, with search / sort / `latest_version_*` filters), `getModel(uuid)`, `listModelVersions(modelUuid, opts?)`, `getModelVersion(uuid)`, `listModelVersionFiles(modelVersionUuid, opts?)`.
+
+**New exports:** `ModelSecurityModelsClient` and its option types, plus the `Model`, `ModelVersion`, and their list schemas/types.
+
+### Fixes & Alignment
+
+- `customerApps.list()` now percent-encodes the TSG ID in the request path, so a TSG ID with URL-reserved characters can't corrupt the URL.
+- Model Security schema accuracy vs the latest OpenAPI: `ScanCreateRequest.scan_origin` is now optional, `ScanBaseResponse.model_version_uuid` is now optional/nullable, and `ViolationResponse.remediation` is now typed (new `ViolationRemediation` schema) instead of only passed through.
+- Refreshed the committed Red Team and Model Security OpenAPI specs to the latest upstream revisions and expanded schema-vs-spec preflight coverage (128 → 232 matched schemas).
+
 ## v0.12.0
 
 ### New Features — Dashboard Apps Enumeration

--- a/docs-site/docs/guides/model-security-api.md
+++ b/docs-site/docs/guides/model-security-api.md
@@ -14,7 +14,7 @@ Three concepts do the work:
 
 The flow: define a security group once → run scans against it → read the outcome and drill into violations. Scans run asynchronously, so a fresh scan starts as `PENDING` and you poll `get()` until it settles.
 
-**When to use it:** vetting third-party models (Hugging Face, S3, registries) before deployment, gating models in CI, or auditing what's already in use. Two planes are involved — a **data plane** for scans (`client.scans`) and a **management plane** for groups and rules (`client.securityGroups`, `client.securityRules`) — but a single OAuth2 token covers both, handled for you.
+**When to use it:** vetting third-party models (Hugging Face, S3, registries) before deployment, gating models in CI, or auditing what's already in use. Two planes are involved — a **data plane** for scans and model/version browsing (`client.scans`, `client.models`) and a **management plane** for groups and rules (`client.securityGroups`, `client.securityRules`) — but a single OAuth2 token covers both, handled for you.
 
 ## Authentication
 

--- a/docs-site/docs/guides/red-team-api.md
+++ b/docs-site/docs/guides/red-team-api.md
@@ -657,7 +657,7 @@ Run **static** scans on every release for fast, repeatable regression coverage. 
 - **Bulk-load custom prompts via CSV.** `uploadPromptsCsv()` is far faster than `createPrompt()` in a loop; grab the shape with `downloadTemplate()`. Mark a prompt set active so it can be referenced by a custom scan.
 - **Accept the EULA once per tenant.** If scans error before running, confirm `eula.getStatus().is_accepted` is `true`.
 
-For the complete, per-method list with input/output shapes (`RedTeamClient` and its seven sub-clients), see the [Full API reference](../reference/api/index.md).
+For the complete, per-method list with input/output shapes (`RedTeamClient` and its eight sub-clients), see the [Full API reference](../reference/api/index.md).
 
 ## Error Handling
 


### PR DESCRIPTION
Brings the Docusaurus docs site up to date with the recently shipped work (network broker, RT languages/target-profile error-log, MS models sub-client, customer-apps + schema-accuracy fixes).

## Changes

- **Release notes** — new `Unreleased` section documenting the new public API across all the shipped PRs (#187, #189, #193, #195, #196). Factual API descriptions; no fabricated live-verification claims.
- **Model Security guide** — the "when to use" intro now mentions the data-plane `models` sub-client alongside `scans`.
- **Red Team guide** — fixed a stale "seven sub-clients" reference to "eight" (network broker).

The per-method **API reference** under `docs-site/docs/reference/api` is gitignored and regenerated by `docs:api` in the deploy workflow, so the new methods appear automatically on deploy — no committed changes needed there.

## Verification

Full site build passes clean locally (`npm run docs:api` + `docusaurus build`, `onBrokenLinks: 'throw'`). Lint/format/typecheck/tests green via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)