### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Unreleased
+## v0.13.0
 
 ### New Features — Red Team Network Broker
 
@@ -26,6 +26,7 @@ Adds a read-only `ModelSecurityClient.models` (new `ModelSecurityModelsClient`) 
 ### Fixes & Alignment
 
 - `customerApps.list()` now percent-encodes the TSG ID in the request path, so a TSG ID with URL-reserved characters can't corrupt the URL.
+- Corrected the Network Broker `ChannelStats` field names to match the live API (`getChannelStats()` previously modeled non-existent fields — `broker_server`, `registry`, `online_channel_count`, etc. — so every typed accessor returned `undefined`; they are now `network_channels_server_domain`, `docker_registry`, `online_channels`, `total_channels`, and friends). `Channel` also gains live fields (`added_by`, `last_online_at`, `connected_clients_count`, `outdated_clients_count`, `features`), and the Network Broker OpenAPI spec is now committed so preflight validates these going forward.
 - Model Security schema accuracy vs the latest OpenAPI: `ScanCreateRequest.scan_origin` is now optional, `ScanBaseResponse.model_version_uuid` is now optional/nullable, and `ViolationResponse.remediation` is now typed (new `ViolationRemediation` schema) instead of only passed through.
 - Refreshed the committed Red Team and Model Security OpenAPI specs to the latest upstream revisions and expanded schema-vs-spec preflight coverage (128 → 232 matched schemas).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.12.0';
+export const SDK_VERSION = '0.13.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults


### PR DESCRIPTION
Release **v0.13.0** (minor). Bumps `package.json`, `package-lock.json`, and `src/constants.ts` `SDK_VERSION`; retitles the release-notes `Unreleased` section.

## Highlights since v0.12.0
- **feat(red-team):** Network Broker channel sub-client — `RedTeamClient.networkBroker` (list/create/get/update channels + stats) (#187)
- **feat(red-team):** supported-languages + target-profile error-log endpoints (#193)
- **feat(model-security):** read-only `models` sub-client (browse models/versions/files) (#195)
- **fix(management):** percent-encode TSG ID in customer-apps list path (#189)
- **fix(red-team):** correct Network Broker `ChannelStats` field names to match live API (#199)

Docs accuracy fixes (#201) and preflight/spec refreshes (#196, #198, #200) also included since the last tag.

On merge: tag `v0.13.0` + GitHub Release will fire the OIDC npm publish.