### PR TITLE
fix(scan): allow 20-item async batches

### DIFF
--- a/.changeset/0200-async-batch-limit-20.md
+++ b/.changeset/0200-async-batch-limit-20.md
@@ -1,0 +1,5 @@
+---
+'@cdot65/prisma-airs-sdk': patch
+---
+
+Raise the `asyncScan()` submission limit from 5 to 20 request objects to match the current AIRS API. Scan-result and report-result query limits remain 5 IDs per call.

--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v0.13.2
+
+### Fix async scan batch limit
+
+Raise the `asyncScan()` submission limit from 5 to 20 request objects to match the current AIRS API. The SDK previously rejected valid 6–20 item batches before making a network request. `queryByScanIds()` and `queryByReportIds()` retain their independent five-ID limits.
+
 ## v0.13.1
 
 ### Reliable SDK primitives for AIRS bulk scanning

--- a/docs-site/docs/developer/architecture.md
+++ b/docs-site/docs/developer/architecture.md
@@ -36,7 +36,7 @@ load-bearing values:
 ```ts
 export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
-export const MAX_NUMBER_OF_BATCH_SCAN_OBJECTS = 5; // batch ops cap at 5 items
+export const MAX_NUMBER_OF_BATCH_SCAN_OBJECTS = 20; // async submission cap
 export const MAX_CONTENT_PROMPT_LENGTH = 2 * 1024 * 1024; // 2 MB
 ```
 

--- a/docs-site/docs/guides/examples.mdx
+++ b/docs-site/docs/guides/examples.mdx
@@ -39,7 +39,7 @@ npx tsx --env-file=.env docs-site/examples/<script>.ts
 | Script | What it demonstrates |
 | --- | --- |
 | `basic-scan.ts` | Calls `init()`, creates `Content`, and runs `Scanner.syncScan()` with metadata. |
-| `async-scan.ts` | Submits a batch with `Scanner.asyncScan()`; batch size is capped at five items. |
+| `async-scan.ts` | Submits a batch with `Scanner.asyncScan()`; batch size is capped at 20 items. |
 | `query-results.ts` | Fetches async scan results and threat reports by scan ID or report ID. |
 
 ```bash

--- a/docs-site/docs/guides/scan-api.md
+++ b/docs-site/docs/guides/scan-api.md
@@ -19,7 +19,7 @@ Key concepts:
 | `Content`            | A wrapper holding the text to scan (`prompt`, `response`, `context`, code, tool events). Validates size as you set it.                                |
 | **Security profile** | The named ruleset (managed via the [Management API](management-api)) that decides which detections run and whether a hit means _allow_ or _block_. |
 | **Verdict**          | The result: `category` (`benign`/`malicious`) and `action` (`allow`/`block`).                                                                         |
-| **Sync vs async**    | Sync gives an inline verdict in one call. Async accepts 1–5 request objects, returns one batch receipt, and you poll for result rows later.           |
+| **Sync vs async**    | Sync gives an inline verdict in one call. Async accepts 1–20 request objects, returns one batch receipt, and you poll for result rows later.          |
 
 :::tip[Profiles live in the Management API]
 The Scan API only _references_ a profile by name or ID — it never creates one. Define and tune profiles with the [Management API](management-api), then point scans at them.
@@ -117,7 +117,7 @@ console.log(result.category, result.scan_id, result.report_id);
 
 ### Scan many items off the hot path (asynchronous)
 
-When you have a backlog (logs, batch evaluation, offline review), submit **1–5 request objects** in one call. AIRS returns one batch receipt. A batch `scan_id` can later produce several result rows, one per `req_id`, and those rows can arrive in any order.
+When you have a backlog (logs, batch evaluation, offline review), submit **1–20 request objects** in one call. AIRS returns one batch receipt. A batch `scan_id` can later produce several result rows, one per `req_id`, and those rows can arrive in any order.
 
 ```ts
 const submitted = await scanner.asyncScan(
@@ -136,7 +136,7 @@ const submitted = await scanner.asyncScan(
         contents: [{ prompt: 'second prompt' }],
       },
     },
-    // ... up to 5 objects, each with a distinct req_id
+    // ... up to 20 objects, each with a distinct req_id
   ],
   { numRetries: 0 },
 );
@@ -186,7 +186,7 @@ A profile is only as good as where you put it. Scan the **prompt inbound** and t
 These are **byte** limits (multibyte characters count for more than one). For very long documents, trim or chunk before scanning. Use `content.length` to check the combined size before sending.
 :::
 :::note[Batch and query caps are 5]
-`asyncScan`, `queryByScanIds`, and `queryByReportIds` each accept **at most 5 items**. The SDK throws a client-side error before any network call if you exceed it — loop in batches of 5 for larger workloads.
+`asyncScan` accepts **at most 20 request objects**. `queryByScanIds` and `queryByReportIds` independently accept **at most 5 IDs**. The SDK throws a client-side error before any network call if you exceed the applicable limit—submit larger workloads in batches of 20, then query IDs in groups of 5.
 :::
 **Retry behavior** — every scan call retries automatically on network failures and transient server errors (`500`, `502`, `503`, `504`) with exponential backoff plus jitter. Tune the global count with `init({ numRetries })` (0–5, default 5), or pass `{ numRetries }` to an individual `syncScan`, `asyncScan`, `queryByScanIds`, or `queryByReportIds` call. The per-call value wins when provided; omitting it preserves the global setting. A value of `0` means one total fetch attempt, while `5` permits six attempts. HTTP 429 is not retried automatically.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export const MAX_AI_PROFILE_NAME_LENGTH = 100;
 // Batch / query limits
 export const MAX_NUMBER_OF_SCAN_IDS = 5;
 export const MAX_NUMBER_OF_REPORT_IDS = 5;
-export const MAX_NUMBER_OF_BATCH_SCAN_OBJECTS = 5;
+export const MAX_NUMBER_OF_BATCH_SCAN_OBJECTS = 20;
 
 // HTTP / retry
 export const MAX_CONNECTION_POOL_SIZE = 100;
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.13.1';
+export const SDK_VERSION = '0.13.2';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/scan/scanner.ts
+++ b/src/scan/scanner.ts
@@ -142,13 +142,13 @@ export class Scanner {
   /**
    * Submit one batch of content for asynchronous scanning.
    *
-   * The call accepts 1–5 request objects and returns one batch receipt. A batch `scan_id` can fan
+   * The call accepts 1–20 request objects and returns one batch receipt. A batch `scan_id` can fan
    * out to several unordered result rows. Correlate each row by `(scan_id, req_id)`, never array
    * position or `scan_id` alone. The SDK preserves the server's row order and cardinality.
    *
    * Setting `numRetries: 0` guarantees one SDK fetch attempt, but cannot guarantee exactly-once
    * server submission after an ambiguous network or 5xx failure.
-   * @param scanObjects - Array of scan objects (1–5 items), each with its own `req_id`.
+   * @param scanObjects - Array of scan objects (1–20 items), each with its own `req_id`.
    * @param opts - Optional per-call retry override.
    * @returns One batch receipt containing the shared scan ID for later querying.
    * @example

--- a/test/scan/scanner.spec.ts
+++ b/test/scan/scanner.spec.ts
@@ -124,9 +124,25 @@ describe('Scanner', () => {
       await expect(scanner.asyncScan([])).rejects.toThrow(AISecSDKException);
     });
 
-    it('throws for >5 objects', async () => {
+    it('submits a 20-object batch', async () => {
+      mockFetch({ received: '2026-07-17T00:00:00Z', scan_id: 'batch-20' });
       const scanner = new Scanner();
-      const objects = Array.from({ length: 6 }, (_, i) => ({
+      const objects = Array.from({ length: 20 }, (_, i) => ({
+        req_id: i,
+        scan_req: { ai_profile: profile, contents: [{ prompt: `prompt-${i}` }] },
+      }));
+
+      const result = await scanner.asyncScan(objects, { numRetries: 0 });
+
+      expect(result.scan_id).toBe('batch-20');
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+      expect(body).toHaveLength(20);
+    });
+
+    it('throws for >20 objects', async () => {
+      const scanner = new Scanner();
+      const objects = Array.from({ length: 21 }, (_, i) => ({
         req_id: i,
         scan_req: { ai_profile: profile, contents: [{ prompt: 'x' }] },
       }));


### PR DESCRIPTION
## What changed

- raise `asyncScan()` from 5 to 20 request objects per call
- keep scan-result and report-result query limits at 5 IDs
- add a public regression proving all 20 objects reach one fetch and 21 fails before fetch
- correct guides, architecture docs, examples index, release notes, and changeset
- bump the package and SDK version to `0.13.2`

## Why

The current AIRS API accepts 20 prompts in one async submission, but SDK v0.13.1 incorrectly rejected valid 6–20 item batches locally.

## Validation

- 1,373 tests
- format, lint, typecheck, build
- docs coverage and Docusaurus production build
- schema preflight with zero unacknowledged drift
- npm package dry-run for `@cdot65/prisma-airs-sdk@0.13.2`
