### PR TITLE
feat: add AI Gateway client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/reference/api/
 
 # Symlinks to external OpenAPI specs
 schemas
+
+# Agent scratch reports
+.superpowers-final-fix-report.md

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ docs/reference/api/
 schemas
 
 # Agent scratch reports
-.superpowers-final-fix-report.md
+.superpowers*

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ coverage
 *.lock
 tsup.config.bundled_*
 review-*
+.superpowers/
 specs
 # Docusaurus site has its own formatting/tooling; generated API ref is huge.
 docs-site/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Node 18+](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-TypeScript SDK for Palo Alto Networks **Prisma AIRS** — covering the full lifecycle from configuration management to operational scanning across all three service domains: **AI Runtime Security**, **AI Red Teaming**, and **Model Security**.
+TypeScript SDK for Palo Alto Networks **Prisma AIRS** — covering the full lifecycle from configuration management to operational scanning across all four service domains: **AI Runtime Security**, **AI Red Teaming**, **Model Security**, and **AI Gateway**.
 
 ## Installation
 
@@ -30,6 +30,7 @@ Requires Node.js 18+. Zero external HTTP dependencies (native `fetch` + `crypto`
 | **AI Runtime Security** | `Scanner`             | API Key | Sync/async content scanning, prompt injection detection    |
 | **Management**          | `ManagementClient`    | OAuth2  | Profiles, topics, API keys, apps, DLP, deployment, logs    |
 | **Model Security**      | `ModelSecurityClient` | OAuth2  | ML model scanning, security groups, rule management        |
+| **AI Gateway**          | `AIGatewayClient`     | OAuth2  | SCM-managed gateway telemetry and configuration            |
 | **AI Red Teaming**      | `RedTeamClient`       | OAuth2  | Automated red team scans, reports, targets, custom attacks |
 
 All OAuth2 services share credentials and handle token lifecycle automatically (caching, proactive refresh, 401/403 auto-retry).
@@ -53,7 +54,50 @@ console.log(result.category); // "benign" | "malicious"
 console.log(result.action); // "allow" | "block"
 ```
 
-That's the API-key scanning path. The OAuth2 clients (`ManagementClient`, `ModelSecurityClient`, `RedTeamClient`), authentication setup, error handling, and runnable examples are all covered in the documentation.
+That's the API-key scanning path. The OAuth2 clients (`ManagementClient`, `ModelSecurityClient`, `RedTeamClient`, `AIGatewayClient`), authentication setup, error handling, and runnable examples are all covered in the documentation.
+
+## AI Gateway
+
+`AIGatewayClient` covers the SCM-managed Prisma AIRS **AI Gateway** — runtime telemetry and configuration across two planes behind one credential set: a data plane (`/ai_gw/v2`, telemetry + workspace-scoped config) and an admin plane (`/ai_gw/admin/v2`, organisation-level config). Twelve sub-clients: `telemetry`, `workspaces`, `configs`, `guardrails`, `providers`, `apiKeys` (data plane) and `integrations`, `mcpIntegrations`, `deployments`, `plugins`, `organisations`, `auditLogs` (admin plane).
+
+### SCM role grants
+
+The two planes authorize against **different SCM role scopes** — a service account needs both, or half the API returns 403:
+
+| Grant                       | Scope                            | Unlocks             |
+| --------------------------- | -------------------------------- | ------------------- |
+| Admin role                  | tenant root (empty last segment) | `/ai_gw/admin/v2/*` |
+| `view_only_admin` or higher | `main_airs_workspace_<TSG>`      | `/ai_gw/v2/*`       |
+
+Decode the service account's JWT `access` claim to check both are present:
+
+```json
+{
+  "prn:<TSG>::::": ["superuser", "base"],
+  "prn:<TSG>::::main_airs_workspace_<TSG>": ["superuser"]
+}
+```
+
+SCM's Access Management UI **edits an existing role row by default** — use _Add Role_ to add the second grant, or you'll move the first one instead of adding to it. The two failure modes look alike but mean different things: a `403` with body `errorCode: "AB03"` means the workspace-scope grant is missing; a `403` with header `x-opa-decision: false` means the tenant-root grant is.
+
+### Setup
+
+```bash
+export PANW_AI_GW_CLIENT_ID=your-client-id
+export PANW_AI_GW_CLIENT_SECRET=your-client-secret
+export PANW_AI_GW_TSG_ID=1234567890
+```
+
+`PANW_AI_GW_*` vars fall back to `PANW_MGMT_*` when unset, so existing management credentials work as-is.
+
+```ts
+import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+
+const gw = new AIGatewayClient();
+
+const cost = await gw.telemetry.cost({ workspaceSlug: 'ws-main-a-349e0e', days: 7 });
+console.log(`$${(cost.data.total / 100).toFixed(2)}`); // cost is returned in cents
+```
 
 ## Documentation
 

--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -10,6 +10,8 @@ The gateway's two planes authorize against **different SCM role scopes**, so a s
 
 Monetary values are returned **in cents**, exactly as the API sends them; the SDK does not convert. `deployments.delete()` archives rather than removes, so the record remains in `list()` with `status: 'archived'`. Write response shapes are verified against a live tenant for `deployments` only; other create and update responses are typed permissively until confirmed.
 
+This is not full admin-plane coverage. `workspaces` is data-plane read-only (`list()` only) — the admin-plane workspace-management endpoints (`GET`/`POST`/`PUT /ai_gw/admin/v2/workspaces`) are not implemented, so 0.14.0 cannot create a workspace. Admin-plane `guardrails` (`GET`) is likewise not implemented; `guardrails` here is the data-plane sub-client only. Both were deferred rather than modeled from unverified response shapes — see the design doc's open questions.
+
 ## v0.13.2
 
 ### Fix async scan batch limit

--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.14.0
+
+### AI Gateway support
+
+New `AIGatewayClient` covering the SCM-managed Prisma AIRS AI Gateway across both of its planes: runtime telemetry (`/ai_gw/v2/logs/*`) and configuration (`/ai_gw/v2` and `/ai_gw/admin/v2`). Twelve sub-clients — `telemetry`, `workspaces`, `configs`, `guardrails`, `providers`, `apiKeys`, `integrations`, `mcpIntegrations`, `deployments`, `plugins`, `organisations`, and `auditLogs`. Configure with `PANW_AI_GW_*`, falling back to `PANW_MGMT_*`.
+
+The gateway's two planes authorize against **different SCM role scopes**, so a service account needs both an admin role at tenant-root scope _and_ `view_only_admin` (or higher) on the `main_airs_workspace_<TSG>` scope. With only one grant, half the API returns 403 — `errorCode: "AB03"` means the workspace-scope grant is missing, `x-opa-decision: false` means the tenant-root one is.
+
+Monetary values are returned **in cents**, exactly as the API sends them; the SDK does not convert. `deployments.delete()` archives rather than removes, so the record remains in `list()` with `status: 'archived'`. Write response shapes are verified against a live tenant for `deployments` only; other create and update responses are typed permissively until confirmed.
+
 ## v0.13.2
 
 ### Fix async scan batch limit

--- a/docs-site/docs/getting-started/configuration.mdx
+++ b/docs-site/docs/getting-started/configuration.mdx
@@ -90,6 +90,19 @@ Falls back to `PANW_MGMT_*` variables if service-specific ones are not set.
 | `PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT` | No        | `https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane/network-broker` |
 | `PANW_RED_TEAM_TOKEN_ENDPOINT` | Falls back to MGMT | `https://auth.apps.paloaltonetworks.com/oauth2/access_token` |
 
+## AI Gateway API
+
+Falls back to `PANW_MGMT_*` variables if service-specific ones are not set. `PANW_AI_GW_TSG_ID` is also sent as the `x-tsg-id` header on every request.
+
+| Env Var                      | Required           | Default                                                |
+| ----------------------------- | ------------------ | ------------------------------------------------------- |
+| `PANW_AI_GW_CLIENT_ID`        | Falls back to MGMT | —                                                       |
+| `PANW_AI_GW_CLIENT_SECRET`    | Falls back to MGMT | —                                                       |
+| `PANW_AI_GW_TSG_ID`           | Falls back to MGMT | —                                                       |
+| `PANW_AI_GW_DATA_ENDPOINT`    | No                  | `https://api.apps.paloaltonetworks.com/ai_gw/v2`         |
+| `PANW_AI_GW_ADMIN_ENDPOINT`   | No                  | `https://api.apps.paloaltonetworks.com/ai_gw/admin/v2`   |
+| `PANW_AI_GW_TOKEN_ENDPOINT`   | Falls back to MGMT | `https://auth.apps.paloaltonetworks.com/oauth2/access_token` |
+
 ## Regional Endpoints
 
 Override endpoint variables for non-US deployments. The scan client also exports `AIRS_ENDPOINTS` with the verified scan hosts:
@@ -115,7 +128,7 @@ export PANW_MGMT_ENDPOINT=https://api.gov.sase.paloaltonetworks.com/aisec
 ```
 
 :::info[Shared Credentials]
-If you use the same OAuth2 client for all services, you only need to set `PANW_MGMT_CLIENT_ID`, `PANW_MGMT_CLIENT_SECRET`, and `PANW_MGMT_TSG_ID`. The Model Security and Red Team clients will use these automatically.
+If you use the same OAuth2 client for all services, you only need to set `PANW_MGMT_CLIENT_ID`, `PANW_MGMT_CLIENT_SECRET`, and `PANW_MGMT_TSG_ID`. The Model Security, Red Team, and AI Gateway clients will use these automatically.
 :::
 
 ## Debug Logging

--- a/docs-site/docs/getting-started/environment-variables.mdx
+++ b/docs-site/docs/getting-started/environment-variables.mdx
@@ -54,6 +54,19 @@ All fall back to the corresponding `PANW_MGMT_*` variable if not set.
 | `PANW_RED_TEAM_NETWORK_BROKER_ENDPOINT` | —                | `https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane/network-broker` | Network broker base URL |
 | `PANW_RED_TEAM_TOKEN_ENDPOINT` | `PANW_MGMT_TOKEN_ENDPOINT` | `https://auth.apps.paloaltonetworks.com/oauth2/access_token` | OAuth2 token endpoint     |
 
+## AI Gateway API
+
+All fall back to the corresponding `PANW_MGMT_*` variable if not set.
+
+| Variable                     | Fallback                   | Default                                              | Description                |
+| ----------------------------- | -------------------------- | ----------------------------------------------------- | --------------------------- |
+| `PANW_AI_GW_CLIENT_ID`        | `PANW_MGMT_CLIENT_ID`      | —                                                     | OAuth2 client ID            |
+| `PANW_AI_GW_CLIENT_SECRET`    | `PANW_MGMT_CLIENT_SECRET`  | —                                                     | OAuth2 client secret        |
+| `PANW_AI_GW_TSG_ID`           | `PANW_MGMT_TSG_ID`         | —                                                     | Tenant Service Group ID; also sent as the `x-tsg-id` header on every request |
+| `PANW_AI_GW_DATA_ENDPOINT`    | —                           | `https://api.apps.paloaltonetworks.com/ai_gw/v2`       | Data plane base URL         |
+| `PANW_AI_GW_ADMIN_ENDPOINT`   | —                           | `https://api.apps.paloaltonetworks.com/ai_gw/admin/v2` | Admin plane base URL        |
+| `PANW_AI_GW_TOKEN_ENDPOINT`   | `PANW_MGMT_TOKEN_ENDPOINT` | `https://auth.apps.paloaltonetworks.com/oauth2/access_token` | OAuth2 token endpoint |
+
 ## Debugging
 
 | Variable             | Required | Default | Description                                                     |
@@ -61,8 +74,9 @@ All fall back to the corresponding `PANW_MGMT_*` variable if not set.
 | `PANW_AI_SEC_DEBUG`  | No       | —       | Set to `1`/`true`/`yes`/`on` to log every API call to `stderr`. |
 
 When enabled, the SDK logs each HTTP request (method, full URL, headers, body) and response
-(status, duration, body) to **stderr** for every domain — scan, management, model security, and
-red teaming. It logs once per attempt, so retries and 401-driven token refreshes are visible.
+(status, duration, body) to **stderr** for every domain — scan, management, model security, red
+teaming, and AI Gateway. It logs once per attempt, so retries and 401-driven token refreshes are
+visible.
 
 Access-token header values (`Authorization`, `x-pan-token`) are replaced with a non-reversible
 `sha256:<prefix>` hash, so debug logs are safe to share and you can still tell when a token

--- a/docs-site/docs/guides/ai-gateway-api.mdx
+++ b/docs-site/docs/guides/ai-gateway-api.mdx
@@ -1,0 +1,350 @@
+# AI Gateway API
+
+Manage and observe the Prisma AIRS AI Gateway — the SCM-managed proxy that routes an app's LLM traffic through a workspace, applying provider configs, guardrails, and API keys, and recording telemetry for every request.
+
+## How it works
+
+The AI Gateway is configured and provisioned entirely through **Strata Cloud Manager (SCM)** — there is no separate onboarding flow. The SDK's `AIGatewayClient` reads and writes the same resources the SCM console does:
+
+- **Workspaces** — the top-level container (`client.workspaces`). A workspace's `slug` is what telemetry queries key on; its `id` is what config-plane resources key on. They are not interchangeable.
+- **Telemetry** — usage, cost, latency, tokens, cache, feedback, and raw request logs, all read-only (`client.telemetry`).
+- **Config plane resources** — gateway configs, guardrails, provider bindings, and API keys, all scoped to a workspace (`client.configs`, `client.guardrails`, `client.providers`, `client.apiKeys`).
+- **Admin plane resources** — organisation-level provider integrations, MCP server integrations, deployments, plugins, org/auth settings, and audit logs — not scoped to a single workspace (`client.integrations`, `client.mcpIntegrations`, `client.deployments`, `client.plugins`, `client.organisations`, `client.auditLogs`).
+
+`AIGatewayClient` exposes **12 sub-clients** total, spanning **two API planes** on one credential set:
+
+- the **data plane** (`/ai_gw/v2`) — telemetry and workspace-scoped config
+- the **admin plane** (`/ai_gw/admin/v2`) — organisation-level config
+
+Both planes share one OAuth2 token; what differs is the **SCM role scope** each plane authorizes against, which is the first thing to get right (see [Authorization](#authorization) below).
+
+:::note[No published OpenAPI spec]
+Unlike most of this SDK's other subsystems, the AI Gateway API has no published OpenAPI spec — endpoint names are bespoke (`user-trends` is plural, `groups/model` is singular, `cache-hits-trend` 404s). Every schema in `src/models/ai-gateway.ts` was verified against a live tenant; see the [Gotchas](#gotchas) section below for the corners that bit us.
+:::
+
+## Authorization
+
+**This is the part most likely to waste your time.** The two planes authorize against **different SCM role scopes**, and a service account needs **both grants** or half the API returns 403.
+
+| Grant | Scope | Unlocks |
+| --- | --- | --- |
+| An admin role | Tenant root (empty final scope segment) | `/ai_gw/admin/v2/*` |
+| `view_only_admin` or higher | `main_airs_workspace_<TSG>` | `/ai_gw/v2/*` (telemetry **and** config) |
+
+Both grants can coexist on one service account. Decode the account's JWT `access` claim to check what it actually has:
+
+```json
+{
+  "prn:<TSG>::::": ["superuser", "base"],
+  "prn:<TSG>::::main_airs_workspace_<TSG>": ["superuser"]
+}
+```
+
+The first key (empty final segment) is the tenant-root grant; the second, scoped to `main_airs_workspace_<TSG>`, is the workspace grant. You need a role present under **both** keys. The workspace scope's exact name is also returned as `scope_name` on `gw.workspaces.list()` / `gw.workspaces.get()` — use that to confirm you're granting the right scope in SCM.
+
+:::warning[SCM's Access Management UI edits, it does not add]
+SCM's Access Management UI **edits an existing role row by default**. If a service account already has a tenant-root role and you need to add the workspace-scope role too, you must explicitly **Add Role** to create a second row — otherwise you will move the existing grant to the new scope instead of adding to it, and the plane you thought you kept will go dark.
+:::
+
+### Telling the failure modes apart
+
+Three different rejections look superficially alike (all `4xx`) but mean completely different things:
+
+| Response | Layer | Meaning |
+| --- | --- | --- |
+| `403` with header `x-opa-decision: false` and body `{"msg":"Access denied"}` | SCM OPA policy | Blocked before reaching the gateway app. Missing the **tenant-root** grant. |
+| `403` with body `{"success":false,"data":{"errorCode":"AB03"}}` | Gateway app RBAC | Real endpoint, reached the app. Missing the **workspace-scope** grant. |
+| `404` with `errorCode: "AB02"` | Gateway routing | Real collection, wrong read form — usually a missing `workspace_id` query param. |
+
+`AISecSDKException` surfaces `errorCode` directly in its `message` (see [Error Handling](#error-handling)), so you don't need to inspect headers or parse the body yourself to tell these apart.
+
+## Configuration
+
+The AI Gateway client uses OAuth2 `client_credentials`, exactly like every other client in this SDK. Each `PANW_AI_GW_*` variable falls back to the corresponding `PANW_MGMT_*` one if unset, so an account already configured for `ManagementClient` needs nothing extra beyond the two SCM grants above.
+
+| Env Var | Fallback | Required | Description |
+| --- | --- | --- | --- |
+| `PANW_AI_GW_CLIENT_ID` | `PANW_MGMT_CLIENT_ID` | Yes | OAuth2 client ID from SCM |
+| `PANW_AI_GW_CLIENT_SECRET` | `PANW_MGMT_CLIENT_SECRET` | Yes | OAuth2 client secret |
+| `PANW_AI_GW_TSG_ID` | `PANW_MGMT_TSG_ID` | Yes | Tenant Service Group ID |
+| `PANW_AI_GW_DATA_ENDPOINT` | -- | No | Data plane URL (default: `https://api.apps.paloaltonetworks.com/ai_gw/v2`) |
+| `PANW_AI_GW_ADMIN_ENDPOINT` | -- | No | Admin plane URL (default: `https://api.apps.paloaltonetworks.com/ai_gw/admin/v2`) |
+| `PANW_AI_GW_TOKEN_ENDPOINT` | `PANW_MGMT_TOKEN_ENDPOINT` | No | Token URL (default: `https://auth.apps.paloaltonetworks.com/oauth2/access_token`) |
+
+### Setup
+
+```bash
+export PANW_AI_GW_CLIENT_ID=your-client-id
+export PANW_AI_GW_CLIENT_SECRET=your-client-secret
+export PANW_AI_GW_TSG_ID=1234567890
+```
+
+Or reuse existing management credentials (the fallback kicks in automatically):
+
+```bash
+export PANW_MGMT_CLIENT_ID=your-client-id
+export PANW_MGMT_CLIENT_SECRET=your-client-secret
+export PANW_MGMT_TSG_ID=1234567890
+```
+
+### Client Initialization
+
+```ts
+import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+
+// From env vars (recommended)
+const gw = new AIGatewayClient();
+
+// Explicit
+const gw = new AIGatewayClient({
+  clientId: 'your-client-id',
+  clientSecret: 'your-client-secret',
+  tsgId: '1234567890',
+});
+
+// Custom endpoints
+const gw = new AIGatewayClient({
+  clientId: 'your-client-id',
+  clientSecret: 'your-client-secret',
+  tsgId: '1234567890',
+  dataEndpoint: 'https://api.sase.paloaltonetworks.com/ai_gw/v2',
+  adminEndpoint: 'https://api.sase.paloaltonetworks.com/ai_gw/admin/v2',
+});
+```
+
+Token fetch, caching, and refresh are handled automatically, same as every other client.
+
+:::tip[`api.apps` and `api.sase` are the same host]
+`api.apps.paloaltonetworks.com` (the default, and what PANW documents) and `api.sase.paloaltonetworks.com` resolve to the same backend and behave identically — same status codes, same error bodies, same `x-opa-decision` header. If your egress allowlist is already scoped to `api.sase` for `ManagementClient`, override `dataEndpoint` / `adminEndpoint` to reuse it rather than opening a new firewall rule.
+:::
+
+## Sub-Clients
+
+`AIGatewayClient` exposes 12 sub-clients:
+
+| Sub-Client | Plane | Access |
+| --- | --- | --- |
+| `telemetry` | Data | `gw.telemetry` |
+| `workspaces` | Data | `gw.workspaces` |
+| `configs` | Data | `gw.configs` |
+| `guardrails` | Data | `gw.guardrails` |
+| `providers` | Data | `gw.providers` |
+| `apiKeys` | Data | `gw.apiKeys` |
+| `integrations` | Admin | `gw.integrations` |
+| `mcpIntegrations` | Admin | `gw.mcpIntegrations` |
+| `deployments` | Admin | `gw.deployments` |
+| `plugins` | Admin | `gw.plugins` |
+| `organisations` | Admin | `gw.organisations` |
+| `auditLogs` | Admin | `gw.auditLogs` |
+
+## Walkthrough: workspace spend and blocked requests
+
+The core loop for observability — resolve a workspace, then pull its telemetry.
+
+```ts
+import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+const gw = new AIGatewayClient();
+
+// 1. Workspaces carry both keys telemetry and config need: `slug` and `id`.
+const ws = (await gw.workspaces.list()).data[0];
+
+// 2. Telemetry is keyed by slug. Costs come back in CENTS.
+const cost = await gw.telemetry.cost({ workspaceSlug: ws.slug, days: 7 });
+console.log(`$${(cost.data.total / 100).toFixed(2)} over 7 days`);
+
+// 3. Group requests by HTTP status to see what AIRS blocked.
+const codes = await gw.telemetry.byStatusCode({
+  workspaceSlug: ws.slug,
+  days: 7,
+  columns: ['cost', 'avg_latency'],
+});
+const blocks = codes.data.find((r) => r.status_code === 446);
+console.log(`AIRS blocks: ${blocks?.requests ?? 0}`); // 446 = blocked before it hit the LLM
+```
+
+## Telemetry
+
+`gw.telemetry` has 19 read methods: 15 chart endpoints (`cost`, `requests`, `latency`, `tokens`, `errors`, `users`, `cacheSummary`, `cacheHitTrend`, `userTrends`, `errorTrends`, `rescuedRetries`, `feedbackTrend`, `feedbackWeighted`, `feedbackScoreDistribution`, `feedbackModels`), 3 group-by aggregates (`groupBy`, `byUser`, `byStatusCode`), and raw `logs`. Every method takes a window: `{ workspaceSlug, days? }` or `{ workspaceSlug, start, end }`.
+
+### Charts
+
+```ts
+const [cost, requests, latency, tokens] = await Promise.all([
+  gw.telemetry.cost({ workspaceSlug: 'ws-main-a-349e0e', days: 7 }),
+  gw.telemetry.requests({ workspaceSlug: 'ws-main-a-349e0e', days: 7 }),
+  gw.telemetry.latency({ workspaceSlug: 'ws-main-a-349e0e', days: 7 }),
+  gw.telemetry.tokens({ workspaceSlug: 'ws-main-a-349e0e', days: 7 }),
+]);
+console.log(cost.data.total); // cents, e.g. 411083
+console.log(latency.data.p99); // ms
+console.log(tokens.data.total_request_units, tokens.data.total_response_units);
+```
+
+Use an explicit window instead of a rolling one by passing `start`/`end` `Date`s instead of `days`.
+
+### groupBy, byUser, byStatusCode
+
+```ts
+// Spend by model — dimension names are underscore-only: 'ai_service' | 'model' | 'api_key' | 'provider'.
+const byModel = await gw.telemetry.groupBy('model', {
+  workspaceSlug: 'ws-main-a-349e0e',
+  days: 7,
+  columns: ['cost', 'total_tokens'],
+});
+
+// Requests and cost per end user.
+const byUser = await gw.telemetry.byUser({ workspaceSlug: 'ws-main-a-349e0e', days: 7 });
+
+// Requests by HTTP status — 446 is an AIRS security block, not a server error.
+const byStatus = await gw.telemetry.byStatusCode({
+  workspaceSlug: 'ws-main-a-349e0e',
+  days: 7,
+  columns: ['cost', 'avg_latency'],
+});
+```
+
+### logs
+
+```ts
+// Only pageSize actually pages upstream; an unfiltered call always returns the same
+// ~50-row recent batch regardless of offset.
+const recent = await gw.telemetry.logs({ workspaceSlug: 'ws-main-a-349e0e', days: 1, pageSize: 3 });
+
+// statusCode is the one filter that bypasses the ~50-row cap — use it to pull every
+// AIRS block in the window, not just the most recent page.
+const blocked = await gw.telemetry.logs({ workspaceSlug: 'ws-main-a-349e0e', days: 7, statusCode: 446 });
+console.log(blocked.data.records.length);
+```
+
+## Config Plane
+
+Workspace-scoped resources: gateway configs, guardrails, provider bindings, and API keys. All list methods take `{ workspaceId }` (the workspace **UUID**, not the slug telemetry uses).
+
+```ts
+const workspaceId = 'a1b2c3d4-0000-4000-8000-000000000000';
+
+const configs = await gw.configs.list({ workspaceId });
+const guardrails = await gw.guardrails.list({ workspaceId });
+const providers = await gw.providers.list({ workspaceId });
+const serviceKeys = await gw.apiKeys.listService({ workspaceId });
+const userKeys = await gw.apiKeys.listUser({ workspaceId });
+```
+
+:::warning[configs.list() and configs.get() are different shapes]
+List rows are a 12-field subset that omits `config`, `format`, `type`, and `version_id`. Fetch a config's detail to get the routing config itself — and note it comes back as a **JSON-encoded string**, not an object:
+
+```ts
+const detail = await gw.configs.get(configs.data[0].id);
+const routing = JSON.parse(detail.config) as Record<string, unknown>;
+```
+:::
+
+## Admin Plane
+
+Organisation-level resources, not scoped to a single workspace: deployments, provider integrations, MCP integrations, plugins, and organisation/auth settings.
+
+```ts
+const deployments = await gw.deployments.list();
+const integrations = await gw.integrations.list();
+const mcp = await gw.mcpIntegrations.list();
+const plugins = await gw.plugins.list();
+const org = await gw.organisations.getSelf();
+```
+
+Per-integration model and workspace bindings:
+
+```ts
+const id = integrations.data[0].id;
+const models = await gw.integrations.getModels(id);
+const bound = await gw.integrations.getWorkspaces(id);
+console.log(bound.global_workspace_access.enabled); // an OBJECT on reads — see Gotchas
+```
+
+## Audit Logs
+
+:::danger[request_body is returned unredacted]
+`gw.auditLogs.list()` returns each entry's `request_body` **unredacted**. Records for credential-bearing calls (creating integrations, plugins, API keys) can contain live secrets — provider API keys, private keys — in plaintext. The sibling `request_headers` field is masked, but `request_body` is not. The SDK returns the response faithfully rather than altering it; **never log these records wholesale, and never forward them to a third-party sink.** Project to safe fields instead:
+
+```ts
+const audit = await gw.auditLogs.list({
+  start: new Date(Date.now() - 7 * 86_400_000),
+  end: new Date(),
+});
+// Safe projection — timestamp, method, and path only, never request_body.
+const summary = audit.records.map((r) => `${r.timestamp} ${r.method} ${r.uri.split('?')[0]}`);
+```
+:::
+
+## Gotchas
+
+- **Costs are in cents, everywhere.** `telemetry.cost().data.total`, `groupBy(...).data[].cost`, `byUser(...).data.records[].cost` — none of them are dollars. Divide by 100 yourself: `(cents / 100).toFixed(2)`.
+- **Workspace slug vs. id.** Telemetry (`gw.telemetry.*`) is keyed by `workspaceSlug`; config-plane lists (`gw.configs.list`, `gw.guardrails.list`, `gw.providers.list`, `gw.apiKeys.list*`) are keyed by `workspaceId`. Both come off the same `gw.workspaces.list()` row — `ws.slug` and `ws.id` — but passing one where the other is expected fails.
+- **`configs.list()` and `configs.get()` are different shapes** — the list read omits `config`/`format`/`type`/`version_id`, and `config` is a JSON string on the detail read, not an object. See the callout above.
+- **`deployments.delete()` is a soft delete.** It returns `200` with an empty body, and the record persists in `deployments.list()` with `status: 'archived'`. There is no observed hard-delete.
+- **`deployments.create()` is the only place credentials are ever readable.** It returns a 5-field receipt — `{ id, client_auth, credentials: { username, password }, organisation_id, object }` — not a deployment record, and `credentials.password` / `client_auth` are masked on every subsequent `deployments.get()`. Capture them from the create response or not at all:
+
+  ```ts
+  const receipt = await gw.deployments.create({
+    name: 'prod-us',
+    type: 'production',
+    organisation_id: '1852583913', // the TSG, NOT the org UUID
+    auth_settings: { allow_all_workspaces: true },
+  });
+  // receipt.credentials.password — capture now; gw.deployments.get(receipt.id) masks it.
+  ```
+
+- **`telemetry.logs()` paging is broken upstream.** Only `pageSize` works; `offset`/`page`/`skip` are ignored and every unfiltered call returns the same recent ~50-row batch. `statusCode` is the one filter that bypasses the cap — use `statusCode: 446` to pull every AIRS security block in the window, since `446` means the request was blocked before it ever reached the LLM (cost `0`).
+- **`organisation_id` is polymorphic across request and response.** Write requests take the TSG as a numeric string (e.g. `'1852583913'`); read responses return the internal organisation **UUID** in the same-named field. Never round-trip a response `organisation_id` back into a request — use the TSG value you already have.
+
+## Error Handling
+
+```ts
+import { AISecSDKException, ErrorType } from '@cdot65/prisma-airs-sdk';
+
+try {
+  await gw.configs.get('00000000-0000-4000-8000-000000000000');
+} catch (err) {
+  if (err instanceof AISecSDKException) {
+    switch (err.errorType) {
+      case ErrorType.OAUTH_ERROR:
+        console.error('Auth failed:', err.message);
+        break;
+      case ErrorType.CLIENT_SIDE_ERROR:
+        // AB03 in the message -> missing view_only_admin on main_airs_workspace_<TSG>
+        // "Access denied" (OPA) in the message -> missing admin role at tenant-root scope
+        // AB02 in the message -> real collection, wrong read form (usually missing workspace_id)
+        console.error('Client error:', err.statusCode, err.message);
+        break;
+      case ErrorType.USER_REQUEST_PAYLOAD_ERROR:
+        console.error('Invalid input:', err.message);
+        break;
+    }
+  }
+}
+```
+
+`AISecSDKException.message` has the API's `errorCode` appended automatically (e.g. `"... (errorCode: AB03)"`), so you can branch on the error codes above by inspecting `message` without parsing the response body yourself.
+
+ID parameters are also validated **before** any network call. UUID-shaped fields (config, workspace, integration, deployment IDs) use `assertUuid`; the TSG/organisation ID field uses `assertNumericId`, since it's a numeric string rather than a UUID. Both throw `AISecSDKException` with `ErrorType.USER_REQUEST_PAYLOAD_ERROR` immediately, without hitting the network:
+
+```ts
+try {
+  await gw.configs.get('not-a-uuid');
+} catch (err) {
+  if (err instanceof AISecSDKException) console.log(err.errorType); // AISEC_USER_REQUEST_PAYLOAD_ERROR
+}
+```
+
+For the complete, per-method list with input/output shapes (`AIGatewayClient` and its 12 sub-clients), see the [Full API reference](../reference/api/index.md).
+
+## Testing against a live tenant
+
+Unit tests run against recorded fixtures written by the same person who wrote the schemas, so they can't catch a schema that disagrees with the live API. `scripts/smoke-ai-gateway.ts` exists specifically to catch that class of bug: it calls all 42 read methods across both planes against a real tenant and reports which parse cleanly.
+
+It is opt-in, read-only, and **not** part of CI or `npm test` — it needs live credentials and hits a real tenant. It has already caught 3 real schema mismatches before they shipped (a config list/detail shape confusion, an MCP integration field typed as an object when the API returns a JSON string, and an integration's workspace-binding flag typed as a boolean when the API returns an object).
+
+```bash
+set -a && source .env && set +a && npm run smoke:ai-gateway
+```
+
+A runnable, read-only example covering telemetry, config plane, admin plane, audit logs, and error handling end-to-end lives at [`examples/ai-gateway.ts`](https://github.com/cdot65/prisma-airs-sdk/blob/main/examples/ai-gateway.ts) in the repo root — run it directly with `npx tsx examples/ai-gateway.ts`.

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -23,6 +23,7 @@ const sidebars: SidebarsConfig = {
         'guides/oauth-lifecycle',
         'guides/model-security-api',
         'guides/red-team-api',
+        'guides/ai-gateway-api',
         'guides/examples',
         {
           type: 'category',

--- a/examples/ai-gateway.ts
+++ b/examples/ai-gateway.ts
@@ -1,0 +1,209 @@
+#!/usr/bin/env tsx
+/**
+ * AI Gateway usage examples — Prisma AIRS SDK (v0.14.0).
+ *
+ * Every call below is READ-ONLY; write calls are shown as comments at the bottom instead of
+ * being executed. Verified against a live tenant.
+ *
+ * Requires PANW_AI_GW_* in the environment, falling back to PANW_MGMT_*. The service account
+ * needs BOTH SCM role grants or half the calls 403:
+ *   - an admin role at tenant-root scope               -> unlocks /ai_gw/admin/v2/*
+ *   - view_only_admin+ on main_airs_workspace_<TSG>     -> unlocks /ai_gw/v2/*
+ * See the "Authorization" section of docs-site/docs/guides/ai-gateway-api.mdx for how to check
+ * and grant these in SCM.
+ *
+ * This file is excluded from the published package (only `dist` ships) and from `tsc --noEmit`
+ * (root tsconfig only includes `src/**\/*`), matching the treatment of `scripts/`.
+ *
+ * Usage:
+ *   set -a && source .env && set +a && npx tsx examples/ai-gateway.ts
+ */
+import { AIGatewayClient, AISecSDKException } from '../src/index.js';
+
+const usd = (cents: number | null | undefined): string =>
+  cents == null ? 'n/a' : `$${(cents / 100).toFixed(2)}`;
+
+async function main(): Promise<void> {
+  // ── 1. Construct ────────────────────────────────────────────────────────
+  // Reads PANW_AI_GW_*, falling back to PANW_MGMT_*.
+  const gw = new AIGatewayClient();
+
+  // ── 2. Workspace: slug drives telemetry, id drives config-plane lists ────
+  const ws = (await gw.workspaces.list()).data[0];
+  const workspaceSlug = ws.slug;
+  const workspaceId = ws.id;
+  console.log(`workspace  ${ws.name}  slug=${workspaceSlug}`);
+  console.log(`           scope_name=${ws.scope_name}  <- the SCM scope your grant targets\n`);
+
+  // ── 3. Telemetry: COSTS ARE IN CENTS, the SDK never converts ────────────
+  const [cost, requests, latency, tokens] = await Promise.all([
+    gw.telemetry.cost({ workspaceSlug, days: 7 }),
+    gw.telemetry.requests({ workspaceSlug, days: 7 }),
+    gw.telemetry.latency({ workspaceSlug, days: 7 }),
+    gw.telemetry.tokens({ workspaceSlug, days: 7 }),
+  ]);
+  console.log('7-day totals');
+  console.log(`  spend     ${usd(cost.data.total)}  (wire: ${cost.data.total} cents)`);
+  console.log(`  requests  ${requests.data.total?.toLocaleString()}`);
+  console.log(
+    `  tokens    ${tokens.data.total.toLocaleString()} (in ${tokens.data.total_request_units.toLocaleString()} / out ${tokens.data.total_response_units.toLocaleString()})`,
+  );
+  console.log(
+    `  latency   mean ${latency.data.total.toFixed(0)}ms · p50 ${latency.data.p50} · p99 ${latency.data.p99}\n`,
+  );
+
+  // Explicit window instead of a rolling one:
+  //   gw.telemetry.cost({ workspaceSlug, start: new Date('2026-07-01'), end: new Date('2026-07-08') })
+
+  // ── 4. Group-by. Dimensions are underscore-named and load-bearing ───────
+  const byModel = await gw.telemetry.groupBy('model', {
+    workspaceSlug,
+    days: 7,
+    columns: ['cost', 'total_tokens'],
+  });
+  console.log('spend by model');
+  for (const r of byModel.data) {
+    console.log(
+      `  ${String(r.model).padEnd(28)} ${String(r.requests).padStart(6)} req  ${usd(r.cost).padStart(10)}`,
+    );
+  }
+
+  // ── 5. Status codes: 446 = AIRS blocked it before it reached the LLM ────
+  const codes = await gw.telemetry.byStatusCode({
+    workspaceSlug,
+    days: 7,
+    columns: ['cost', 'avg_latency'],
+  });
+  console.log('\nby HTTP status');
+  for (const r of codes.data) {
+    const note =
+      r.status_code === 446 ? '  <- AIRS security block (cost 0, never hit the LLM)' : '';
+    console.log(
+      `  ${String(r.status_code).padEnd(5)} ${String(r.requests).padStart(6)} req  ${usd(r.cost).padStart(10)}${note}`,
+    );
+  }
+
+  // ── 6. Raw logs. Paging is broken upstream: only pageSize works, and an
+  //      unfiltered call always returns the same recent batch. statusCode is
+  //      the one filter that bypasses the ~50-row cap.
+  const recent = await gw.telemetry.logs({ workspaceSlug, days: 1, pageSize: 3 });
+  console.log('\nrecent requests');
+  for (const r of recent.data.records) {
+    console.log(
+      `  ${r.created_at.slice(0, 19)}  ${String(r.response_status_code).padEnd(4)} ${r.ai_model.padEnd(24)} ${usd(r.cost).padStart(8)}  cache=${r.cache_status}`,
+    );
+  }
+  const blocked = await gw.telemetry.logs({ workspaceSlug, days: 7, statusCode: 446 });
+  console.log(`  AIRS blocks in window: ${blocked.data.records.length}`);
+
+  // ── 7. Config plane. NOTE list vs detail are DIFFERENT shapes: list rows
+  //      omit config/format/type/version_id. And `config` is a JSON STRING.
+  const configs = await gw.configs.list({ workspaceId });
+  console.log('\ngateway configs');
+  for (const c of configs.data) {
+    console.log(`  ${c.name.padEnd(18)} slug=${c.slug}`);
+  }
+  if (configs.data[0]) {
+    const detail = await gw.configs.get(configs.data[0].id); // detail read
+    const routing = JSON.parse(detail.config) as Record<string, unknown>; // string -> object
+    console.log(`  routing for "${detail.name}": ${JSON.stringify(routing)}`);
+  }
+
+  const guardrails = await gw.guardrails.list({ workspaceId });
+  const providers = await gw.providers.list({ workspaceId });
+  const svcKeys = await gw.apiKeys.listService({ workspaceId });
+  console.log(
+    `  guardrails=${guardrails.total}  providers=${providers.total}  serviceKeys=${svcKeys.total}`,
+  );
+
+  // ── 8. Admin plane. Same client, same credentials, different role scope.
+  //      delete() is a SOFT delete — records persist as status:'archived'.
+  const deployments = await gw.deployments.list();
+  const active = deployments.data.filter((d) => d.status === 'active');
+  console.log(`\ndeployments: ${deployments.data.length} total, ${active.length} active`);
+  for (const d of active) console.log(`  ${d.name.padEnd(14)} ${d.type.padEnd(16)} ${d.slug}`);
+
+  const integrations = await gw.integrations.list();
+  console.log('\nprovider integrations');
+  for (const i of integrations.data) console.log(`  ${i.name.padEnd(22)} ${i.status}`);
+
+  if (integrations.data[0]) {
+    const id = integrations.data[0].id;
+    const models = await gw.integrations.getModels(id);
+    const enabled = models.models.filter((m) => m.enabled).length;
+    const bound = await gw.integrations.getWorkspaces(id);
+    console.log(
+      `  -> ${enabled}/${models.models.length} models enabled, allow_all=${models.allow_all_models}`,
+    );
+    console.log(
+      `  -> bound to ${bound.workspaces.length} workspace(s), global access enabled=${bound.global_workspace_access.enabled}`,
+    );
+  }
+
+  const mcp = await gw.mcpIntegrations.list();
+  console.log(`\nMCP servers: ${mcp.total}`);
+  for (const m of mcp.data) console.log(`  ${m.name.padEnd(14)} ${m.transport.padEnd(6)} ${m.url}`);
+
+  // ── 9. Audit logs. SECURITY: request_body is returned UNREDACTED upstream
+  //      and can contain live credentials. The SDK returns wire data faithfully
+  //      rather than altering it. Project to safe fields; never log wholesale.
+  const audit = await gw.auditLogs.list({
+    start: new Date(Date.now() - 7 * 86_400_000),
+    end: new Date(),
+  });
+  console.log('\naudit trail (safe projection)');
+  for (const r of audit.records.slice(0, 4)) {
+    console.log(`  ${r.timestamp.slice(0, 19)}  ${r.method.padEnd(6)} ${r.uri.split('?')[0]}`);
+  }
+
+  // ── 10. Errors. The two 403s mean opposite things; the SDK surfaces the code
+  console.log('\nerror handling');
+  try {
+    await gw.configs.get('00000000-0000-4000-8000-000000000000');
+  } catch (e) {
+    if (e instanceof AISecSDKException) {
+      console.log(`  ${e.errorType} status=${e.statusCode}`);
+      console.log(`  "${e.message}"`);
+      console.log('    AB03 -> missing view_only_admin on main_airs_workspace_<TSG>');
+      console.log('    "Access denied" (OPA) -> missing admin role at tenant-root scope');
+      console.log('    AB02 -> real collection, wrong read form (usually a missing workspace_id)');
+    }
+  }
+  try {
+    await gw.configs.get('not-a-uuid'); // fails locally, before any network call
+  } catch (e) {
+    if (e instanceof AISecSDKException) console.log(`  local guard: ${e.errorType}`);
+  }
+
+  // ── Writes (NOT executed here) ──────────────────────────────────────────
+  //
+  // create() returns a 5-field RECEIPT, not a deployment record — and it is the
+  // only time credentials.password and client_auth are ever readable:
+  //   const receipt = await gw.deployments.create({
+  //     name: 'prod-us', type: 'production',
+  //     organisation_id: '1852583913',            // the TSG, NOT the org UUID
+  //     auth_settings: { allow_all_workspaces: true },
+  //   });
+  //   // receipt.credentials.password — capture now; the detail read masks it
+  //   const full = await gw.deployments.get(receipt.id);
+  //
+  // config is sent as an OBJECT but read back as a JSON string:
+  //   await gw.configs.create({
+  //     name: 'vertex-airs', workspace_id: workspaceId,
+  //     config: { retry: { attempts: 3 }, cache: { mode: 'simple' } },
+  //   });
+  //
+  //   await gw.guardrails.create({
+  //     workspace_id: workspaceId, name: 'PrismaAIRS',
+  //     checks: [{ id: 'panw.prisma-airs.intercept',
+  //                parameters: { profile_name: 'AI Gateway - Strict' }, is_enabled: true }],
+  //     actions: { deny: false, async: false, sequential: false },
+  //   });
+  //
+  //   await gw.deployments.delete(id, '1852583913');  // archives, does not remove
+}
+
+main().catch((e: unknown) => {
+  console.error('FAILED:', e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.13.2",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "docs:check:warn": "tsx scripts/check-example-coverage.ts --warn-only",
     "preflight": "tsx scripts/preflight-schemas.ts",
     "preflight:warn": "tsx scripts/preflight-schemas.ts --warn-only",
+    "smoke:ai-gateway": "tsx scripts/smoke-ai-gateway.ts",
     "prepare": "git config core.hooksPath .githooks && npm run build",
     "prepublishOnly": "npm run lint && npm run test"
   },

--- a/scripts/preflight-schemas.ts
+++ b/scripts/preflight-schemas.ts
@@ -57,6 +57,13 @@ const MODELED_SPECS = [
   'dlp/Dictionaries.yaml',
 ];
 
+/**
+ * Model files that intentionally have no OpenAPI spec, so their schemas must not be listed
+ * individually as "unmatched". AI Gateway has no published spec — its schemas are derived
+ * from live responses and documented in PRD-ai-gateway-client.md.
+ */
+const UNSPECCED_MODEL_FILES = ['ai-gateway.ts'];
+
 function findSpecFiles(): string[] {
   if (!existsSync(SCHEMAS_DIR)) {
     throw new Error(
@@ -168,11 +175,20 @@ function printReport(report: PreflightReport): void {
   );
 
   if (report.unmatchedZodSchemas.length > 0) {
-    console.log(
-      `[preflight] Unmatched Zod schemas (no OpenAPI counterpart, likely local helpers): ${report.unmatchedZodSchemas.length}`,
+    const unspecced = report.unmatchedZodSchemas.filter((u) =>
+      UNSPECCED_MODEL_FILES.some((f) => u.sourceFile.endsWith(f)),
     );
-    for (const u of report.unmatchedZodSchemas) {
+    const rest = report.unmatchedZodSchemas.filter((u) => !unspecced.includes(u));
+
+    console.log(
+      `[preflight] Unmatched Zod schemas (no OpenAPI counterpart, likely local helpers): ${rest.length}`,
+    );
+    for (const u of rest) {
       console.log(`  - ${u.exportName}  (${relative(ROOT, u.sourceFile)})`);
+    }
+    for (const f of UNSPECCED_MODEL_FILES) {
+      const n = unspecced.filter((u) => u.sourceFile.endsWith(f)).length;
+      if (n > 0) console.log(`[preflight] ${n} schemas in ${f} (no upstream spec by design)`);
     }
   }
 

--- a/scripts/smoke-ai-gateway.ts
+++ b/scripts/smoke-ai-gateway.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env tsx
+/**
+ * @internal
+ * AI Gateway live smoke test.
+ *
+ * Calls every AI Gateway READ method (41 total) against a real tenant and reports which
+ * parse cleanly. Unit tests use recorded fixtures written by the same person who wrote the
+ * schemas, so they cannot catch a schema that disagrees with the live API — this is the one
+ * mechanism that can. See PRD-ai-gateway-client.md in the Obsidian vault for the schema
+ * rationale and the defects this script has previously caught.
+ *
+ * Opt-in, read-only, NOT part of CI or `npm test` — it needs live credentials and hits a
+ * real tenant. Requires both SCM role grants on the service account (see
+ * `AIGatewayClient`'s class doc): an admin role at tenant-root scope (unlocks
+ * `/ai_gw/admin/v2/*`) and `view_only_admin`+ on the `main_airs_workspace_<TSG>` scope
+ * (unlocks `/ai_gw/v2/*`). Reads `PANW_AI_GW_*` env vars, falling back to `PANW_MGMT_*`.
+ *
+ * Usage:
+ *   set -a && source .env && set +a && npx tsx scripts/smoke-ai-gateway.ts
+ *   npm run smoke:ai-gateway
+ */
+import { fileURLToPath } from 'node:url';
+import { AIGatewayClient, AISecSDKException } from '../src/index.js';
+
+interface CheckResult {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+const gw = new AIGatewayClient();
+const results: CheckResult[] = [];
+
+async function check(name: string, fn: () => Promise<unknown>): Promise<void> {
+  try {
+    const r = await fn();
+    let shape = '';
+    if (r && typeof r === 'object') {
+      const o = r as Record<string, unknown>;
+      if (Array.isArray(o.data)) shape = `${o.data.length} rows`;
+      else if (Array.isArray(o.records)) shape = `${o.records.length} records`;
+      else if (o.data && typeof o.data === 'object') shape = 'envelope';
+      else shape = `${Object.keys(o).length} fields`;
+    }
+    results.push({ name, ok: true, detail: shape });
+  } catch (e) {
+    const msg =
+      e instanceof AISecSDKException
+        ? `${e.errorType}${e.statusCode ? ` ${e.statusCode}` : ''}: ${e.message.split('\n')[0].slice(0, 120)}`
+        : String(e).slice(0, 120);
+    results.push({ name, ok: false, detail: msg });
+  }
+}
+
+async function main(): Promise<void> {
+  const ws = await gw.workspaces.list();
+  const slug = ws.data[0].slug;
+  const wsId = ws.data[0].id;
+  const tsg = process.env.PANW_AI_GW_TSG_ID ?? process.env.PANW_MGMT_TSG_ID ?? '';
+  const win = { workspaceSlug: slug, days: 7 };
+
+  // --- data plane: telemetry (15 charts + 3 aggregates + raw logs) ---
+  await check('telemetry.cost', () => gw.telemetry.cost(win));
+  await check('telemetry.requests', () => gw.telemetry.requests(win));
+  await check('telemetry.latency', () => gw.telemetry.latency(win));
+  await check('telemetry.tokens', () => gw.telemetry.tokens(win));
+  await check('telemetry.errors', () => gw.telemetry.errors(win));
+  await check('telemetry.users', () => gw.telemetry.users(win));
+  await check('telemetry.cacheSummary', () => gw.telemetry.cacheSummary(win));
+  await check('telemetry.cacheHitTrend', () => gw.telemetry.cacheHitTrend(win));
+  await check('telemetry.userTrends', () => gw.telemetry.userTrends(win));
+  await check('telemetry.errorTrends', () => gw.telemetry.errorTrends(win));
+  await check('telemetry.rescuedRetries', () => gw.telemetry.rescuedRetries(win));
+  await check('telemetry.feedbackTrend', () => gw.telemetry.feedbackTrend(win));
+  await check('telemetry.feedbackWeighted', () => gw.telemetry.feedbackWeighted(win));
+  await check('telemetry.feedbackScoreDistribution', () =>
+    gw.telemetry.feedbackScoreDistribution(win),
+  );
+  await check('telemetry.feedbackModels', () => gw.telemetry.feedbackModels(win));
+  await check('telemetry.groupBy(ai_service)', () =>
+    gw.telemetry.groupBy('ai_service', {
+      ...win,
+      columns: ['cost', 'avg_latency', 'avg_tokens', 'total_tokens', 'success_rate', 'last_seen'],
+    }),
+  );
+  await check('telemetry.groupBy(model)', () =>
+    gw.telemetry.groupBy('model', { ...win, columns: ['cost', 'total_tokens'] }),
+  );
+  await check('telemetry.groupBy(api_key)', () =>
+    gw.telemetry.groupBy('api_key', { ...win, columns: ['cost'] }),
+  );
+  await check('telemetry.groupBy(provider)', () =>
+    gw.telemetry.groupBy('provider', { ...win, columns: ['cost'] }),
+  );
+  await check('telemetry.byUser', () => gw.telemetry.byUser(win));
+  await check('telemetry.byStatusCode', () =>
+    gw.telemetry.byStatusCode({ ...win, columns: ['cost', 'avg_latency'] }),
+  );
+  await check('telemetry.logs', () => gw.telemetry.logs({ ...win, pageSize: 5 }));
+  await check('telemetry.logs(statusCode)', () =>
+    gw.telemetry.logs({ ...win, statusCode: 200, pageSize: 3 }),
+  );
+
+  // --- data plane: config ---
+  await check('workspaces.list', () => gw.workspaces.list());
+  await check('workspaces.get', () => gw.workspaces.get(wsId));
+  await check('configs.list', () => gw.configs.list({ workspaceId: wsId }));
+  await check('guardrails.list', () => gw.guardrails.list({ workspaceId: wsId }));
+  await check('providers.list', () => gw.providers.list({ workspaceId: wsId }));
+  await check('apiKeys.listService', () => gw.apiKeys.listService({ workspaceId: wsId }));
+  await check('apiKeys.listUser', () => gw.apiKeys.listUser({ workspaceId: wsId }));
+
+  const cfgs = await gw.configs.list({ workspaceId: wsId }).catch(() => null);
+  if (cfgs?.data?.[0]) await check('configs.get', () => gw.configs.get(cfgs.data[0].id));
+
+  // --- admin plane ---
+  await check('integrations.list', () => gw.integrations.list());
+  await check('mcpIntegrations.list', () => gw.mcpIntegrations.list());
+  await check('deployments.list', () => gw.deployments.list());
+  await check('plugins.list', () => gw.plugins.list());
+  await check('organisations.getSelf', () => gw.organisations.getSelf());
+  await check('organisations.getAuthSettings', () => gw.organisations.getAuthSettings(tsg));
+  await check('auditLogs.list', () =>
+    gw.auditLogs.list({ start: new Date(Date.now() - 7 * 86_400_000), end: new Date() }),
+  );
+
+  const ints = await gw.integrations.list().catch(() => null);
+  if (ints?.data?.[0]) {
+    await check('integrations.get', () => gw.integrations.get(ints.data[0].id));
+    await check('integrations.getModels', () => gw.integrations.getModels(ints.data[0].id));
+    await check('integrations.getWorkspaces', () => gw.integrations.getWorkspaces(ints.data[0].id));
+  }
+  const deps = await gw.deployments.list().catch(() => null);
+  const activeDep = deps?.data?.find((d) => d.status === 'active');
+  if (activeDep) await check('deployments.get', () => gw.deployments.get(activeDep.id));
+
+  const pass = results.filter((r) => r.ok);
+  const fail = results.filter((r) => !r.ok);
+  for (const r of results) {
+    console.log(`${r.ok ? ' ok ' : 'FAIL'}  ${r.name.padEnd(36)} ${r.detail}`);
+  }
+  console.log(`\n${pass.length}/${results.length} read methods parse against the live tenant`);
+  if (fail.length) {
+    console.log(`\nFAILURES:`);
+    for (const f of fail) console.log(`  ${f.name}\n    ${f.detail}`);
+  }
+}
+
+const invokedDirectly = process.argv[1] === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  main().catch((e: unknown) => {
+    console.error('harness failed:', e instanceof Error ? e.message : e);
+    process.exit(1);
+  });
+}

--- a/src/ai-gateway/api-keys-client.ts
+++ b/src/ai-gateway/api-keys-client.ts
@@ -1,0 +1,214 @@
+import { AI_GW_API_KEYS_SERVICE_PATH, AI_GW_API_KEYS_USER_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  ListApiKeysResponseSchema,
+  GatewayWriteResponseSchema,
+  type ListApiKeysResponse,
+  type GatewayWriteResponse,
+} from '../models/ai-gateway.js';
+import type { AIGatewaySubClientOptions } from './types.js';
+import type { AIGatewayWorkspaceScopedListOptions } from './guardrails-client.js';
+
+/** Request body for creating a service or user API key. */
+export interface GatewayApiKeyCreateRequest {
+  name: string;
+  description?: string;
+  /** e.g. `completions.write`, `mcp.invoke`, `prompts.render`, `agents.invoke`, `logs.write`. */
+  scopes: string[];
+  /** The TSG as a numeric string — NOT the organisation UUID returned on reads. */
+  organisation_id: string;
+  workspace_id: string;
+  /** Usually `workspace`. */
+  type: string;
+  expires_at?: string | null;
+  defaults?: Record<string, unknown> | null;
+  rotation_policy?: Record<string, unknown> | null;
+  /** Required for user keys only. */
+  user_id?: string;
+}
+
+/**
+ * Client for AI Gateway API-key operations (data plane).
+ *
+ * Service and user keys are separate sub-collections; there is no combined `api-keys`
+ * endpoint (it is OPA-denied).
+ */
+export class AIGatewayApiKeysClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /** @internal */
+  private listAt(
+    path: string,
+    opts: AIGatewayWorkspaceScopedListOptions,
+  ): Promise<ListApiKeysResponse> {
+    assertUuid(opts.workspaceId, 'workspaceId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path,
+      params: { workspace_id: opts.workspaceId },
+      responseSchema: ListApiKeysResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /** @internal */
+  private writeAt(
+    method: 'POST' | 'PUT',
+    path: string,
+    body: GatewayApiKeyCreateRequest,
+  ): Promise<GatewayWriteResponse> {
+    assertUuid(body.workspace_id, 'workspace_id');
+    return request({
+      method,
+      baseUrl: this.baseUrl,
+      path,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * List service API keys in a workspace.
+   * @param opts - Must include the workspace UUID.
+   * @returns Service keys; the secret itself is only ever returned at creation.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const keys = await gw.apiKeys.listService({ workspaceId: '16f7e90d-382a-4e78-b577-1b01eb5f8297' });
+   * // keys.total => 1
+   * ```
+   */
+  async listService(opts: AIGatewayWorkspaceScopedListOptions): Promise<ListApiKeysResponse> {
+    return this.listAt(AI_GW_API_KEYS_SERVICE_PATH, opts);
+  }
+
+  /**
+   * List user API keys in a workspace.
+   * @param opts - Must include the workspace UUID.
+   * @returns User-scoped keys.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const keys = await gw.apiKeys.listUser({ workspaceId: '16f7e90d-382a-4e78-b577-1b01eb5f8297' });
+   * // keys.total => 0
+   * ```
+   */
+  async listUser(opts: AIGatewayWorkspaceScopedListOptions): Promise<ListApiKeysResponse> {
+    return this.listAt(AI_GW_API_KEYS_USER_PATH, opts);
+  }
+
+  /**
+   * Create a service API key.
+   * @param body - Name, scopes, TSG, workspace UUID, and type.
+   * @returns The raw create response — the only place the key secret appears. Capture it.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.apiKeys.createService({
+   *   name: 'ci-runner',
+   *   scopes: ['completions.write', 'logs.write'],
+   *   organisation_id: '1852583913',
+   *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+   *   type: 'workspace',
+   * });
+   * ```
+   */
+  async createService(body: GatewayApiKeyCreateRequest): Promise<GatewayWriteResponse> {
+    return this.writeAt('POST', AI_GW_API_KEYS_SERVICE_PATH, body);
+  }
+
+  /**
+   * Create a user API key.
+   * @param body - As {@link createService}, plus `user_id`.
+   * @returns The raw create response — the only place the key secret appears. Capture it.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.apiKeys.createUser({
+   *   name: 'calvin-laptop',
+   *   scopes: ['completions.write'],
+   *   organisation_id: '1852583913',
+   *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+   *   type: 'workspace',
+   *   user_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+   * });
+   * ```
+   */
+  async createUser(body: GatewayApiKeyCreateRequest): Promise<GatewayWriteResponse> {
+    return this.writeAt('POST', AI_GW_API_KEYS_USER_PATH, body);
+  }
+
+  /**
+   * Update a service API key.
+   * @param keyId - Key UUID.
+   * @param body - Replacement fields.
+   * @returns The raw update response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.apiKeys.updateService('11111111-1111-4111-8111-111111111111', {
+   *   name: 'ci-runner',
+   *   scopes: ['completions.write'],
+   *   organisation_id: '1852583913',
+   *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+   *   type: 'workspace',
+   * });
+   * ```
+   */
+  async updateService(
+    keyId: string,
+    body: GatewayApiKeyCreateRequest,
+  ): Promise<GatewayWriteResponse> {
+    assertUuid(keyId, 'keyId');
+    return this.writeAt('PUT', `${AI_GW_API_KEYS_SERVICE_PATH}/${keyId}`, body);
+  }
+
+  /**
+   * Update a user API key.
+   * @param keyId - Key UUID.
+   * @param body - Replacement fields.
+   * @returns The raw update response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.apiKeys.updateUser('11111111-1111-4111-8111-111111111111', {
+   *   name: 'calvin-laptop',
+   *   scopes: ['completions.write'],
+   *   organisation_id: '1852583913',
+   *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+   *   type: 'workspace',
+   *   user_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+   * });
+   * ```
+   */
+  async updateUser(keyId: string, body: GatewayApiKeyCreateRequest): Promise<GatewayWriteResponse> {
+    assertUuid(keyId, 'keyId');
+    return this.writeAt('PUT', `${AI_GW_API_KEYS_USER_PATH}/${keyId}`, body);
+  }
+}

--- a/src/ai-gateway/api-keys-client.ts
+++ b/src/ai-gateway/api-keys-client.ts
@@ -8,8 +8,7 @@ import {
   type ListApiKeysResponse,
   type GatewayWriteResponse,
 } from '../models/ai-gateway.js';
-import type { AIGatewaySubClientOptions } from './types.js';
-import type { AIGatewayWorkspaceScopedListOptions } from './guardrails-client.js';
+import type { AIGatewaySubClientOptions, AIGatewayWorkspaceScopedListOptions } from './types.js';
 
 /** Request body for creating a service or user API key. */
 export interface GatewayApiKeyCreateRequest {

--- a/src/ai-gateway/audit-logs-client.ts
+++ b/src/ai-gateway/audit-logs-client.ts
@@ -1,7 +1,10 @@
 import { AI_GW_AUDIT_LOGS_PATH } from '../constants.js';
 import { request } from '../http/request.js';
 import type { AuthAdapter } from '../http/types.js';
-import { AuditLogsResponseSchema, type AuditLogsResponse } from '../models/ai-gateway.js';
+import {
+  GatewayAuditLogsResponseSchema,
+  type GatewayAuditLogsResponse,
+} from '../models/ai-gateway.js';
 import type { AIGatewaySubClientOptions } from './types.js';
 
 /** Time range for an audit-log query. Both bounds are required by the API. */
@@ -31,7 +34,9 @@ export class AIGatewayAuditLogsClient {
    * contain live secrets — private keys, provider API keys — in plaintext. The sibling
    * `request_headers` field is masked, but `request_body` is not. The SDK returns the
    * response faithfully rather than altering it; never log these records wholesale, and
-   * never forward them to a third-party sink.
+   * never forward them to a third-party sink. Note that setting `PANW_AI_SEC_DEBUG` will
+   * print the raw response — including these unredacted secrets — to the SDK's own debug
+   * log regardless of this warning.
    *
    * @param opts - Inclusive start and end of the window.
    * @returns Audit records, newest first.
@@ -48,7 +53,7 @@ export class AIGatewayAuditLogsClient {
    * const summary = logs.records.map((r) => `${r.timestamp} ${r.method} ${r.uri}`);
    * ```
    */
-  async list(opts: AIGatewayAuditLogListOptions): Promise<AuditLogsResponse> {
+  async list(opts: AIGatewayAuditLogListOptions): Promise<GatewayAuditLogsResponse> {
     return request({
       method: 'GET',
       baseUrl: this.baseUrl,
@@ -57,7 +62,7 @@ export class AIGatewayAuditLogsClient {
         start_time: opts.start.toISOString(),
         end_time: opts.end.toISOString(),
       },
-      responseSchema: AuditLogsResponseSchema,
+      responseSchema: GatewayAuditLogsResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/ai-gateway/audit-logs-client.ts
+++ b/src/ai-gateway/audit-logs-client.ts
@@ -1,0 +1,65 @@
+import { AI_GW_AUDIT_LOGS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { AuditLogsResponseSchema, type AuditLogsResponse } from '../models/ai-gateway.js';
+import type { AIGatewaySubClientOptions } from './types.js';
+
+/** Time range for an audit-log query. Both bounds are required by the API. */
+export interface AIGatewayAuditLogListOptions {
+  start: Date;
+  end: Date;
+}
+
+/** Client for AI Gateway audit logs (admin plane). */
+export class AIGatewayAuditLogsClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * Read organisation audit logs.
+   *
+   * @remarks
+   * **Handle the result as sensitive.** The API returns each entry's `request_body`
+   * **unredacted**, so records for credential-bearing calls (integrations, plugins) can
+   * contain live secrets — private keys, provider API keys — in plaintext. The sibling
+   * `request_headers` field is masked, but `request_body` is not. The SDK returns the
+   * response faithfully rather than altering it; never log these records wholesale, and
+   * never forward them to a third-party sink.
+   *
+   * @param opts - Inclusive start and end of the window.
+   * @returns Audit records, newest first.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const logs = await gw.auditLogs.list({
+   *   start: new Date('2026-07-20T00:00:00Z'),
+   *   end: new Date(),
+   * });
+   * // Safe projection — never log the whole record.
+   * const summary = logs.records.map((r) => `${r.timestamp} ${r.method} ${r.uri}`);
+   * ```
+   */
+  async list(opts: AIGatewayAuditLogListOptions): Promise<AuditLogsResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_AUDIT_LOGS_PATH,
+      params: {
+        start_time: opts.start.toISOString(),
+        end_time: opts.end.toISOString(),
+      },
+      responseSchema: AuditLogsResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/ai-gateway/client.ts
+++ b/src/ai-gateway/client.ts
@@ -1,0 +1,135 @@
+import {
+  AI_GW_ADMIN_ENDPOINT,
+  AI_GW_DATA_ENDPOINT,
+  DEFAULT_AI_GW_ADMIN_ENDPOINT,
+  DEFAULT_AI_GW_DATA_ENDPOINT,
+} from '../constants.js';
+import { OAuthAuth } from '../http/auth/oauth.js';
+import { TsgHeaderAuth } from '../http/auth/tsg-header.js';
+import type { AuthAdapter } from '../http/types.js';
+import { resolveOAuthConfig } from '../oauth-config.js';
+import { AIGatewayTelemetryClient } from './telemetry-client.js';
+import { AIGatewayWorkspacesClient } from './workspaces-client.js';
+import { AIGatewayConfigsClient } from './configs-client.js';
+import { AIGatewayGuardrailsClient } from './guardrails-client.js';
+import { AIGatewayProvidersClient } from './providers-client.js';
+import { AIGatewayApiKeysClient } from './api-keys-client.js';
+import { AIGatewayIntegrationsClient } from './integrations-client.js';
+import { AIGatewayMcpIntegrationsClient } from './mcp-integrations-client.js';
+import { AIGatewayDeploymentsClient } from './deployments-client.js';
+import { AIGatewayPluginsClient } from './plugins-client.js';
+import { AIGatewayOrganisationsClient } from './organisations-client.js';
+import { AIGatewayAuditLogsClient } from './audit-logs-client.js';
+
+/** Options for constructing an {@link AIGatewayClient}. */
+export interface AIGatewayClientOptions {
+  /** OAuth2 client ID. Falls back to `PANW_AI_GW_CLIENT_ID`, then `PANW_MGMT_CLIENT_ID`. */
+  clientId?: string;
+  /** OAuth2 client secret. Falls back to `PANW_AI_GW_CLIENT_SECRET`, then `PANW_MGMT_CLIENT_SECRET`. */
+  clientSecret?: string;
+  /** Tenant Service Group ID. Falls back to `PANW_AI_GW_TSG_ID`, then `PANW_MGMT_TSG_ID`. */
+  tsgId?: string;
+  /** Data-plane endpoint. Falls back to `PANW_AI_GW_DATA_ENDPOINT`. */
+  dataEndpoint?: string;
+  /** Admin-plane endpoint. Falls back to `PANW_AI_GW_ADMIN_ENDPOINT`. */
+  adminEndpoint?: string;
+  /** OAuth2 token endpoint. Falls back to `PANW_AI_GW_TOKEN_ENDPOINT`, then `PANW_MGMT_TOKEN_ENDPOINT`. */
+  tokenEndpoint?: string;
+  /** Max retry attempts (0-5). Defaults to 5. */
+  numRetries?: number;
+}
+
+/**
+ * Client for the Prisma AIRS AI Gateway, managed through Strata Cloud Manager.
+ *
+ * Spans two planes over one credential set: the **data plane** (`/ai_gw/v2`) for runtime
+ * telemetry and workspace-scoped config, and the **admin plane** (`/ai_gw/admin/v2`) for
+ * organisation-level config.
+ *
+ * @remarks
+ * The two planes authorize against **different SCM role scopes**, and the service account
+ * needs both grants or half the API returns 403:
+ *
+ * - an admin role at **tenant root** scope → `/ai_gw/admin/v2/*`
+ * - `view_only_admin` or higher on the **`main_airs_workspace_<TSG>`** scope → `/ai_gw/v2/*`
+ *
+ * Both can coexist on one account, but SCM's Access Management UI edits an existing role row
+ * by default — use *Add Role* to add the second, or you will move the first instead of
+ * adding to it. A `403` whose body carries `errorCode: "AB03"` means the workspace-scope
+ * grant is missing; a `403` carrying `x-opa-decision: false` means the tenant-root grant is.
+ *
+ * @example
+ * ```ts
+ * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+ *
+ * // Reads PANW_AI_GW_* (falling back to PANW_MGMT_*) env vars.
+ * const gw = new AIGatewayClient();
+ *
+ * const cost = await gw.telemetry.cost({ workspaceSlug: 'ws-main-a-349e0e', days: 7 });
+ * console.log(`$${(cost.data.total / 100).toFixed(2)}`); // cost is in cents
+ * ```
+ */
+export class AIGatewayClient {
+  /** Runtime telemetry: charts, group-bys, and raw request logs. */
+  public readonly telemetry: AIGatewayTelemetryClient;
+  /** Workspace reads (data plane). */
+  public readonly workspaces: AIGatewayWorkspacesClient;
+  /** Gateway routing configs. */
+  public readonly configs: AIGatewayConfigsClient;
+  /** Workspace guardrails. */
+  public readonly guardrails: AIGatewayGuardrailsClient;
+  /** Workspace-scoped provider bindings. */
+  public readonly providers: AIGatewayProvidersClient;
+  /** Service and user API keys. */
+  public readonly apiKeys: AIGatewayApiKeysClient;
+  /** Organisation-level provider integrations (admin plane). */
+  public readonly integrations: AIGatewayIntegrationsClient;
+  /** MCP server integrations (admin plane). */
+  public readonly mcpIntegrations: AIGatewayMcpIntegrationsClient;
+  /** Gateway deployments (admin plane). */
+  public readonly deployments: AIGatewayDeploymentsClient;
+  /** Plugin bindings such as the Prisma AIRS scanner (admin plane). */
+  public readonly plugins: AIGatewayPluginsClient;
+  /** Organisation and auth settings (admin plane). */
+  public readonly organisations: AIGatewayOrganisationsClient;
+  /** Organisation audit logs (admin plane). */
+  public readonly auditLogs: AIGatewayAuditLogsClient;
+
+  constructor(opts: AIGatewayClientOptions = {}) {
+    const dataEndpoint =
+      opts.dataEndpoint ?? process.env[AI_GW_DATA_ENDPOINT] ?? DEFAULT_AI_GW_DATA_ENDPOINT;
+    const adminEndpoint =
+      opts.adminEndpoint ?? process.env[AI_GW_ADMIN_ENDPOINT] ?? DEFAULT_AI_GW_ADMIN_ENDPOINT;
+
+    const { oauthClient, numRetries, tsgId } = resolveOAuthConfig({
+      clientId: opts.clientId,
+      clientSecret: opts.clientSecret,
+      tsgId: opts.tsgId,
+      baseUrl: dataEndpoint,
+      numRetries: opts.numRetries,
+      tokenEndpoint: opts.tokenEndpoint,
+      primaryEnvPrefix: 'PANW_AI_GW',
+      fallbackEnvPrefix: 'PANW_MGMT',
+    });
+
+    // Every AI Gateway endpoint requires x-tsg-id on top of the bearer token.
+    const auth: AuthAdapter = new TsgHeaderAuth(new OAuthAuth(oauthClient), tsgId);
+
+    const dataOpts = { baseUrl: dataEndpoint, auth, numRetries };
+    const adminOpts = { baseUrl: adminEndpoint, auth, numRetries };
+
+    this.telemetry = new AIGatewayTelemetryClient({ ...dataOpts, tsgId });
+    this.workspaces = new AIGatewayWorkspacesClient(dataOpts);
+    this.configs = new AIGatewayConfigsClient(dataOpts);
+    this.guardrails = new AIGatewayGuardrailsClient(dataOpts);
+    this.providers = new AIGatewayProvidersClient(dataOpts);
+    this.apiKeys = new AIGatewayApiKeysClient(dataOpts);
+
+    this.integrations = new AIGatewayIntegrationsClient(adminOpts);
+    this.mcpIntegrations = new AIGatewayMcpIntegrationsClient(adminOpts);
+    this.deployments = new AIGatewayDeploymentsClient(adminOpts);
+    this.plugins = new AIGatewayPluginsClient(adminOpts);
+    this.organisations = new AIGatewayOrganisationsClient(adminOpts);
+    this.auditLogs = new AIGatewayAuditLogsClient(adminOpts);
+  }
+}

--- a/src/ai-gateway/configs-client.ts
+++ b/src/ai-gateway/configs-client.ts
@@ -10,13 +10,7 @@ import {
   type GatewayConfig,
   type GatewayWriteResponse,
 } from '../models/ai-gateway.js';
-import type { AIGatewaySubClientOptions } from './types.js';
-
-/** Options for listing configs. */
-export interface AIGatewayConfigListOptions {
-  /** Workspace UUID. Required — omitting it returns `404 AB02`, not an empty list. */
-  workspaceId: string;
-}
+import type { AIGatewaySubClientOptions, AIGatewayWorkspaceScopedListOptions } from './types.js';
 
 /** Request body for creating or updating a config. */
 export interface GatewayConfigCreateRequest {
@@ -56,7 +50,7 @@ export class AIGatewayConfigsClient {
    * // routing.provider => '@anthropic-prod'
    * ```
    */
-  async list(opts: AIGatewayConfigListOptions): Promise<ListConfigsResponse> {
+  async list(opts: AIGatewayWorkspaceScopedListOptions): Promise<ListConfigsResponse> {
     assertUuid(opts.workspaceId, 'workspaceId');
     return request({
       method: 'GET',

--- a/src/ai-gateway/configs-client.ts
+++ b/src/ai-gateway/configs-client.ts
@@ -4,10 +4,10 @@ import type { AuthAdapter } from '../http/types.js';
 import { assertUuid } from '../validators.js';
 import {
   ListConfigsResponseSchema,
-  GatewayConfigSchema,
+  GatewayConfigDetailSchema,
   GatewayWriteResponseSchema,
   type ListConfigsResponse,
-  type GatewayConfig,
+  type GatewayConfigDetail,
   type GatewayWriteResponse,
 } from '../models/ai-gateway.js';
 import type { AIGatewaySubClientOptions, AIGatewayWorkspaceScopedListOptions } from './types.js';
@@ -38,16 +38,20 @@ export class AIGatewayConfigsClient {
 
   /**
    * List configs in a workspace.
+   *
+   * @remarks
+   * List rows are a strict 12-field subset of the detail read — they do NOT carry `config`,
+   * `format`, `type`, or `version_id`. Call {@link get} for those.
+   *
    * @param opts - Must include the workspace UUID.
-   * @returns Configs, each with `config` as a JSON-encoded string.
+   * @returns Config list rows.
    * @example
    * ```ts
    * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
    * const gw = new AIGatewayClient();
    *
    * const cfgs = await gw.configs.list({ workspaceId: '16f7e90d-382a-4e78-b577-1b01eb5f8297' });
-   * const routing = JSON.parse(cfgs.data[0].config) as Record<string, unknown>;
-   * // routing.provider => '@anthropic-prod'
+   * // cfgs.data[0] => { name: 'claude-code', slug: 'pc-claude-e46fe6', status: 'active', ... }
    * ```
    */
   async list(opts: AIGatewayWorkspaceScopedListOptions): Promise<ListConfigsResponse> {
@@ -66,23 +70,25 @@ export class AIGatewayConfigsClient {
   /**
    * Fetch one config.
    * @param configId - Config UUID.
-   * @returns The config; `config` is a JSON-encoded string, not an object.
+   * @returns The config detail — adds `config` (a JSON-encoded string, not an object),
+   * `format`, `type`, and `version_id` on top of the list row.
    * @example
    * ```ts
    * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
    * const gw = new AIGatewayClient();
    *
    * const cfg = await gw.configs.get('764cf9cd-4ebf-449e-b669-08149b0fbbbc');
-   * // cfg.name => 'claude-code'
+   * const routing = JSON.parse(cfg.config) as Record<string, unknown>;
+   * // routing.provider => '@anthropic-prod'
    * ```
    */
-  async get(configId: string): Promise<GatewayConfig> {
+  async get(configId: string): Promise<GatewayConfigDetail> {
     assertUuid(configId, 'configId');
     return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${AI_GW_CONFIGS_PATH}/${configId}`,
-      responseSchema: GatewayConfigSchema,
+      responseSchema: GatewayConfigDetailSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/ai-gateway/configs-client.ts
+++ b/src/ai-gateway/configs-client.ts
@@ -10,7 +10,7 @@ import {
   type GatewayConfig,
   type GatewayWriteResponse,
 } from '../models/ai-gateway.js';
-import type { AIGatewaySubClientOptions } from './workspaces-client.js';
+import type { AIGatewaySubClientOptions } from './types.js';
 
 /** Options for listing configs. */
 export interface AIGatewayConfigListOptions {
@@ -142,6 +142,7 @@ export class AIGatewayConfigsClient {
    */
   async update(configId: string, body: GatewayConfigCreateRequest): Promise<GatewayWriteResponse> {
     assertUuid(configId, 'configId');
+    assertUuid(body.workspace_id, 'workspace_id');
     return request({
       method: 'PUT',
       baseUrl: this.baseUrl,

--- a/src/ai-gateway/configs-client.ts
+++ b/src/ai-gateway/configs-client.ts
@@ -1,0 +1,155 @@
+import { AI_GW_CONFIGS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  ListConfigsResponseSchema,
+  GatewayConfigSchema,
+  GatewayWriteResponseSchema,
+  type ListConfigsResponse,
+  type GatewayConfig,
+  type GatewayWriteResponse,
+} from '../models/ai-gateway.js';
+import type { AIGatewaySubClientOptions } from './workspaces-client.js';
+
+/** Options for listing configs. */
+export interface AIGatewayConfigListOptions {
+  /** Workspace UUID. Required — omitting it returns `404 AB02`, not an empty list. */
+  workspaceId: string;
+}
+
+/** Request body for creating or updating a config. */
+export interface GatewayConfigCreateRequest {
+  name: string;
+  /** Workspace UUID the config belongs to. */
+  workspace_id: string;
+  /**
+   * The gateway routing config. Sent as an **object**; note the API returns it back as a
+   * JSON-encoded **string** on reads.
+   */
+  config: Record<string, unknown>;
+}
+
+/** Client for AI Gateway config operations (data plane). */
+export class AIGatewayConfigsClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List configs in a workspace.
+   * @param opts - Must include the workspace UUID.
+   * @returns Configs, each with `config` as a JSON-encoded string.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const cfgs = await gw.configs.list({ workspaceId: '16f7e90d-382a-4e78-b577-1b01eb5f8297' });
+   * const routing = JSON.parse(cfgs.data[0].config) as Record<string, unknown>;
+   * // routing.provider => '@anthropic-prod'
+   * ```
+   */
+  async list(opts: AIGatewayConfigListOptions): Promise<ListConfigsResponse> {
+    assertUuid(opts.workspaceId, 'workspaceId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_CONFIGS_PATH,
+      params: { workspace_id: opts.workspaceId },
+      responseSchema: ListConfigsResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Fetch one config.
+   * @param configId - Config UUID.
+   * @returns The config; `config` is a JSON-encoded string, not an object.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const cfg = await gw.configs.get('764cf9cd-4ebf-449e-b669-08149b0fbbbc');
+   * // cfg.name => 'claude-code'
+   * ```
+   */
+  async get(configId: string): Promise<GatewayConfig> {
+    assertUuid(configId, 'configId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_CONFIGS_PATH}/${configId}`,
+      responseSchema: GatewayConfigSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Create a config.
+   * @param body - Name, workspace UUID, and the routing config object.
+   * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.configs.create({
+   *   name: 'vertex-airs',
+   *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+   *   config: { retry: { attempts: 3 }, cache: { mode: 'simple' } },
+   * });
+   * ```
+   */
+  async create(body: GatewayConfigCreateRequest): Promise<GatewayWriteResponse> {
+    assertUuid(body.workspace_id, 'workspace_id');
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: AI_GW_CONFIGS_PATH,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Update a config.
+   * @param configId - Config UUID.
+   * @param body - Replacement fields.
+   * @returns The raw update response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.configs.update('764cf9cd-4ebf-449e-b669-08149b0fbbbc', {
+   *   name: 'claude-code',
+   *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+   *   config: { retry: { attempts: 5 } },
+   * });
+   * ```
+   */
+  async update(configId: string, body: GatewayConfigCreateRequest): Promise<GatewayWriteResponse> {
+    assertUuid(configId, 'configId');
+    return request({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_CONFIGS_PATH}/${configId}`,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/ai-gateway/deployments-client.ts
+++ b/src/ai-gateway/deployments-client.ts
@@ -4,16 +4,16 @@ import type { AuthAdapter } from '../http/types.js';
 import { assertUuid, assertNumericId } from '../validators.js';
 import {
   ListDeploymentsResponseSchema,
-  DeploymentDetailSchema,
-  DeploymentCreateResponseSchema,
+  GatewayDeploymentDetailSchema,
+  GatewayDeploymentCreateResponseSchema,
   type ListDeploymentsResponse,
-  type DeploymentDetail,
-  type DeploymentCreateResponse,
+  type GatewayDeploymentDetail,
+  type GatewayDeploymentCreateResponse,
 } from '../models/ai-gateway.js';
 import type { AIGatewaySubClientOptions } from './types.js';
 
 /** Request body for creating a deployment. */
-export interface DeploymentCreateRequest {
+export interface GatewayDeploymentCreateRequest {
   name: string;
   /** `production` or `non_production`. */
   type: string;
@@ -77,13 +77,13 @@ export class AIGatewayDeploymentsClient {
    * // d.auth_settings?.allow_all_workspaces => 1   (a number, not a boolean)
    * ```
    */
-  async get(deploymentId: string): Promise<DeploymentDetail> {
+  async get(deploymentId: string): Promise<GatewayDeploymentDetail> {
     assertUuid(deploymentId, 'deploymentId');
     return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${AI_GW_DEPLOYMENTS_PATH}/${deploymentId}`,
-      responseSchema: DeploymentDetailSchema,
+      responseSchema: GatewayDeploymentDetailSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });
@@ -118,13 +118,13 @@ export class AIGatewayDeploymentsClient {
    * const full = await gw.deployments.get(receipt.id);
    * ```
    */
-  async create(body: DeploymentCreateRequest): Promise<DeploymentCreateResponse> {
+  async create(body: GatewayDeploymentCreateRequest): Promise<GatewayDeploymentCreateResponse> {
     return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: AI_GW_DEPLOYMENTS_PATH,
       body,
-      responseSchema: DeploymentCreateResponseSchema,
+      responseSchema: GatewayDeploymentCreateResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/ai-gateway/deployments-client.ts
+++ b/src/ai-gateway/deployments-client.ts
@@ -1,7 +1,7 @@
 import { AI_GW_DEPLOYMENTS_PATH } from '../constants.js';
 import { request } from '../http/request.js';
 import type { AuthAdapter } from '../http/types.js';
-import { assertUuid } from '../validators.js';
+import { assertUuid, assertNumericId } from '../validators.js';
 import {
   ListDeploymentsResponseSchema,
   DeploymentDetailSchema,
@@ -98,6 +98,8 @@ export class AIGatewayDeploymentsClient {
    *
    * This is the **only** time `credentials.password` and `client_auth` are readable; the
    * detail read masks them. Capture them here or they are unrecoverable. Never log them.
+   * Note that setting `PANW_AI_SEC_DEBUG` will print the raw request/response, including
+   * `credentials.password`, to the SDK's own debug log regardless of this warning.
    *
    * @param body - Name, type, TSG, and auth settings.
    * @returns The creation receipt including the deployment's gateway credentials.
@@ -150,6 +152,7 @@ export class AIGatewayDeploymentsClient {
    */
   async delete(deploymentId: string, organisationId: string): Promise<void> {
     assertUuid(deploymentId, 'deploymentId');
+    assertNumericId(organisationId, 'organisationId');
     // The API returns 200 with an empty body. request() resolves to undefined whenever
     // no responseSchema is supplied, regardless of allowEmptyBody — so that flag is
     // intentionally omitted here rather than implying it does something.

--- a/src/ai-gateway/deployments-client.ts
+++ b/src/ai-gateway/deployments-client.ts
@@ -1,0 +1,165 @@
+import { AI_GW_DEPLOYMENTS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  ListDeploymentsResponseSchema,
+  DeploymentDetailSchema,
+  DeploymentCreateResponseSchema,
+  type ListDeploymentsResponse,
+  type DeploymentDetail,
+  type DeploymentCreateResponse,
+} from '../models/ai-gateway.js';
+import type { AIGatewaySubClientOptions } from './types.js';
+
+/** Request body for creating a deployment. */
+export interface DeploymentCreateRequest {
+  name: string;
+  /** `production` or `non_production`. */
+  type: string;
+  /** The TSG as a numeric string — NOT the organisation UUID returned on reads. */
+  organisation_id: string;
+  /** Note `allow_all_workspaces` is a real boolean here; reads return it as 0/1. */
+  auth_settings?: { allow_all_workspaces?: boolean; [k: string]: unknown };
+}
+
+/** Client for AI Gateway deployment operations (admin plane). */
+export class AIGatewayDeploymentsClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List deployments.
+   *
+   * @remarks
+   * Archived deployments are included — `delete()` is a soft-delete. Filter on
+   * `status === 'active'` if you only want live ones.
+   *
+   * @returns All deployments, active and archived.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const all = await gw.deployments.list();
+   * const live = all.data.filter((d) => d.status === 'active');
+   * // live[0] => { name: 'talos', slug: 'dp-talos-f3b74e', status: 'active', ... }
+   * ```
+   */
+  async list(): Promise<ListDeploymentsResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_DEPLOYMENTS_PATH,
+      responseSchema: ListDeploymentsResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Fetch one deployment.
+   * @param deploymentId - Deployment UUID.
+   * @returns Deployment detail, including bound workspaces and masked credentials.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const d = await gw.deployments.get('32e8314e-7e68-4384-aacb-a476f6c3f91d');
+   * // d.auth_settings?.allow_all_workspaces => 1   (a number, not a boolean)
+   * ```
+   */
+  async get(deploymentId: string): Promise<DeploymentDetail> {
+    assertUuid(deploymentId, 'deploymentId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_DEPLOYMENTS_PATH}/${deploymentId}`,
+      responseSchema: DeploymentDetailSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Create a deployment.
+   *
+   * @remarks
+   * The response is a **creation receipt**, not a deployment record — it has 5 fields and
+   * carries no `name`, `slug`, or `status`. Call {@link get} for the full record.
+   *
+   * This is the **only** time `credentials.password` and `client_auth` are readable; the
+   * detail read masks them. Capture them here or they are unrecoverable. Never log them.
+   *
+   * @param body - Name, type, TSG, and auth settings.
+   * @returns The creation receipt including the deployment's gateway credentials.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const receipt = await gw.deployments.create({
+   *   name: 'prod-us',
+   *   type: 'production',
+   *   organisation_id: '1852583913',
+   *   auth_settings: { allow_all_workspaces: true },
+   * });
+   * // receipt => { id: '2141...', client_auth: 'client-auth-...', credentials: { username, password }, ... }
+   * const full = await gw.deployments.get(receipt.id);
+   * ```
+   */
+  async create(body: DeploymentCreateRequest): Promise<DeploymentCreateResponse> {
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: AI_GW_DEPLOYMENTS_PATH,
+      body,
+      responseSchema: DeploymentCreateResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Archive a deployment.
+   *
+   * @remarks
+   * This is a **soft delete**. The API returns 200 with an empty body and the record
+   * persists with `status: 'archived'`, still visible in {@link list}. There is no
+   * observed hard-delete.
+   *
+   * @param deploymentId - Deployment UUID.
+   * @param organisationId - The TSG as a numeric string; sent as a query param.
+   * @returns Nothing.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.deployments.delete('21414819-485e-4ba3-b3d3-3e1815580e43', '1852583913');
+   * // the record remains in list() with status 'archived'
+   * ```
+   */
+  async delete(deploymentId: string, organisationId: string): Promise<void> {
+    assertUuid(deploymentId, 'deploymentId');
+    // The API returns 200 with an empty body. request() resolves to undefined whenever
+    // no responseSchema is supplied, regardless of allowEmptyBody — so that flag is
+    // intentionally omitted here rather than implying it does something.
+    await request({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_DEPLOYMENTS_PATH}/${deploymentId}`,
+      params: { organisation_id: organisationId },
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/ai-gateway/guardrails-client.ts
+++ b/src/ai-gateway/guardrails-client.ts
@@ -1,0 +1,102 @@
+import { AI_GW_GUARDRAILS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  ListGuardrailsResponseSchema,
+  GatewayWriteResponseSchema,
+  type ListGuardrailsResponse,
+  type GatewayWriteResponse,
+} from '../models/ai-gateway.js';
+import type { AIGatewaySubClientOptions } from './types.js';
+
+/** Options for listing workspace-scoped resources. */
+export interface AIGatewayWorkspaceScopedListOptions {
+  /** Workspace UUID. Required — omitting it returns `404 AB02`. */
+  workspaceId: string;
+}
+
+/** One guardrail check binding. */
+export interface GatewayGuardrailCheck {
+  /** Check id, e.g. the Prisma AIRS intercept check. */
+  id: string;
+  parameters: Record<string, unknown>;
+  is_enabled: boolean;
+}
+
+/** Request body for creating a guardrail. */
+export interface GatewayGuardrailCreateRequest {
+  workspace_id: string;
+  name: string;
+  checks: GatewayGuardrailCheck[];
+  actions: Record<string, unknown>;
+}
+
+/** Client for AI Gateway guardrail operations (data plane). */
+export class AIGatewayGuardrailsClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List guardrails in a workspace.
+   * @param opts - Must include the workspace UUID.
+   * @returns Guardrails defined on that workspace.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const g = await gw.guardrails.list({ workspaceId: '16f7e90d-382a-4e78-b577-1b01eb5f8297' });
+   * // g.data[0].id => 'pg-prisma-099a16'
+   * ```
+   */
+  async list(opts: AIGatewayWorkspaceScopedListOptions): Promise<ListGuardrailsResponse> {
+    assertUuid(opts.workspaceId, 'workspaceId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_GUARDRAILS_PATH,
+      params: { workspace_id: opts.workspaceId },
+      responseSchema: ListGuardrailsResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Create a guardrail.
+   * @param body - Workspace UUID, name, checks, and pass/fail actions.
+   * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.guardrails.create({
+   *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+   *   name: 'PrismaAIRS',
+   *   checks: [{ id: 'panw.prisma-airs.intercept', parameters: { profile_name: 'AI Gateway - Strict' }, is_enabled: true }],
+   *   actions: { deny: false, async: false, sequential: false },
+   * });
+   * ```
+   */
+  async create(body: GatewayGuardrailCreateRequest): Promise<GatewayWriteResponse> {
+    assertUuid(body.workspace_id, 'workspace_id');
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: AI_GW_GUARDRAILS_PATH,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/ai-gateway/guardrails-client.ts
+++ b/src/ai-gateway/guardrails-client.ts
@@ -8,13 +8,7 @@ import {
   type ListGuardrailsResponse,
   type GatewayWriteResponse,
 } from '../models/ai-gateway.js';
-import type { AIGatewaySubClientOptions } from './types.js';
-
-/** Options for listing workspace-scoped resources. */
-export interface AIGatewayWorkspaceScopedListOptions {
-  /** Workspace UUID. Required — omitting it returns `404 AB02`. */
-  workspaceId: string;
-}
+import type { AIGatewaySubClientOptions, AIGatewayWorkspaceScopedListOptions } from './types.js';
 
 /** One guardrail check binding. */
 export interface GatewayGuardrailCheck {

--- a/src/ai-gateway/index.ts
+++ b/src/ai-gateway/index.ts
@@ -1,20 +1,19 @@
 export { AIGatewayClient, type AIGatewayClientOptions } from './client.js';
 export {
   AIGatewayTelemetryClient,
+  type AIGatewayTelemetryClientOptions,
   type AIGatewayGroupOptions,
   type AIGatewayLogsOptions,
 } from './telemetry-client.js';
 export { type AIGatewayWindowOptions } from './window.js';
-export { type AIGatewaySubClientOptions } from './types.js';
-export { AIGatewayWorkspacesClient } from './workspaces-client.js';
 export {
-  AIGatewayConfigsClient,
-  type AIGatewayConfigListOptions,
-  type GatewayConfigCreateRequest,
-} from './configs-client.js';
+  type AIGatewaySubClientOptions,
+  type AIGatewayWorkspaceScopedListOptions,
+} from './types.js';
+export { AIGatewayWorkspacesClient } from './workspaces-client.js';
+export { AIGatewayConfigsClient, type GatewayConfigCreateRequest } from './configs-client.js';
 export {
   AIGatewayGuardrailsClient,
-  type AIGatewayWorkspaceScopedListOptions,
   type GatewayGuardrailCheck,
   type GatewayGuardrailCreateRequest,
 } from './guardrails-client.js';
@@ -29,6 +28,7 @@ export {
 export {
   AIGatewayMcpIntegrationsClient,
   type McpIntegrationCreateRequest,
+  type McpIntegrationWorkspacesRequest,
 } from './mcp-integrations-client.js';
 export { AIGatewayDeploymentsClient, type DeploymentCreateRequest } from './deployments-client.js';
 export { AIGatewayPluginsClient, type PluginCreateRequest } from './plugins-client.js';

--- a/src/ai-gateway/index.ts
+++ b/src/ai-gateway/index.ts
@@ -21,17 +21,20 @@ export { AIGatewayProvidersClient, type GatewayProviderCreateRequest } from './p
 export { AIGatewayApiKeysClient, type GatewayApiKeyCreateRequest } from './api-keys-client.js';
 export {
   AIGatewayIntegrationsClient,
-  type IntegrationCreateRequest,
-  type IntegrationModelsRequest,
-  type IntegrationWorkspacesRequest,
+  type GatewayIntegrationCreateRequest,
+  type GatewayIntegrationModelsRequest,
+  type GatewayIntegrationWorkspacesRequest,
 } from './integrations-client.js';
 export {
   AIGatewayMcpIntegrationsClient,
   type McpIntegrationCreateRequest,
   type McpIntegrationWorkspacesRequest,
 } from './mcp-integrations-client.js';
-export { AIGatewayDeploymentsClient, type DeploymentCreateRequest } from './deployments-client.js';
-export { AIGatewayPluginsClient, type PluginCreateRequest } from './plugins-client.js';
+export {
+  AIGatewayDeploymentsClient,
+  type GatewayDeploymentCreateRequest,
+} from './deployments-client.js';
+export { AIGatewayPluginsClient, type GatewayPluginCreateRequest } from './plugins-client.js';
 export { AIGatewayOrganisationsClient } from './organisations-client.js';
 export {
   AIGatewayAuditLogsClient,

--- a/src/ai-gateway/index.ts
+++ b/src/ai-gateway/index.ts
@@ -1,0 +1,39 @@
+export { AIGatewayClient, type AIGatewayClientOptions } from './client.js';
+export {
+  AIGatewayTelemetryClient,
+  type AIGatewayGroupOptions,
+  type AIGatewayLogsOptions,
+} from './telemetry-client.js';
+export { type AIGatewayWindowOptions } from './window.js';
+export { type AIGatewaySubClientOptions } from './types.js';
+export { AIGatewayWorkspacesClient } from './workspaces-client.js';
+export {
+  AIGatewayConfigsClient,
+  type AIGatewayConfigListOptions,
+  type GatewayConfigCreateRequest,
+} from './configs-client.js';
+export {
+  AIGatewayGuardrailsClient,
+  type AIGatewayWorkspaceScopedListOptions,
+  type GatewayGuardrailCheck,
+  type GatewayGuardrailCreateRequest,
+} from './guardrails-client.js';
+export { AIGatewayProvidersClient, type GatewayProviderCreateRequest } from './providers-client.js';
+export { AIGatewayApiKeysClient, type GatewayApiKeyCreateRequest } from './api-keys-client.js';
+export {
+  AIGatewayIntegrationsClient,
+  type IntegrationCreateRequest,
+  type IntegrationModelsRequest,
+  type IntegrationWorkspacesRequest,
+} from './integrations-client.js';
+export {
+  AIGatewayMcpIntegrationsClient,
+  type McpIntegrationCreateRequest,
+} from './mcp-integrations-client.js';
+export { AIGatewayDeploymentsClient, type DeploymentCreateRequest } from './deployments-client.js';
+export { AIGatewayPluginsClient, type PluginCreateRequest } from './plugins-client.js';
+export { AIGatewayOrganisationsClient } from './organisations-client.js';
+export {
+  AIGatewayAuditLogsClient,
+  type AIGatewayAuditLogListOptions,
+} from './audit-logs-client.js';

--- a/src/ai-gateway/integrations-client.ts
+++ b/src/ai-gateway/integrations-client.ts
@@ -1,15 +1,15 @@
 import { AI_GW_INTEGRATIONS_PATH } from '../constants.js';
 import { request } from '../http/request.js';
 import type { AuthAdapter } from '../http/types.js';
-import { assertUuid } from '../validators.js';
+import { assertUuid, assertNumericId } from '../validators.js';
 import {
   ListIntegrationsResponseSchema,
-  IntegrationSchema,
+  GatewayIntegrationSchema,
   IntegrationModelsResponseSchema,
   IntegrationWorkspacesResponseSchema,
   GatewayWriteResponseSchema,
   type ListIntegrationsResponse,
-  type Integration,
+  type GatewayIntegration,
   type IntegrationModelsResponse,
   type IntegrationWorkspacesResponse,
   type GatewayWriteResponse,
@@ -91,13 +91,13 @@ export class AIGatewayIntegrationsClient {
    * // i.name => 'openai-calvin'
    * ```
    */
-  async get(integrationId: string): Promise<Integration> {
+  async get(integrationId: string): Promise<GatewayIntegration> {
     assertUuid(integrationId, 'integrationId');
     return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}`,
-      responseSchema: IntegrationSchema,
+      responseSchema: GatewayIntegrationSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });
@@ -105,6 +105,11 @@ export class AIGatewayIntegrationsClient {
 
   /**
    * Create an integration.
+   *
+   * @remarks
+   * `body.key` (the provider API key) is a live secret. Setting `PANW_AI_SEC_DEBUG` will
+   * print it, unredacted, to the SDK's own debug log.
+   *
    * @param body - Provider id, name, slug, and provider-specific configuration.
    * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
    * @example
@@ -182,12 +187,15 @@ export class AIGatewayIntegrationsClient {
    */
   async delete(integrationId: string, organisationId: string): Promise<void> {
     assertUuid(integrationId, 'integrationId');
+    assertNumericId(organisationId, 'organisationId');
+    // The API returns 200 with an empty body. request() resolves to undefined whenever
+    // no responseSchema is supplied, regardless of allowEmptyBody — so that flag is
+    // intentionally omitted here rather than implying it does something.
     await request({
       method: 'DELETE',
       baseUrl: this.baseUrl,
       path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}`,
       params: { organisation_id: organisationId },
-      allowEmptyBody: true,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/ai-gateway/integrations-client.ts
+++ b/src/ai-gateway/integrations-client.ts
@@ -259,15 +259,21 @@ export class AIGatewayIntegrationsClient {
 
   /**
    * Read which workspaces may use this integration.
+   *
+   * @remarks
+   * `global_workspace_access` is an **object** on this read, not a boolean, despite the
+   * field name — `{ enabled, rate_limits, usage_limits }`. The corresponding write
+   * ({@link setWorkspaces}) DOES send a plain boolean; the two are not symmetric.
+   *
    * @param integrationId - Integration UUID.
-   * @returns Bound workspaces plus the `global_workspace_access` flag.
+   * @returns Bound workspaces plus the `global_workspace_access` object.
    * @example
    * ```ts
    * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
    * const gw = new AIGatewayClient();
    *
    * const w = await gw.integrations.getWorkspaces('f6692544-3265-49be-9711-bbdcebc079e4');
-   * // w.global_workspace_access => false
+   * // w.global_workspace_access => { enabled: false, rate_limits: null, usage_limits: null }
    * ```
    */
   async getWorkspaces(integrationId: string): Promise<GatewayIntegrationWorkspacesResponse> {

--- a/src/ai-gateway/integrations-client.ts
+++ b/src/ai-gateway/integrations-client.ts
@@ -122,6 +122,7 @@ export class AIGatewayIntegrationsClient {
    * ```
    */
   async create(body: IntegrationCreateRequest): Promise<GatewayWriteResponse> {
+    assertUuid(body.ai_provider_id, 'ai_provider_id');
     return request({
       method: 'POST',
       baseUrl: this.baseUrl,
@@ -154,6 +155,7 @@ export class AIGatewayIntegrationsClient {
     body: Partial<IntegrationCreateRequest>,
   ): Promise<GatewayWriteResponse> {
     assertUuid(integrationId, 'integrationId');
+    if (body.ai_provider_id !== undefined) assertUuid(body.ai_provider_id, 'ai_provider_id');
     return request({
       method: 'PUT',
       baseUrl: this.baseUrl,

--- a/src/ai-gateway/integrations-client.ts
+++ b/src/ai-gateway/integrations-client.ts
@@ -1,0 +1,305 @@
+import { AI_GW_INTEGRATIONS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  ListIntegrationsResponseSchema,
+  IntegrationSchema,
+  IntegrationModelsResponseSchema,
+  IntegrationWorkspacesResponseSchema,
+  GatewayWriteResponseSchema,
+  type ListIntegrationsResponse,
+  type Integration,
+  type IntegrationModelsResponse,
+  type IntegrationWorkspacesResponse,
+  type GatewayWriteResponse,
+} from '../models/ai-gateway.js';
+import type { AIGatewaySubClientOptions } from './types.js';
+
+/** Request body for creating an org-level provider integration. */
+export interface IntegrationCreateRequest {
+  /** The TSG as a numeric string. */
+  organisation_id: string;
+  /** Upstream AI provider id. */
+  ai_provider_id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  /** Provider-specific settings (e.g. `vertex_auth_type`, `vertex_region`). */
+  configurations?: Record<string, unknown>;
+  /** Provider API key, when the provider authenticates by key. */
+  key?: string;
+  secret_mappings?: unknown[];
+}
+
+/** Per-model enablement payload for `integrations/{id}/models`. */
+export interface IntegrationModelsRequest {
+  models: { slug: string; enabled: boolean }[];
+}
+
+/** Workspace-binding payload for `integrations/{id}/workspaces`. */
+export interface IntegrationWorkspacesRequest {
+  workspaces?: unknown[];
+  global_workspace_access?: boolean;
+}
+
+/** Client for AI Gateway organisation-level integrations (admin plane). */
+export class AIGatewayIntegrationsClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List organisation integrations.
+   * @returns All provider integrations defined on the organisation.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const ints = await gw.integrations.list();
+   * // ints.data[0] => { name: 'openai-calvin', slug: 'openai-calvin', ... }
+   * ```
+   */
+  async list(): Promise<ListIntegrationsResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_INTEGRATIONS_PATH,
+      responseSchema: ListIntegrationsResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Fetch one integration.
+   * @param integrationId - Integration UUID.
+   * @returns The integration record.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const i = await gw.integrations.get('f6692544-3265-49be-9711-bbdcebc079e4');
+   * // i.name => 'openai-calvin'
+   * ```
+   */
+  async get(integrationId: string): Promise<Integration> {
+    assertUuid(integrationId, 'integrationId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}`,
+      responseSchema: IntegrationSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Create an integration.
+   * @param body - Provider id, name, slug, and provider-specific configuration.
+   * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.integrations.create({
+   *   organisation_id: '1852583913',
+   *   ai_provider_id: 'de7d7d50-31cd-11ee-b93b-0e06f1aa7f7c',
+   *   name: 'openai-prod',
+   *   slug: 'openai-prod',
+   *   key: process.env.OPENAI_API_KEY,
+   * });
+   * ```
+   */
+  async create(body: IntegrationCreateRequest): Promise<GatewayWriteResponse> {
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: AI_GW_INTEGRATIONS_PATH,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Update an integration.
+   * @param integrationId - Integration UUID.
+   * @param body - Replacement fields.
+   * @returns The raw update response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.integrations.update('f6692544-3265-49be-9711-bbdcebc079e4', {
+   *   name: 'openai-prod',
+   *   description: 'Production OpenAI',
+   * });
+   * ```
+   */
+  async update(
+    integrationId: string,
+    body: Partial<IntegrationCreateRequest>,
+  ): Promise<GatewayWriteResponse> {
+    assertUuid(integrationId, 'integrationId');
+    return request({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}`,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Delete an integration.
+   * @param integrationId - Integration UUID.
+   * @param organisationId - The TSG as a numeric string; sent as a query param.
+   * @returns Nothing — the API replies 200 with an empty body.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.integrations.delete('f6692544-3265-49be-9711-bbdcebc079e4', '1852583913');
+   * ```
+   */
+  async delete(integrationId: string, organisationId: string): Promise<void> {
+    assertUuid(integrationId, 'integrationId');
+    await request({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}`,
+      params: { organisation_id: organisationId },
+      allowEmptyBody: true,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Read which models this integration exposes.
+   * @param integrationId - Integration UUID.
+   * @returns Per-model enablement plus the `allow_all_models` flag.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const m = await gw.integrations.getModels('f6692544-3265-49be-9711-bbdcebc079e4');
+   * // m.models[0] => { slug: 'gpt-4', enabled: true }
+   * ```
+   */
+  async getModels(integrationId: string): Promise<IntegrationModelsResponse> {
+    assertUuid(integrationId, 'integrationId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}/models`,
+      responseSchema: IntegrationModelsResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Replace which models this integration exposes.
+   * @param integrationId - Integration UUID.
+   * @param body - Full model list; this is a replace, not a merge.
+   * @returns The raw response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.integrations.setModels('f6692544-3265-49be-9711-bbdcebc079e4', {
+   *   models: [{ slug: 'gpt-4', enabled: true }, { slug: 'gpt-4-32k', enabled: false }],
+   * });
+   * ```
+   */
+  async setModels(
+    integrationId: string,
+    body: IntegrationModelsRequest,
+  ): Promise<GatewayWriteResponse> {
+    assertUuid(integrationId, 'integrationId');
+    return request({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}/models`,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Read which workspaces may use this integration.
+   * @param integrationId - Integration UUID.
+   * @returns Bound workspaces plus the `global_workspace_access` flag.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const w = await gw.integrations.getWorkspaces('f6692544-3265-49be-9711-bbdcebc079e4');
+   * // w.global_workspace_access => false
+   * ```
+   */
+  async getWorkspaces(integrationId: string): Promise<IntegrationWorkspacesResponse> {
+    assertUuid(integrationId, 'integrationId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}/workspaces`,
+      responseSchema: IntegrationWorkspacesResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Replace which workspaces may use this integration.
+   * @param integrationId - Integration UUID.
+   * @param body - Workspace bindings or a global-access flag.
+   * @returns The raw response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.integrations.setWorkspaces('f6692544-3265-49be-9711-bbdcebc079e4', {
+   *   global_workspace_access: true,
+   * });
+   * ```
+   */
+  async setWorkspaces(
+    integrationId: string,
+    body: IntegrationWorkspacesRequest,
+  ): Promise<GatewayWriteResponse> {
+    assertUuid(integrationId, 'integrationId');
+    return request({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}/workspaces`,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/ai-gateway/integrations-client.ts
+++ b/src/ai-gateway/integrations-client.ts
@@ -5,19 +5,19 @@ import { assertUuid, assertNumericId } from '../validators.js';
 import {
   ListIntegrationsResponseSchema,
   GatewayIntegrationSchema,
-  IntegrationModelsResponseSchema,
-  IntegrationWorkspacesResponseSchema,
+  GatewayIntegrationModelsResponseSchema,
+  GatewayIntegrationWorkspacesResponseSchema,
   GatewayWriteResponseSchema,
   type ListIntegrationsResponse,
   type GatewayIntegration,
-  type IntegrationModelsResponse,
-  type IntegrationWorkspacesResponse,
+  type GatewayIntegrationModelsResponse,
+  type GatewayIntegrationWorkspacesResponse,
   type GatewayWriteResponse,
 } from '../models/ai-gateway.js';
 import type { AIGatewaySubClientOptions } from './types.js';
 
 /** Request body for creating an org-level provider integration. */
-export interface IntegrationCreateRequest {
+export interface GatewayIntegrationCreateRequest {
   /** The TSG as a numeric string. */
   organisation_id: string;
   /** Upstream AI provider id. */
@@ -33,12 +33,12 @@ export interface IntegrationCreateRequest {
 }
 
 /** Per-model enablement payload for `integrations/{id}/models`. */
-export interface IntegrationModelsRequest {
+export interface GatewayIntegrationModelsRequest {
   models: { slug: string; enabled: boolean }[];
 }
 
 /** Workspace-binding payload for `integrations/{id}/workspaces`. */
-export interface IntegrationWorkspacesRequest {
+export interface GatewayIntegrationWorkspacesRequest {
   workspaces?: unknown[];
   global_workspace_access?: boolean;
 }
@@ -126,7 +126,7 @@ export class AIGatewayIntegrationsClient {
    * });
    * ```
    */
-  async create(body: IntegrationCreateRequest): Promise<GatewayWriteResponse> {
+  async create(body: GatewayIntegrationCreateRequest): Promise<GatewayWriteResponse> {
     assertUuid(body.ai_provider_id, 'ai_provider_id');
     return request({
       method: 'POST',
@@ -157,7 +157,7 @@ export class AIGatewayIntegrationsClient {
    */
   async update(
     integrationId: string,
-    body: Partial<IntegrationCreateRequest>,
+    body: Partial<GatewayIntegrationCreateRequest>,
   ): Promise<GatewayWriteResponse> {
     assertUuid(integrationId, 'integrationId');
     if (body.ai_provider_id !== undefined) assertUuid(body.ai_provider_id, 'ai_provider_id');
@@ -214,13 +214,13 @@ export class AIGatewayIntegrationsClient {
    * // m.models[0] => { slug: 'gpt-4', enabled: true }
    * ```
    */
-  async getModels(integrationId: string): Promise<IntegrationModelsResponse> {
+  async getModels(integrationId: string): Promise<GatewayIntegrationModelsResponse> {
     assertUuid(integrationId, 'integrationId');
     return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}/models`,
-      responseSchema: IntegrationModelsResponseSchema,
+      responseSchema: GatewayIntegrationModelsResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });
@@ -243,7 +243,7 @@ export class AIGatewayIntegrationsClient {
    */
   async setModels(
     integrationId: string,
-    body: IntegrationModelsRequest,
+    body: GatewayIntegrationModelsRequest,
   ): Promise<GatewayWriteResponse> {
     assertUuid(integrationId, 'integrationId');
     return request({
@@ -270,13 +270,13 @@ export class AIGatewayIntegrationsClient {
    * // w.global_workspace_access => false
    * ```
    */
-  async getWorkspaces(integrationId: string): Promise<IntegrationWorkspacesResponse> {
+  async getWorkspaces(integrationId: string): Promise<GatewayIntegrationWorkspacesResponse> {
     assertUuid(integrationId, 'integrationId');
     return request({
       method: 'GET',
       baseUrl: this.baseUrl,
       path: `${AI_GW_INTEGRATIONS_PATH}/${integrationId}/workspaces`,
-      responseSchema: IntegrationWorkspacesResponseSchema,
+      responseSchema: GatewayIntegrationWorkspacesResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });
@@ -299,7 +299,7 @@ export class AIGatewayIntegrationsClient {
    */
   async setWorkspaces(
     integrationId: string,
-    body: IntegrationWorkspacesRequest,
+    body: GatewayIntegrationWorkspacesRequest,
   ): Promise<GatewayWriteResponse> {
     assertUuid(integrationId, 'integrationId');
     return request({

--- a/src/ai-gateway/mcp-integrations-client.ts
+++ b/src/ai-gateway/mcp-integrations-client.ts
@@ -29,7 +29,7 @@ export interface McpIntegrationCreateRequest {
 
 /**
  * Workspace-binding payload for `mcp-integrations/{id}/workspaces`.
- * Shape inferred from the sibling `IntegrationWorkspacesRequest` — not confirmed against a
+ * Shape inferred from the sibling `GatewayIntegrationWorkspacesRequest` — not confirmed against a
  * live MCP-integrations tenant.
  */
 export interface McpIntegrationWorkspacesRequest {

--- a/src/ai-gateway/mcp-integrations-client.ts
+++ b/src/ai-gateway/mcp-integrations-client.ts
@@ -1,0 +1,132 @@
+import { AI_GW_MCP_INTEGRATIONS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  ListMcpIntegrationsResponseSchema,
+  GatewayWriteResponseSchema,
+  type ListMcpIntegrationsResponse,
+  type GatewayWriteResponse,
+} from '../models/ai-gateway.js';
+import type { AIGatewaySubClientOptions } from './types.js';
+
+/** Request body for registering an MCP server. */
+export interface McpIntegrationCreateRequest {
+  name: string;
+  /** The TSG as a numeric string. */
+  organisation_id: string;
+  slug: string;
+  /** MCP server URL. */
+  url: string;
+  /** e.g. `none`, `bearer`. */
+  auth_type: string;
+  /** e.g. `http`, `sse`. */
+  transport: string;
+  description?: string;
+  configurations?: Record<string, unknown>;
+  secret_mappings?: unknown[];
+}
+
+/** Workspace-binding payload for `mcp-integrations/{id}/workspaces`. */
+export interface McpIntegrationWorkspacesRequest {
+  workspaces?: unknown[];
+  global_workspace_access?: boolean;
+}
+
+/** Client for AI Gateway MCP server integrations (admin plane). */
+export class AIGatewayMcpIntegrationsClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List organisation MCP integrations.
+   * @returns All MCP server integrations defined on the organisation.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const mcp = await gw.mcpIntegrations.list();
+   * // mcp.data[0] => { name: 'Context 7', url: 'https://mcp.context7.com/mcp', transport: 'http', ... }
+   * ```
+   */
+  async list(): Promise<ListMcpIntegrationsResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_MCP_INTEGRATIONS_PATH,
+      responseSchema: ListMcpIntegrationsResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Register an MCP server.
+   * @param body - Name, server URL, auth type, transport, and provider-specific configuration.
+   * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.mcpIntegrations.create({
+   *   name: 'Context 7',
+   *   organisation_id: '1852583913',
+   *   slug: 'context-7',
+   *   url: 'https://mcp.context7.com/mcp',
+   *   auth_type: 'none',
+   *   transport: 'http',
+   * });
+   * ```
+   */
+  async create(body: McpIntegrationCreateRequest): Promise<GatewayWriteResponse> {
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: AI_GW_MCP_INTEGRATIONS_PATH,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Replace which workspaces may use this MCP integration.
+   * @param mcpIntegrationId - MCP integration UUID.
+   * @param body - Workspace bindings or a global-access flag; this is a replace, not a merge.
+   * @returns The raw response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.mcpIntegrations.setWorkspaces('f6692544-3265-49be-9711-bbdcebc079e4', {
+   *   global_workspace_access: true,
+   * });
+   * ```
+   */
+  async setWorkspaces(
+    mcpIntegrationId: string,
+    body: McpIntegrationWorkspacesRequest,
+  ): Promise<GatewayWriteResponse> {
+    assertUuid(mcpIntegrationId, 'mcpIntegrationId');
+    return request({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_MCP_INTEGRATIONS_PATH}/${mcpIntegrationId}/workspaces`,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/ai-gateway/mcp-integrations-client.ts
+++ b/src/ai-gateway/mcp-integrations-client.ts
@@ -27,7 +27,11 @@ export interface McpIntegrationCreateRequest {
   secret_mappings?: unknown[];
 }
 
-/** Workspace-binding payload for `mcp-integrations/{id}/workspaces`. */
+/**
+ * Workspace-binding payload for `mcp-integrations/{id}/workspaces`.
+ * Shape inferred from the sibling `IntegrationWorkspacesRequest` — not confirmed against a
+ * live MCP-integrations tenant.
+ */
 export interface McpIntegrationWorkspacesRequest {
   workspaces?: unknown[];
   global_workspace_access?: boolean;

--- a/src/ai-gateway/organisations-client.ts
+++ b/src/ai-gateway/organisations-client.ts
@@ -1,4 +1,4 @@
-import { AI_GW_ORGANISATIONS_SELF_PATH } from '../constants.js';
+import { AI_GW_ORGANISATIONS_SELF_PATH, aiGwOrganisationsAuthSettingsPath } from '../constants.js';
 import { request } from '../http/request.js';
 import type { AuthAdapter } from '../http/types.js';
 import {
@@ -10,6 +10,7 @@ import {
   type GatewayWriteResponse,
 } from '../models/ai-gateway.js';
 import type { AIGatewaySubClientOptions } from './types.js';
+import { assertNumericId } from '../validators.js';
 
 /** Client for AI Gateway organisation settings (admin plane). */
 export class AIGatewayOrganisationsClient {
@@ -75,6 +76,8 @@ export class AIGatewayOrganisationsClient {
    *
    * @remarks
    * The response includes a `scim_token` — a live secret. Never log the returned object.
+   * Note that setting `PANW_AI_SEC_DEBUG` will print it (unredacted) to the SDK's own debug
+   * log regardless of this warning, since debug logging only sanitizes header values.
    *
    * @param tsgId - The TSG as a numeric string, not a UUID.
    * @returns Auth settings, including domains and the SCIM token.
@@ -88,10 +91,11 @@ export class AIGatewayOrganisationsClient {
    * ```
    */
   async getAuthSettings(tsgId: string): Promise<AuthSettingsResponse> {
+    assertNumericId(tsgId, 'tsgId');
     return request({
       method: 'GET',
       baseUrl: this.baseUrl,
-      path: `/organisations/${tsgId}/auth-settings`,
+      path: aiGwOrganisationsAuthSettingsPath(tsgId),
       responseSchema: AuthSettingsResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
@@ -117,10 +121,11 @@ export class AIGatewayOrganisationsClient {
     tsgId: string,
     body: Record<string, unknown>,
   ): Promise<GatewayWriteResponse> {
+    assertNumericId(tsgId, 'tsgId');
     return request({
       method: 'PUT',
       baseUrl: this.baseUrl,
-      path: `/organisations/${tsgId}/auth-settings`,
+      path: aiGwOrganisationsAuthSettingsPath(tsgId),
       body,
       responseSchema: GatewayWriteResponseSchema,
       auth: this.auth,

--- a/src/ai-gateway/organisations-client.ts
+++ b/src/ai-gateway/organisations-client.ts
@@ -1,0 +1,130 @@
+import { AI_GW_ORGANISATIONS_SELF_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import {
+  OrganisationSelfResponseSchema,
+  AuthSettingsResponseSchema,
+  GatewayWriteResponseSchema,
+  type OrganisationSelfResponse,
+  type AuthSettingsResponse,
+  type GatewayWriteResponse,
+} from '../models/ai-gateway.js';
+import type { AIGatewaySubClientOptions } from './types.js';
+
+/** Client for AI Gateway organisation settings (admin plane). */
+export class AIGatewayOrganisationsClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * Fetch the calling organisation's settings.
+   * @returns The organisation record.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const org = await gw.organisations.getSelf();
+   * // org.data.name => 'Acme Corp'
+   * ```
+   */
+  async getSelf(): Promise<OrganisationSelfResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_ORGANISATIONS_SELF_PATH,
+      responseSchema: OrganisationSelfResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Update the calling organisation's settings.
+   * @param body - Replacement fields.
+   * @returns The raw update response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.organisations.updateSelf({ name: 'Acme Corp' });
+   * ```
+   */
+  async updateSelf(body: Record<string, unknown>): Promise<GatewayWriteResponse> {
+    return request({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: AI_GW_ORGANISATIONS_SELF_PATH,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Fetch an organisation's auth settings.
+   *
+   * @remarks
+   * The response includes a `scim_token` — a live secret. Never log the returned object.
+   *
+   * @param tsgId - The TSG as a numeric string, not a UUID.
+   * @returns Auth settings, including domains and the SCIM token.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const auth = await gw.organisations.getAuthSettings('1852583913');
+   * // Object.keys(auth.data) => ['auth_settings', 'domains', 'scim_token', ...]
+   * ```
+   */
+  async getAuthSettings(tsgId: string): Promise<AuthSettingsResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `/organisations/${tsgId}/auth-settings`,
+      responseSchema: AuthSettingsResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Update an organisation's auth settings.
+   * @param tsgId - The TSG as a numeric string, not a UUID.
+   * @param body - Replacement fields.
+   * @returns The raw update response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.organisations.updateAuthSettings('1852583913', {
+   *   domains: ['acme.com'],
+   * });
+   * ```
+   */
+  async updateAuthSettings(
+    tsgId: string,
+    body: Record<string, unknown>,
+  ): Promise<GatewayWriteResponse> {
+    return request({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `/organisations/${tsgId}/auth-settings`,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/ai-gateway/plugins-client.ts
+++ b/src/ai-gateway/plugins-client.ts
@@ -11,7 +11,7 @@ import {
 import type { AIGatewaySubClientOptions } from './types.js';
 
 /** Request body for binding a plugin (e.g. the Prisma AIRS scanner) to the organisation. */
-export interface PluginCreateRequest {
+export interface GatewayPluginCreateRequest {
   /** The TSG as a numeric string. */
   organisation_id: string;
   /** Plugin provider integration id, e.g. the `panw-prisma-airs` provider. */
@@ -76,7 +76,7 @@ export class AIGatewayPluginsClient {
    * });
    * ```
    */
-  async create(body: PluginCreateRequest): Promise<GatewayWriteResponse> {
+  async create(body: GatewayPluginCreateRequest): Promise<GatewayWriteResponse> {
     assertUuid(body.integration_id, 'integration_id');
     return request({
       method: 'POST',

--- a/src/ai-gateway/plugins-client.ts
+++ b/src/ai-gateway/plugins-client.ts
@@ -57,6 +57,11 @@ export class AIGatewayPluginsClient {
 
   /**
    * Bind a plugin to the organisation.
+   *
+   * @remarks
+   * `body.credentials` (e.g. `AIRS_API_KEY`) is a live secret. Setting `PANW_AI_SEC_DEBUG`
+   * will print it, unredacted, to the SDK's own debug log.
+   *
    * @param body - Integration id and provider-specific credentials.
    * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
    * @example

--- a/src/ai-gateway/plugins-client.ts
+++ b/src/ai-gateway/plugins-client.ts
@@ -1,0 +1,86 @@
+import { AI_GW_PLUGINS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  ListPluginsResponseSchema,
+  GatewayWriteResponseSchema,
+  type ListPluginsResponse,
+  type GatewayWriteResponse,
+} from '../models/ai-gateway.js';
+import type { AIGatewaySubClientOptions } from './types.js';
+
+/** Request body for binding a plugin (e.g. the Prisma AIRS scanner) to the organisation. */
+export interface PluginCreateRequest {
+  /** The TSG as a numeric string. */
+  organisation_id: string;
+  /** Plugin provider integration id, e.g. the `panw-prisma-airs` provider. */
+  integration_id: string;
+  /** Provider-specific secrets, e.g. `{ AIRS_API_KEY: '...' }`. Never log this. */
+  credentials: Record<string, string>;
+}
+
+/** Client for AI Gateway plugin bindings (admin plane). */
+export class AIGatewayPluginsClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List organisation plugin bindings.
+   * @returns All plugins bound to the organisation, with masked credentials.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const p = await gw.plugins.list();
+   * // p.data[0] => { integration_slug: 'panw-prisma-airs', credentials: { AIRS_API_KEY: 'sn*****Gul' }, ... }
+   * ```
+   */
+  async list(): Promise<ListPluginsResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_PLUGINS_PATH,
+      responseSchema: ListPluginsResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Bind a plugin to the organisation.
+   * @param body - Integration id and provider-specific credentials.
+   * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.plugins.create({
+   *   organisation_id: '1852583913',
+   *   integration_id: '232e45c4-809a-11f1-af60-2ca2a760eb7b',
+   *   credentials: { AIRS_API_KEY: process.env.PANW_AI_SEC_API_KEY ?? '' },
+   * });
+   * ```
+   */
+  async create(body: PluginCreateRequest): Promise<GatewayWriteResponse> {
+    assertUuid(body.integration_id, 'integration_id');
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: AI_GW_PLUGINS_PATH,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/ai-gateway/providers-client.ts
+++ b/src/ai-gateway/providers-client.ts
@@ -1,0 +1,95 @@
+import { AI_GW_PROVIDERS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  ListProvidersResponseSchema,
+  GatewayWriteResponseSchema,
+  type ListProvidersResponse,
+  type GatewayWriteResponse,
+} from '../models/ai-gateway.js';
+import type { AIGatewaySubClientOptions } from './types.js';
+import type { AIGatewayWorkspaceScopedListOptions } from './guardrails-client.js';
+
+/** Request body for binding an org integration into a workspace as a provider. */
+export interface GatewayProviderCreateRequest {
+  workspace_id: string;
+  /** Upstream AI provider id (e.g. the OpenAI or Vertex provider). */
+  ai_provider_id: string;
+  name: string;
+  /** Org-level integration this provider draws credentials from. */
+  integration_id: string;
+  slug: string;
+  note?: string;
+  expires_at?: string | null;
+}
+
+/** Client for AI Gateway provider operations (data plane). */
+export class AIGatewayProvidersClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List providers in a workspace.
+   * @param opts - Must include the workspace UUID.
+   * @returns Providers bound into that workspace.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const p = await gw.providers.list({ workspaceId: '16f7e90d-382a-4e78-b577-1b01eb5f8297' });
+   * // p.data[0].slug => 'openai-calvin'
+   * ```
+   */
+  async list(opts: AIGatewayWorkspaceScopedListOptions): Promise<ListProvidersResponse> {
+    assertUuid(opts.workspaceId, 'workspaceId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_PROVIDERS_PATH,
+      params: { workspace_id: opts.workspaceId },
+      responseSchema: ListProvidersResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Create a provider.
+   * @param body - Workspace UUID, upstream provider id, integration id, name, and slug.
+   * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.providers.create({
+   *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+   *   ai_provider_id: 'de7d7d50-31cd-11ee-b93b-0e06f1aa7f7c',
+   *   integration_id: 'f6692544-3265-49be-9711-bbdcebc079e4',
+   *   name: 'openai-calvin',
+   *   slug: 'openai-calvin',
+   * });
+   * ```
+   */
+  async create(body: GatewayProviderCreateRequest): Promise<GatewayWriteResponse> {
+    assertUuid(body.workspace_id, 'workspace_id');
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: AI_GW_PROVIDERS_PATH,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/ai-gateway/providers-client.ts
+++ b/src/ai-gateway/providers-client.ts
@@ -8,8 +8,7 @@ import {
   type ListProvidersResponse,
   type GatewayWriteResponse,
 } from '../models/ai-gateway.js';
-import type { AIGatewaySubClientOptions } from './types.js';
-import type { AIGatewayWorkspaceScopedListOptions } from './guardrails-client.js';
+import type { AIGatewaySubClientOptions, AIGatewayWorkspaceScopedListOptions } from './types.js';
 
 /** Request body for binding an org integration into a workspace as a provider. */
 export interface GatewayProviderCreateRequest {
@@ -82,6 +81,8 @@ export class AIGatewayProvidersClient {
    */
   async create(body: GatewayProviderCreateRequest): Promise<GatewayWriteResponse> {
     assertUuid(body.workspace_id, 'workspace_id');
+    assertUuid(body.ai_provider_id, 'ai_provider_id');
+    assertUuid(body.integration_id, 'integration_id');
     return request({
       method: 'POST',
       baseUrl: this.baseUrl,

--- a/src/ai-gateway/telemetry-client.ts
+++ b/src/ai-gateway/telemetry-client.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import { AI_GW_CHARTS_PATH } from '../constants.js';
+import { AI_GW_CHARTS_PATH, AI_GW_GROUPS_PATH, AI_GW_LOGS_PATH } from '../constants.js';
 import { request } from '../http/request.js';
 import type { AuthAdapter } from '../http/types.js';
 import {
@@ -14,6 +14,9 @@ import {
   RescuedRetriesResponseSchema,
   FeedbackScoreDistributionResponseSchema,
   FeedbackModelsResponseSchema,
+  GroupListResponseSchema,
+  UserGroupResponseSchema,
+  GatewayLogsResponseSchema,
   type CostChartResponse,
   type CountChartResponse,
   type LatencyChartResponse,
@@ -25,6 +28,9 @@ import {
   type RescuedRetriesResponse,
   type FeedbackScoreDistributionResponse,
   type FeedbackModelsResponse,
+  type GroupListResponse,
+  type UserGroupResponse,
+  type GatewayLogsResponse,
 } from '../models/ai-gateway.js';
 import { serializeWindow, type AIGatewayWindowOptions } from './window.js';
 
@@ -34,6 +40,30 @@ export interface AIGatewayTelemetryClientOptions {
   auth: AuthAdapter;
   numRetries: number;
   tsgId: string;
+}
+
+/** Options for a `logs/groups/{dimension}` query. */
+export interface AIGatewayGroupOptions extends AIGatewayWindowOptions {
+  /**
+   * Extra columns to aggregate. Invalid names are silently dropped by the API rather than
+   * erroring. Valid: `cost`, `avg_latency`, `avg_tokens`, `total_tokens`, `success_rate`, `last_seen`.
+   */
+  columns?: string[];
+}
+
+/**
+ * Options for the raw `logs` collection.
+ *
+ * Deliberately NOT {@link ListingOptions}: offset paging is broken upstream. `skip`/`offset`/
+ * `page` are ignored by the API and every unfiltered call returns the same most-recent batch.
+ */
+export interface AIGatewayLogsOptions extends AIGatewayWindowOptions {
+  /** Rows per response. The only working pagination control. */
+  pageSize?: number;
+  /** Return the single row for one trace id. */
+  traceId?: string;
+  /** Filter by HTTP status. **Bypasses the ~50-row cap** — use 446 to pull every AIRS block. */
+  statusCode?: number;
 }
 
 /**
@@ -331,5 +361,136 @@ export class AIGatewayTelemetryClient {
    */
   async feedbackModels(opts: AIGatewayWindowOptions): Promise<FeedbackModelsResponse> {
     return this.chart('feedback-models', opts, FeedbackModelsResponseSchema);
+  }
+
+  /**
+   * Aggregate requests by a dimension.
+   * @param dimension - One of `ai_service`, `model`, `api_key`, `provider`. Underscore names only.
+   * @param opts - Window plus optional extra columns.
+   * @returns One row per distinct dimension value.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const byModel = await gw.telemetry.groupBy('model', {
+   *   workspaceSlug: 'ws-main-a-349e0e',
+   *   columns: ['cost', 'total_tokens'],
+   * });
+   * // byModel.data[0] => { model: 'claude-sonnet-5', requests: 10506, cost: 29704.16, ... }
+   * ```
+   */
+  async groupBy(
+    dimension: 'ai_service' | 'model' | 'api_key' | 'provider',
+    opts: AIGatewayGroupOptions,
+  ): Promise<GroupListResponse> {
+    const params = serializeWindow(this.tsgId, opts);
+    if (opts.columns?.length) params.columns = opts.columns.join(',');
+
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_GROUPS_PATH}/${dimension}`,
+      params,
+      responseSchema: GroupListResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Requests and cost per end user.
+   * @param opts - Workspace slug and time window.
+   * @returns One record per user; `_user: ''` means calls with no end-user id. Costs in cents.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const users = await gw.telemetry.byUser({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // users.data.records[0] => { _user: '', count: 25748, cost: 411060.85 }
+   * ```
+   */
+  async byUser(opts: AIGatewayWindowOptions): Promise<UserGroupResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_GROUPS_PATH}/users`,
+      params: serializeWindow(this.tsgId, opts),
+      responseSchema: UserGroupResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Requests grouped by HTTP status code.
+   * @param opts - Window plus optional extra columns.
+   * @returns One row per status. **446 = AIRS security block** (cost 0, never reached the LLM).
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const codes = await gw.telemetry.byStatusCode({
+   *   workspaceSlug: 'ws-main-a-349e0e',
+   *   columns: ['cost', 'avg_latency'],
+   * });
+   * // codes.data => [{ status_code: 200, requests: 25623, ... }, { status_code: 446, ... }]
+   * ```
+   */
+  async byStatusCode(opts: AIGatewayGroupOptions): Promise<GroupListResponse> {
+    const params = serializeWindow(this.tsgId, opts);
+    if (opts.columns?.length) params.columns = opts.columns.join(',');
+
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_GROUPS_PATH}/status_code`,
+      params,
+      responseSchema: GroupListResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Raw per-request log rows — the deepest granularity this API offers.
+   *
+   * @remarks
+   * Upstream pagination is broken: only `pageSize` works, and an unfiltered call always
+   * returns the same most-recent batch (~50 rows) regardless of offset. To read beyond that,
+   * filter by `statusCode`, which bypasses the cap and returns every match in the window.
+   *
+   * @param opts - Window plus `pageSize` / `traceId` / `statusCode` filters.
+   * @returns Log records plus the full-period `total` (which you cannot page to).
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * // Every AIRS security block in the window, not just the most recent page.
+   * const blocked = await gw.telemetry.logs({
+   *   workspaceSlug: 'ws-main-a-349e0e',
+   *   statusCode: 446,
+   * });
+   * // blocked.data.records[0] => { response_status_code: 446, cost: 0, is_success: 0, ... }
+   * ```
+   */
+  async logs(opts: AIGatewayLogsOptions): Promise<GatewayLogsResponse> {
+    const params = serializeWindow(this.tsgId, opts);
+    if (opts.pageSize !== undefined) params.pageSize = String(opts.pageSize);
+    if (opts.traceId !== undefined) params.traceId = opts.traceId;
+    if (opts.statusCode !== undefined) params.statusCode = String(opts.statusCode);
+
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_LOGS_PATH,
+      params,
+      responseSchema: GatewayLogsResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
   }
 }

--- a/src/ai-gateway/telemetry-client.ts
+++ b/src/ai-gateway/telemetry-client.ts
@@ -1,5 +1,12 @@
 import type { z } from 'zod';
-import { AI_GW_CHARTS_PATH, AI_GW_GROUPS_PATH, AI_GW_LOGS_PATH } from '../constants.js';
+import {
+  AI_GW_CHARTS_PATH,
+  AI_GW_GROUPS_PATH,
+  AI_GW_LOGS_PATH,
+  AI_GW_CHART_METRICS,
+  AI_GW_GROUP_DIMENSIONS,
+  AI_GW_GROUP_COLUMNS,
+} from '../constants.js';
 import { request } from '../http/request.js';
 import type { AuthAdapter } from '../http/types.js';
 import {
@@ -46,9 +53,9 @@ export interface AIGatewayTelemetryClientOptions {
 export interface AIGatewayGroupOptions extends AIGatewayWindowOptions {
   /**
    * Extra columns to aggregate. Invalid names are silently dropped by the API rather than
-   * erroring. Valid: `cost`, `avg_latency`, `avg_tokens`, `total_tokens`, `success_rate`, `last_seen`.
+   * erroring. See {@link AI_GW_GROUP_COLUMNS} for the valid set.
    */
-  columns?: string[];
+  columns?: (typeof AI_GW_GROUP_COLUMNS)[number][];
 }
 
 /**
@@ -87,7 +94,7 @@ export class AIGatewayTelemetryClient {
 
   /** @internal Shared GET for every `logs/charts/*` endpoint. */
   private chart<T>(
-    metric: string,
+    metric: (typeof AI_GW_CHART_METRICS)[number],
     opts: AIGatewayWindowOptions,
     // `any` for Zod's def/input generics, mirroring RequestSpec.responseSchema — schemas
     // built with .passthrough() have input ≠ output and fail a stricter constraint.
@@ -365,7 +372,7 @@ export class AIGatewayTelemetryClient {
 
   /**
    * Aggregate requests by a dimension.
-   * @param dimension - One of `ai_service`, `model`, `api_key`, `provider`. Underscore names only.
+   * @param dimension - One of {@link AI_GW_GROUP_DIMENSIONS}. Underscore names only.
    * @param opts - Window plus optional extra columns.
    * @returns One row per distinct dimension value.
    * @example
@@ -381,7 +388,7 @@ export class AIGatewayTelemetryClient {
    * ```
    */
   async groupBy(
-    dimension: 'ai_service' | 'model' | 'api_key' | 'provider',
+    dimension: (typeof AI_GW_GROUP_DIMENSIONS)[number],
     opts: AIGatewayGroupOptions,
   ): Promise<GroupListResponse> {
     const params = serializeWindow(this.tsgId, opts);

--- a/src/ai-gateway/telemetry-client.ts
+++ b/src/ai-gateway/telemetry-client.ts
@@ -1,0 +1,335 @@
+import type { z } from 'zod';
+import { AI_GW_CHARTS_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import {
+  CostChartResponseSchema,
+  CountChartResponseSchema,
+  LatencyChartResponseSchema,
+  TokensChartResponseSchema,
+  CacheSummaryResponseSchema,
+  CacheHitTrendResponseSchema,
+  UserTrendsResponseSchema,
+  ErrorTrendsResponseSchema,
+  RescuedRetriesResponseSchema,
+  FeedbackScoreDistributionResponseSchema,
+  FeedbackModelsResponseSchema,
+  type CostChartResponse,
+  type CountChartResponse,
+  type LatencyChartResponse,
+  type TokensChartResponse,
+  type CacheSummaryResponse,
+  type CacheHitTrendResponse,
+  type UserTrendsResponse,
+  type ErrorTrendsResponse,
+  type RescuedRetriesResponse,
+  type FeedbackScoreDistributionResponse,
+  type FeedbackModelsResponse,
+} from '../models/ai-gateway.js';
+import { serializeWindow, type AIGatewayWindowOptions } from './window.js';
+
+/** @internal */
+export interface AIGatewayTelemetryClientOptions {
+  baseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+  tsgId: string;
+}
+
+/**
+ * Client for AI Gateway runtime telemetry — the data behind the SCM Observability tabs.
+ *
+ * Endpoint slugs are bespoke and inconsistent (`user-trends` is plural, `cache-hit-trend`
+ * is singular, `cache-hits-trend` 404s). They are hardcoded, not derived.
+ */
+export class AIGatewayTelemetryClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+  private readonly tsgId: string;
+
+  constructor(opts: AIGatewayTelemetryClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+    this.tsgId = opts.tsgId;
+  }
+
+  /** @internal Shared GET for every `logs/charts/*` endpoint. */
+  private chart<T>(
+    metric: string,
+    opts: AIGatewayWindowOptions,
+    // `any` for Zod's def/input generics, mirroring RequestSpec.responseSchema — schemas
+    // built with .passthrough() have input ≠ output and fail a stricter constraint.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    schema: z.ZodType<T, any, any>,
+  ): Promise<T> {
+    return request<T>({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_CHARTS_PATH}/${metric}`,
+      params: serializeWindow(this.tsgId, opts),
+      responseSchema: schema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Total and per-day spend. **Values are in cents.**
+   * @param opts - Workspace slug and time window.
+   * @returns Cost series plus the period total, in cents.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const cost = await gw.telemetry.cost({ workspaceSlug: 'ws-main-a-349e0e', days: 7 });
+   * console.log(`$${(cost.data.total / 100).toFixed(2)}`); // => "$4110.83"
+   * ```
+   */
+  async cost(opts: AIGatewayWindowOptions): Promise<CostChartResponse> {
+    return this.chart('cost', opts, CostChartResponseSchema);
+  }
+
+  /**
+   * Per-day request counts.
+   * @param opts - Workspace slug and time window.
+   * @returns Request-count series plus the period total.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const r = await gw.telemetry.requests({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // r.data.total => 25746
+   * ```
+   */
+  async requests(opts: AIGatewayWindowOptions): Promise<CountChartResponse> {
+    return this.chart('requests', opts, CountChartResponseSchema);
+  }
+
+  /**
+   * Latency in milliseconds. Percentiles are returned per-bucket and for the period.
+   * @param opts - Workspace slug and time window.
+   * @returns Latency series with p50/p90/p99; `data.total` is the period mean, not a sum.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const l = await gw.telemetry.latency({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // l.data.p99 => 8329.14
+   * ```
+   */
+  async latency(opts: AIGatewayWindowOptions): Promise<LatencyChartResponse> {
+    return this.chart('latency', opts, LatencyChartResponseSchema);
+  }
+
+  /**
+   * Token usage, split into request and response units.
+   * @param opts - Workspace slug and time window.
+   * @returns Token series plus request/response unit totals.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const t = await gw.telemetry.tokens({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // t.data.total_request_units => 4919015459
+   * ```
+   */
+  async tokens(opts: AIGatewayWindowOptions): Promise<TokensChartResponse> {
+    return this.chart('tokens', opts, TokensChartResponseSchema);
+  }
+
+  /**
+   * Per-day error counts.
+   * @param opts - Workspace slug and time window.
+   * @returns Error-count series plus the period total.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const e = await gw.telemetry.errors({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // e.data.total => 125
+   * ```
+   */
+  async errors(opts: AIGatewayWindowOptions): Promise<CountChartResponse> {
+    return this.chart('errors', opts, CountChartResponseSchema);
+  }
+
+  /**
+   * Per-day distinct end-user counts.
+   * @param opts - Workspace slug and time window.
+   * @returns Unique-user series plus the period total.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const u = await gw.telemetry.users({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // u.data.total => 1
+   * ```
+   */
+  async users(opts: AIGatewayWindowOptions): Promise<CountChartResponse> {
+    return this.chart('users', opts, CountChartResponseSchema);
+  }
+
+  /**
+   * Cache hit count, speedup, and average cached-response latency.
+   * @param opts - Workspace slug and time window.
+   * @returns Cache summary; `avgCacheLatency` is null when there were no hits.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const c = await gw.telemetry.cacheSummary({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // c.data.summary => { cacheHits: 0, avgCacheLatency: null, totalRequests: 25621, cacheSpeedup: 0 }
+   * ```
+   */
+  async cacheSummary(opts: AIGatewayWindowOptions): Promise<CacheSummaryResponse> {
+    return this.chart('cache-summary', opts, CacheSummaryResponseSchema);
+  }
+
+  /**
+   * Cache hit-rate trend and cumulative savings.
+   * @param opts - Workspace slug and time window.
+   * @returns Per-bucket hits and **cumulative** savings in cents — the last non-zero bucket is the period total.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const t = await gw.telemetry.cacheHitTrend({ workspaceSlug: 'ws-main-a-349e0e' });
+   * const last = t.data.trend.at(-1);
+   * const savedUsd = ((last?.cumulativeSimpleHitSavings ?? 0) + (last?.cumulativeSemanticHitSavings ?? 0)) / 100;
+   * ```
+   */
+  async cacheHitTrend(opts: AIGatewayWindowOptions): Promise<CacheHitTrendResponse> {
+    return this.chart('cache-hit-trend', opts, CacheHitTrendResponseSchema);
+  }
+
+  /**
+   * Requests-per-user trend.
+   * @param opts - Workspace slug and time window.
+   * @returns Daily request counts plus `summary.avg` (requests per user).
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const t = await gw.telemetry.userTrends({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // t.data.summary => { total: 25748, unique: 1, avg: 25748 }
+   * ```
+   */
+  async userTrends(opts: AIGatewayWindowOptions): Promise<UserTrendsResponse> {
+    return this.chart('user-trends', opts, UserTrendsResponseSchema);
+  }
+
+  /**
+   * Error-rate trend as a percentage.
+   * @param opts - Workspace slug and time window.
+   * @returns Daily error percentages plus `summary.errorPercent` for the period.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const t = await gw.telemetry.errorTrends({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // t.data.summary.errorPercent => 0.485
+   * ```
+   */
+  async errorTrends(opts: AIGatewayWindowOptions): Promise<ErrorTrendsResponse> {
+    return this.chart('error-trends', opts, ErrorTrendsResponseSchema);
+  }
+
+  /**
+   * Gateway auto-retry and fallback resilience. Sparse — only populated on upstream failures.
+   * @param opts - Workspace slug and time window.
+   * @returns Retry/fallback trends; note `trend[].y` is an **array**, not a scalar.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const r = await gw.telemetry.rescuedRetries({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // r.data.retryTotal => 0
+   * ```
+   */
+  async rescuedRetries(opts: AIGatewayWindowOptions): Promise<RescuedRetriesResponse> {
+    return this.chart('rescued-retries', opts, RescuedRetriesResponseSchema);
+  }
+
+  /**
+   * Daily count of feedback submissions.
+   * @param opts - Workspace slug and time window.
+   * @returns Feedback-count series plus the period total.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const f = await gw.telemetry.feedbackTrend({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // f.data.total => 61
+   * ```
+   */
+  async feedbackTrend(opts: AIGatewayWindowOptions): Promise<CountChartResponse> {
+    return this.chart('feedback-trend', opts, CountChartResponseSchema);
+  }
+
+  /**
+   * Weighted average feedback score, averaged over days.
+   * @param opts - Workspace slug and time window.
+   * @returns Weighted score series; `data.total` is null when there is no feedback.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const f = await gw.telemetry.feedbackWeighted({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // f.data.total => -2.58
+   * ```
+   */
+  async feedbackWeighted(opts: AIGatewayWindowOptions): Promise<CountChartResponse> {
+    return this.chart('feedback-weighted', opts, CountChartResponseSchema);
+  }
+
+  /**
+   * Distribution of feedback scores. Feedback is binary: +5 (thumbs up) or -5 (thumbs down).
+   * @param opts - Workspace slug and time window.
+   * @returns Score histogram as `{x: score, y: count}` records.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const d = await gw.telemetry.feedbackScoreDistribution({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // d.data.records => [{ x: 5, y: 30 }, { x: -5, y: 33 }]
+   * ```
+   */
+  async feedbackScoreDistribution(
+    opts: AIGatewayWindowOptions,
+  ): Promise<FeedbackScoreDistributionResponse> {
+    return this.chart('feedback-score-distribution', opts, FeedbackScoreDistributionResponseSchema);
+  }
+
+  /**
+   * Feedback broken down by AI model.
+   * @param opts - Workspace slug and time window.
+   * @returns Records where `x` is the model and `y` is an object, not a number.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const m = await gw.telemetry.feedbackModels({ workspaceSlug: 'ws-main-a-349e0e' });
+   * // m.data.records[0] => { x: 'claude-sonnet-5', y: { avgWeightedFeedback: 4.2, feedbackCount: 12 } }
+   * ```
+   */
+  async feedbackModels(opts: AIGatewayWindowOptions): Promise<FeedbackModelsResponse> {
+    return this.chart('feedback-models', opts, FeedbackModelsResponseSchema);
+  }
+}

--- a/src/ai-gateway/types.ts
+++ b/src/ai-gateway/types.ts
@@ -1,0 +1,13 @@
+import type { AuthAdapter } from '../http/types.js';
+
+/**
+ * @internal
+ * Construction options shared by every AI Gateway sub-client. Lives in its own module
+ * rather than in any one resource client, because all twelve sub-clients consume it —
+ * the same reason `AIGatewayWindowOptions` lives in `window.ts`.
+ */
+export interface AIGatewaySubClientOptions {
+  baseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+}

--- a/src/ai-gateway/types.ts
+++ b/src/ai-gateway/types.ts
@@ -11,3 +11,13 @@ export interface AIGatewaySubClientOptions {
   auth: AuthAdapter;
   numRetries: number;
 }
+
+/**
+ * Options for listing workspace-scoped resources. Shared by every sub-client whose `list`
+ * (or list-alike) endpoint takes only a workspace UUID — guardrails, providers, api-keys,
+ * and configs.
+ */
+export interface AIGatewayWorkspaceScopedListOptions {
+  /** Workspace UUID. Required — omitting it returns `404 AB02`. */
+  workspaceId: string;
+}

--- a/src/ai-gateway/window.ts
+++ b/src/ai-gateway/window.ts
@@ -1,0 +1,43 @@
+/** Time window for an AI Gateway telemetry query. */
+export interface AIGatewayWindowOptions {
+  /** Workspace slug, e.g. `ws-main-a-349e0e`. Required by every telemetry endpoint. */
+  workspaceSlug: string;
+  /** Rolling window size in days, counted back from now. Defaults to 7. Ignored if `start` is set. */
+  days?: number;
+  /** Explicit window start. Overrides `days`. */
+  start?: Date;
+  /** Explicit window end. Defaults to now. */
+  end?: Date;
+}
+
+/**
+ * @internal
+ * ISO-8601 with a **numeric** UTC offset (`2026-07-20T00:00:00+02:00`), which is what the
+ * gateway's validator requires. A `Z` suffix is rejected with `AB01`. `URLSearchParams`
+ * percent-encodes the `+` correctly, so no manual escaping is needed downstream.
+ */
+export function toOffsetIso(d: Date): string {
+  const pad = (n: number): string => String(Math.floor(Math.abs(n))).padStart(2, '0');
+  const offsetMin = -d.getTimezoneOffset();
+  const sign = offsetMin >= 0 ? '+' : '-';
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}` +
+    `${sign}${pad(offsetMin / 60)}:${pad(offsetMin % 60)}`
+  );
+}
+
+/** @internal Build the four query params every telemetry endpoint requires. */
+export function serializeWindow(
+  tsgId: string,
+  opts: AIGatewayWindowOptions,
+): Record<string, string> {
+  const end = opts.end ?? new Date();
+  const start = opts.start ?? new Date(end.getTime() - (opts.days ?? 7) * 86_400_000);
+  return {
+    organisationId: tsgId,
+    workspaceSlug: opts.workspaceSlug,
+    timeOfGenerationMin: toOffsetIso(start),
+    timeOfGenerationMax: toOffsetIso(end),
+  };
+}

--- a/src/ai-gateway/workspaces-client.ts
+++ b/src/ai-gateway/workspaces-client.ts
@@ -8,13 +8,7 @@ import {
   type ListWorkspacesResponse,
   type GatewayWorkspaceDetail,
 } from '../models/ai-gateway.js';
-
-/** @internal Shared construction options for every AI Gateway sub-client. */
-export interface AIGatewaySubClientOptions {
-  baseUrl: string;
-  auth: AuthAdapter;
-  numRetries: number;
-}
+import type { AIGatewaySubClientOptions } from './types.js';
 
 /** Client for AI Gateway workspace reads (data plane). */
 export class AIGatewayWorkspacesClient {

--- a/src/ai-gateway/workspaces-client.ts
+++ b/src/ai-gateway/workspaces-client.ts
@@ -1,0 +1,78 @@
+import { AI_GW_WORKSPACES_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { assertUuid } from '../validators.js';
+import {
+  ListWorkspacesResponseSchema,
+  GatewayWorkspaceDetailSchema,
+  type ListWorkspacesResponse,
+  type GatewayWorkspaceDetail,
+} from '../models/ai-gateway.js';
+
+/** @internal Shared construction options for every AI Gateway sub-client. */
+export interface AIGatewaySubClientOptions {
+  baseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+}
+
+/** Client for AI Gateway workspace reads (data plane). */
+export class AIGatewayWorkspacesClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: AIGatewaySubClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * List workspaces visible to the caller.
+   * @returns All workspaces, each with the `scope_name` that grants data-plane access to it.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const ws = await gw.workspaces.list();
+   * // ws.data[0] => { slug: 'ws-main-a-349e0e', scope_name: 'main_airs_workspace_1852583913', ... }
+   * ```
+   */
+  async list(): Promise<ListWorkspacesResponse> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: AI_GW_WORKSPACES_PATH,
+      responseSchema: ListWorkspacesResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Fetch one workspace, including its security and rate-limit settings.
+   * @param workspaceId - Workspace UUID.
+   * @returns Workspace detail; list rows do not carry the settings blocks.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const ws = await gw.workspaces.get('16f7e90d-382a-4e78-b577-1b01eb5f8297');
+   * // ws.security_settings?.membersViewLogs => true
+   * ```
+   */
+  async get(workspaceId: string): Promise<GatewayWorkspaceDetail> {
+    assertUuid(workspaceId, 'workspaceId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_WORKSPACES_PATH}/${workspaceId}`,
+      responseSchema: GatewayWorkspaceDetailSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -186,7 +186,8 @@ export const DEFAULT_AI_GW_ADMIN_ENDPOINT = 'https://api.apps.paloaltonetworks.c
 
 export const AI_GW_DATA_ENDPOINT = 'PANW_AI_GW_DATA_ENDPOINT';
 export const AI_GW_ADMIN_ENDPOINT = 'PANW_AI_GW_ADMIN_ENDPOINT';
-export const AI_GW_TOKEN_ENDPOINT = 'PANW_AI_GW_TOKEN_ENDPOINT';
+// No AI_GW_TOKEN_ENDPOINT constant: resolveOAuthConfig() builds `${primaryEnvPrefix}_TOKEN_ENDPOINT`
+// dynamically from 'PANW_AI_GW', so a static export here would be dead code (see oauth-config.ts).
 
 /** Mandatory on every AI Gateway request; omitting it yields a 403 OPA denial. */
 export const TSG_ID_HEADER = 'x-tsg-id';
@@ -209,6 +210,14 @@ export const AI_GW_DEPLOYMENTS_PATH = '/deployments';
 export const AI_GW_PLUGINS_PATH = '/plugins';
 export const AI_GW_ORGANISATIONS_SELF_PATH = '/organisations/self';
 export const AI_GW_AUDIT_LOGS_PATH = '/audit-logs';
+
+/**
+ * @internal
+ * Build the `/organisations/{tsgId}/auth-settings` path. Validate `tsgId` before calling.
+ */
+export function aiGwOrganisationsAuthSettingsPath(tsgId: string): string {
+  return `/organisations/${tsgId}/auth-settings`;
+}
 
 /**
  * Chart metric slugs. Bespoke and unguessable — plural vs singular is load-bearing

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.13.2';
+export const SDK_VERSION = '0.14.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -167,3 +167,80 @@ export const RED_TEAM_MGMT_DASHBOARD_PATH = '/v1/dashboard/overview';
 // API paths — red team network broker (distinct data-plane base URL)
 export const RED_TEAM_CHANNELS_PATH = '/v1/channels';
 export const RED_TEAM_CHANNELS_STATS_PATH = '/v1/channels/stats';
+
+// ---------------------------------------------------------------------------
+// AI Gateway
+// ---------------------------------------------------------------------------
+
+/**
+ * Default AI Gateway data-plane endpoint (telemetry + workspace-scoped config).
+ *
+ * `api.apps.paloaltonetworks.com` and `api.sase.paloaltonetworks.com` resolve to the same
+ * host and behave identically — one API gateway routing by path prefix. `api.apps` is the
+ * documented name; override with `PANW_AI_GW_DATA_ENDPOINT` to reuse an existing
+ * `api.sase` egress allowlist.
+ */
+export const DEFAULT_AI_GW_DATA_ENDPOINT = 'https://api.apps.paloaltonetworks.com/ai_gw/v2';
+/** Default AI Gateway admin-plane (organisation-scoped config) endpoint. */
+export const DEFAULT_AI_GW_ADMIN_ENDPOINT = 'https://api.apps.paloaltonetworks.com/ai_gw/admin/v2';
+
+export const AI_GW_DATA_ENDPOINT = 'PANW_AI_GW_DATA_ENDPOINT';
+export const AI_GW_ADMIN_ENDPOINT = 'PANW_AI_GW_ADMIN_ENDPOINT';
+export const AI_GW_TOKEN_ENDPOINT = 'PANW_AI_GW_TOKEN_ENDPOINT';
+
+/** Mandatory on every AI Gateway request; omitting it yields a 403 OPA denial. */
+export const TSG_ID_HEADER = 'x-tsg-id';
+
+// Data plane
+export const AI_GW_WORKSPACES_PATH = '/workspaces';
+export const AI_GW_CONFIGS_PATH = '/configs';
+export const AI_GW_GUARDRAILS_PATH = '/guardrails';
+export const AI_GW_PROVIDERS_PATH = '/providers';
+export const AI_GW_API_KEYS_SERVICE_PATH = '/api-keys/service';
+export const AI_GW_API_KEYS_USER_PATH = '/api-keys/user';
+export const AI_GW_LOGS_PATH = '/logs';
+export const AI_GW_CHARTS_PATH = '/logs/charts';
+export const AI_GW_GROUPS_PATH = '/logs/groups';
+
+// Admin plane
+export const AI_GW_INTEGRATIONS_PATH = '/integrations';
+export const AI_GW_MCP_INTEGRATIONS_PATH = '/mcp-integrations';
+export const AI_GW_DEPLOYMENTS_PATH = '/deployments';
+export const AI_GW_PLUGINS_PATH = '/plugins';
+export const AI_GW_ORGANISATIONS_SELF_PATH = '/organisations/self';
+export const AI_GW_AUDIT_LOGS_PATH = '/audit-logs';
+
+/**
+ * Chart metric slugs. Bespoke and unguessable — plural vs singular is load-bearing
+ * (`user-trends` works, `user-trend` 404s). Verified live 2026-07-27; do not derive.
+ */
+export const AI_GW_CHART_METRICS = [
+  'cost',
+  'requests',
+  'latency',
+  'tokens',
+  'errors',
+  'users',
+  'cache-summary',
+  'cache-hit-trend',
+  'user-trends',
+  'error-trends',
+  'rescued-retries',
+  'feedback-trend',
+  'feedback-weighted',
+  'feedback-score-distribution',
+  'feedback-models',
+] as const;
+
+/** Valid `logs/groups/{dimension}` values. Underscore names only; hyphen/camel variants 400. */
+export const AI_GW_GROUP_DIMENSIONS = ['ai_service', 'model', 'api_key', 'provider'] as const;
+
+/** Valid `&columns=` values for `logs/groups/*`. Invalid names are silently dropped. */
+export const AI_GW_GROUP_COLUMNS = [
+  'cost',
+  'avg_latency',
+  'avg_tokens',
+  'total_tokens',
+  'success_rate',
+  'last_seen',
+] as const;

--- a/src/http-retry.ts
+++ b/src/http-retry.ts
@@ -45,19 +45,29 @@ export function classifyErrorType(status: number): ErrorType {
 /**
  * @internal
  * Extract a human-readable error message from an API error response body.
- * Tries `error_message`, `message`, and `error.message` fields in order.
+ *
+ * Tries, in order: `error_message`, `message`, `data.message` (the AI Gateway app-RBAC
+ * shape, `{success:false,data:{message,errorCode}}`), `error.message`, and `msg` (the SCM
+ * OPA-denial shape, `{"msg":"Access denied"}`). When the body carries an `errorCode` (e.g.
+ * AI Gateway's `AB01`/`AB02`/`AB03`), it is appended to the message so callers can act on
+ * the distinction without inspecting headers — see PRD-ai-gateway-client.md "Failure modes".
+ *
  * @param body - Raw response body string.
  * @param status - HTTP status code for fallback message.
  */
 export function extractErrorMessage(body: string, status: number): string {
   try {
     const parsed = JSON.parse(body) as Record<string, unknown>;
-    return (
+    const data = parsed.data as Record<string, unknown> | undefined;
+    const code = (data?.errorCode as string | undefined) ?? undefined;
+    const base =
       (parsed.error_message as string) ??
       (parsed.message as string) ??
+      (data?.message as string) ??
       ((parsed.error as Record<string, unknown> | undefined)?.message as string) ??
-      `API error ${status}`
-    );
+      (parsed.msg as string) ??
+      `API error ${status}`;
+    return code ? `${base} (errorCode: ${code})` : base;
   } catch {
     return body ? `API error ${status}: ${body}` : `API error ${status}`;
   }

--- a/src/http/auth/tsg-header.ts
+++ b/src/http/auth/tsg-header.ts
@@ -1,0 +1,27 @@
+import { TSG_ID_HEADER } from '../../constants.js';
+import type { AuthAdapter, PreparedRequest } from '../types.js';
+
+/**
+ * @internal
+ * Wraps another {@link AuthAdapter} and adds the `x-tsg-id` header that every AI Gateway
+ * endpoint requires. Composes over {@link OAuthAuth} so the existing token-refresh
+ * free-retry behaviour is preserved unchanged.
+ */
+export class TsgHeaderAuth implements AuthAdapter {
+  constructor(
+    private readonly inner: AuthAdapter,
+    private readonly tsgId: string,
+  ) {}
+
+  async prepare(req: PreparedRequest): Promise<PreparedRequest> {
+    const prepared = await this.inner.prepare(req);
+    return {
+      ...prepared,
+      headers: { ...prepared.headers, [TSG_ID_HEADER]: this.tsgId },
+    };
+  }
+
+  async onUnauthorized(res: Response): Promise<boolean> {
+    return (await this.inner.onUnauthorized?.(res)) ?? false;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,4 @@ export * from './constants.js';
 export * from './management/index.js';
 export * from './model-security/index.js';
 export * from './red-team/index.js';
+export * from './ai-gateway/index.js';

--- a/src/models/ai-gateway.ts
+++ b/src/models/ai-gateway.ts
@@ -357,3 +357,339 @@ export const GatewayLogsResponseSchema = aiGatewayEnvelope(
     .passthrough(),
 );
 export type GatewayLogsResponse = z.infer<typeof GatewayLogsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Write responses
+// ---------------------------------------------------------------------------
+
+/**
+ * Placeholder for write responses whose shape has NOT been verified against a live tenant.
+ *
+ * Verifying `deployments` proved a create response can differ completely from the record it
+ * creates (5-field receipt vs 15-field record), so these shapes cannot be inferred from the
+ * corresponding read. Tighten each into a named schema as it is verified. See
+ * PRD-ai-gateway-client.md "Testing".
+ */
+export const GatewayWriteResponseSchema = z.object({}).passthrough();
+export type GatewayWriteResponse = z.infer<typeof GatewayWriteResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Workspaces (data plane)
+// ---------------------------------------------------------------------------
+
+/** A workspace list row. `scope_name` is the SCM role scope that grants data-plane access. */
+export const GatewayWorkspaceSchema = z
+  .object({
+    id: z.string(),
+    slug: z.string(),
+    name: z.string(),
+    icon: z.string().nullable(),
+    description: z.string(),
+    created_at: z.string(),
+    last_updated_at: z.string(),
+    is_default: z.number(),
+    status: z.string(),
+    scope_name: z.string(),
+    object: z.string(),
+  })
+  .passthrough();
+export type GatewayWorkspace = z.infer<typeof GatewayWorkspaceSchema>;
+
+/** Workspace detail. Carries settings blocks absent from list rows. */
+export const GatewayWorkspaceDetailSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    created_at: z.string(),
+    last_updated_at: z.string(),
+    is_default: z.number(),
+    slug: z.string(),
+    icon: z.string().nullable(),
+    defaults: z.record(z.unknown()).nullable(),
+    usage_limits: z.record(z.unknown()).nullable(),
+    rate_limits: z.record(z.unknown()).nullable(),
+    security_settings: z.record(z.boolean()).optional(),
+    data_plane_security_settings: z.record(z.unknown()).optional(),
+    settings: z.record(z.unknown()).optional(),
+  })
+  .passthrough();
+export type GatewayWorkspaceDetail = z.infer<typeof GatewayWorkspaceDetailSchema>;
+
+export const ListWorkspacesResponseSchema = aiGatewayList(GatewayWorkspaceSchema);
+export type ListWorkspacesResponse = z.infer<typeof ListWorkspacesResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Configs (data plane)
+// ---------------------------------------------------------------------------
+
+/**
+ * A gateway config. **`config` is a JSON-encoded STRING, not an object** — the wire type is
+ * preserved rather than silently parsed. Use `JSON.parse(config)` at the call site.
+ */
+export const GatewayConfigSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string(),
+    /** Internal organisation UUID — NOT the TSG that write requests take. */
+    organisation_id: z.string(),
+    is_default: z.number(),
+    status: z.string(),
+    owner_id: z.string(),
+    updated_by: z.string(),
+    created_at: z.string(),
+    last_updated_at: z.string(),
+    workspace_id: z.string(),
+    config: z.string(),
+    format: z.string(),
+    type: z.string(),
+    version_id: z.string(),
+    object: z.string(),
+  })
+  .passthrough();
+export type GatewayConfig = z.infer<typeof GatewayConfigSchema>;
+
+export const ListConfigsResponseSchema = aiGatewayList(GatewayConfigSchema);
+export type ListConfigsResponse = z.infer<typeof ListConfigsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Guardrails / providers / API keys (data plane)
+// ---------------------------------------------------------------------------
+
+/** A workspace guardrail. Field set beyond the identifiers is tenant-dependent. */
+export const GatewayGuardrailSchema = z
+  .object({ id: z.string(), name: z.string().optional(), object: z.string().optional() })
+  .passthrough();
+export type GatewayGuardrail = z.infer<typeof GatewayGuardrailSchema>;
+export const ListGuardrailsResponseSchema = aiGatewayList(GatewayGuardrailSchema);
+export type ListGuardrailsResponse = z.infer<typeof ListGuardrailsResponseSchema>;
+
+/** A workspace-scoped AI provider binding. */
+export const GatewayProviderSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    slug: z.string().optional(),
+    object: z.string().optional(),
+  })
+  .passthrough();
+export type GatewayProvider = z.infer<typeof GatewayProviderSchema>;
+export const ListProvidersResponseSchema = aiGatewayList(GatewayProviderSchema);
+export type ListProvidersResponse = z.infer<typeof ListProvidersResponseSchema>;
+
+/** A service or user API key. The secret itself is only returned at creation. */
+export const GatewayApiKeySchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    object: z.string().optional(),
+  })
+  .passthrough();
+export type GatewayApiKey = z.infer<typeof GatewayApiKeySchema>;
+export const ListApiKeysResponseSchema = aiGatewayList(GatewayApiKeySchema);
+export type ListApiKeysResponse = z.infer<typeof ListApiKeysResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Integrations (admin plane)
+// ---------------------------------------------------------------------------
+
+/** An organisation-level provider integration. */
+export const IntegrationSchema = z
+  .object({
+    id: z.string(),
+    organisation_id: z.string().optional(),
+    name: z.string(),
+    owner_id: z.string(),
+    status: z.string(),
+    created_at: z.string(),
+    last_updated_at: z.string(),
+    slug: z.string(),
+    tags: z.unknown().nullable(),
+    description: z.string().nullable(),
+    workspaces_count: z.number().optional(),
+    type: z.string().optional(),
+    workspace_id: z.string().nullable(),
+    ai_provider_id: z.string(),
+    object: z.string(),
+  })
+  .passthrough();
+export type Integration = z.infer<typeof IntegrationSchema>;
+export const ListIntegrationsResponseSchema = aiGatewayList(IntegrationSchema);
+export type ListIntegrationsResponse = z.infer<typeof ListIntegrationsResponseSchema>;
+
+/** `integrations/{id}/models` — per-model enablement for one integration. */
+export const IntegrationModelsResponseSchema = z
+  .object({
+    models: z.array(z.object({ slug: z.string(), enabled: z.boolean() }).passthrough()),
+    allow_all_models: z.boolean(),
+    object: z.string(),
+  })
+  .passthrough();
+export type IntegrationModelsResponse = z.infer<typeof IntegrationModelsResponseSchema>;
+
+/** `integrations/{id}/workspaces` — which workspaces may use this integration. */
+export const IntegrationWorkspacesResponseSchema = z
+  .object({
+    workspaces: z.array(z.record(z.unknown())),
+    global_workspace_access: z.boolean(),
+    object: z.string(),
+  })
+  .passthrough();
+export type IntegrationWorkspacesResponse = z.infer<typeof IntegrationWorkspacesResponseSchema>;
+
+/** An MCP server integration. */
+export const McpIntegrationSchema = z
+  .object({
+    id: z.string(),
+    organisation_id: z.string(),
+    name: z.string(),
+    owner_id: z.string(),
+    status: z.string(),
+    type: z.string(),
+    url: z.string(),
+    auth_type: z.string(),
+    transport: z.string(),
+    configurations: z.record(z.unknown()),
+    created_at: z.string(),
+    last_updated_at: z.string(),
+  })
+  .passthrough();
+export type McpIntegration = z.infer<typeof McpIntegrationSchema>;
+export const ListMcpIntegrationsResponseSchema = aiGatewayList(McpIntegrationSchema);
+export type ListMcpIntegrationsResponse = z.infer<typeof ListMcpIntegrationsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Deployments (admin plane) — three distinct shapes, verified live
+// ---------------------------------------------------------------------------
+
+/** A deployment list row. */
+export const DeploymentSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string(),
+    type: z.string(),
+    /** `active` | `archived`. DELETE archives rather than removes. */
+    status: z.string(),
+    created_at: z.string(),
+    last_updated_at: z.string(),
+    last_synced_at: z.string().nullable(),
+    last_resynced_at: z.string().nullable(),
+    is_default: z.number(),
+    created_by: z.string(),
+    object: z.string(),
+  })
+  .passthrough();
+export type Deployment = z.infer<typeof DeploymentSchema>;
+
+/** Deployment detail — adds credentials (masked), auth settings, and bound workspaces. */
+export const DeploymentDetailSchema = DeploymentSchema.extend({
+  credentials: z.object({ username: z.string(), password: z.string() }).passthrough().optional(),
+  deployment_config: z.record(z.unknown()).nullable(),
+  auth_settings: z
+    .object({
+      /** 0/1, not boolean — the create REQUEST sends a real boolean here. */
+      disable_portkey_gateway: z.number(),
+      workspaces_allowed: z.array(z.string()),
+      allow_all_workspaces: z.number(),
+    })
+    .passthrough()
+    .optional(),
+  client_auth: z.string().optional(),
+  workspaces: z.array(z.object({ id: z.string(), slug: z.string() }).passthrough()).optional(),
+}).passthrough();
+export type DeploymentDetail = z.infer<typeof DeploymentDetailSchema>;
+
+/**
+ * `POST /deployments` response — a 5-field creation receipt, **not** a {@link Deployment}.
+ * Verified live 2026-07-27.
+ *
+ * This is the only time `credentials.password` and `client_auth` are readable; the detail
+ * read masks them. Capture them at creation or they are unrecoverable.
+ */
+export const DeploymentCreateResponseSchema = z
+  .object({
+    id: z.string(),
+    client_auth: z.string(),
+    credentials: z.object({ username: z.string(), password: z.string() }).passthrough(),
+    /** Internal organisation UUID — NOT the TSG sent in the request. */
+    organisation_id: z.string(),
+    object: z.string(),
+  })
+  .passthrough();
+export type DeploymentCreateResponse = z.infer<typeof DeploymentCreateResponseSchema>;
+
+export const ListDeploymentsResponseSchema = aiGatewayList(DeploymentSchema);
+export type ListDeploymentsResponse = z.infer<typeof ListDeploymentsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Plugins / organisations / audit logs (admin plane)
+// ---------------------------------------------------------------------------
+
+/** A gateway plugin binding (e.g. the Prisma AIRS scanner). Credentials arrive masked. */
+export const PluginSchema = z
+  .object({
+    id: z.string(),
+    integration_id: z.string(),
+    credentials: z.record(z.string()),
+    owner_id: z.string(),
+    created_at: z.string(),
+    last_updated_at: z.string(),
+    status: z.string(),
+    integration_slug: z.string(),
+    plugin_provider_id: z.string(),
+    plugin_provider_slug: z.string(),
+    object: z.string(),
+  })
+  .passthrough();
+export type Plugin = z.infer<typeof PluginSchema>;
+export const ListPluginsResponseSchema = aiGatewayList(PluginSchema);
+export type ListPluginsResponse = z.infer<typeof ListPluginsResponseSchema>;
+
+/** `organisations/self`. Wrapped in `{success, data}` unlike the other admin resources. */
+export const OrganisationSelfResponseSchema = z
+  .object({ success: z.boolean(), data: z.record(z.unknown()) })
+  .passthrough();
+export type OrganisationSelfResponse = z.infer<typeof OrganisationSelfResponseSchema>;
+
+/** `organisations/{tsg}/auth-settings`. */
+export const AuthSettingsResponseSchema = z
+  .object({ success: z.boolean(), data: z.record(z.unknown()) })
+  .passthrough();
+export type AuthSettingsResponse = z.infer<typeof AuthSettingsResponseSchema>;
+
+/**
+ * One audit-log record.
+ *
+ * SECURITY: `request_body` is returned **unredacted** by the API and can contain live
+ * credentials (private keys, API keys) submitted through the SCM UI. The sibling
+ * `request_headers` field IS masked. Never log this record wholesale.
+ */
+export const AuditLogRecordSchema = z
+  .object({
+    timestamp: z.string(),
+    method: z.string(),
+    uri: z.string(),
+    request_id: z.string(),
+    request_body: z.string(),
+    query_params: z.string(),
+    request_headers: z.string(),
+    user_id: z.string(),
+    user_type: z.string(),
+    organisation_id: z.string(),
+    workspace_id: z.string(),
+    response_status_code: z.number(),
+    resource_type: z.string(),
+    action: z.string(),
+    client_ip: z.string(),
+    country: z.string(),
+  })
+  .passthrough();
+export type AuditLogRecord = z.infer<typeof AuditLogRecordSchema>;
+
+/** `audit-logs` — a bare `{records}` object, neither list envelope. */
+export const AuditLogsResponseSchema = z
+  .object({ records: z.array(AuditLogRecordSchema) })
+  .passthrough();
+export type AuditLogsResponse = z.infer<typeof AuditLogsResponseSchema>;

--- a/src/models/ai-gateway.ts
+++ b/src/models/ai-gateway.ts
@@ -1,0 +1,359 @@
+// src/models/ai-gateway.ts — Zod schemas + types for the Prisma AIRS AI Gateway API
+//
+// Derived from live responses against TSG 1852583913 on 2026-07-27, not from an OpenAPI
+// spec (none exists for this API). Schema rationale, landmines, and the full endpoint
+// inventory live in PRD-ai-gateway-client.md in the Obsidian vault.
+//
+// Conventions specific to this API:
+//   - `cost` values are in CENTS. Never divided here.
+//   - Booleans arrive as 0/1 integers. z.number(), not z.boolean().
+//   - Observed-null fields use .nullable(), not .optional().
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Envelopes — three distinct families
+// ---------------------------------------------------------------------------
+
+/** Envelope A: `{ success, data }` — telemetry charts and the bare `logs` collection. */
+const aiGatewayEnvelope = <T extends z.ZodTypeAny>(data: T) =>
+  z.object({ success: z.boolean(), data }).passthrough();
+
+/** Envelope B: `{ object, total, data[] }` — config and admin collections. */
+export const aiGatewayList = <T extends z.ZodTypeAny>(item: T) =>
+  z
+    .object({
+      object: z.string(),
+      total: z.number(),
+      has_more: z.boolean().optional(),
+      data: z.array(item),
+    })
+    .passthrough();
+
+/** Envelope C: `logs/groups/*` — note `is_quota_exceeded` is snake_case here only. */
+const aiGatewayGroupList = <T extends z.ZodTypeAny>(item: T) =>
+  z
+    .object({
+      object: z.string(),
+      is_quota_exceeded: z.boolean(),
+      total: z.number(),
+      data: z.array(item),
+    })
+    .passthrough();
+
+/** Present on every envelope-A telemetry payload. */
+const quotaFlag = { isQuotaExceeded: z.boolean() };
+
+// ---------------------------------------------------------------------------
+// Telemetry — charts
+// ---------------------------------------------------------------------------
+
+/** A `{x, y}` time-bucket, optionally carrying a bucket average. */
+export const ChartRecordSchema = z
+  .object({ x: z.string(), y: z.number(), avg: z.number().optional() })
+  .passthrough();
+export type ChartRecord = z.infer<typeof ChartRecordSchema>;
+
+/** `logs/charts/cost`. **`y` and `total` are in cents.** */
+export const CostChartResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      records: z.array(ChartRecordSchema),
+      total: z.number(),
+      avg: z.number(),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type CostChartResponse = z.infer<typeof CostChartResponseSchema>;
+
+/** `logs/charts/{requests,errors,users,feedback-trend,feedback-weighted}` — plain counts. */
+export const CountChartResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      records: z.array(ChartRecordSchema),
+      total: z.number().nullable(),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type CountChartResponse = z.infer<typeof CountChartResponseSchema>;
+
+/** `logs/charts/latency`. Percentiles appear per-bucket AND at top level; ms. */
+export const LatencyChartResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      records: z.array(
+        z
+          .object({
+            x: z.string(),
+            y: z.number(),
+            p50: z.number(),
+            p90: z.number(),
+            p99: z.number(),
+          })
+          .passthrough(),
+      ),
+      total: z.number(),
+      p50: z.number(),
+      p90: z.number(),
+      p99: z.number(),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type LatencyChartResponse = z.infer<typeof LatencyChartResponseSchema>;
+
+/** `logs/charts/tokens`. Request/response unit splits appear at both levels. */
+export const TokensChartResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      records: z.array(
+        z
+          .object({
+            x: z.string(),
+            y: z.number(),
+            total_request_units: z.number(),
+            total_response_units: z.number(),
+            avg: z.number(),
+          })
+          .passthrough(),
+      ),
+      total: z.number(),
+      avg: z.number(),
+      total_request_units: z.number(),
+      total_response_units: z.number(),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type TokensChartResponse = z.infer<typeof TokensChartResponseSchema>;
+
+/** `logs/charts/cache-summary`. `avgCacheLatency` is null when there are no hits. */
+export const CacheSummaryResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      summary: z
+        .object({
+          cacheHits: z.number(),
+          avgCacheLatency: z.number().nullable(),
+          totalRequests: z.number(),
+          cacheSpeedup: z.number(),
+        })
+        .passthrough(),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type CacheSummaryResponse = z.infer<typeof CacheSummaryResponseSchema>;
+
+/** `logs/charts/cache-hit-trend`. Savings are CUMULATIVE cents — take the last non-zero bucket. */
+export const CacheHitTrendResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      trend: z.array(
+        z
+          .object({
+            x: z.string(),
+            simpleHits: z.number(),
+            semanticHits: z.number(),
+            hitRate: z.number(),
+            cumulativeSimpleHitSavings: z.number(),
+            cumulativeSemanticHitSavings: z.number(),
+          })
+          .passthrough(),
+      ),
+      total: z.number(),
+      summary: z.object({ totalCacheHits: z.number(), hitRate: z.number() }).passthrough(),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type CacheHitTrendResponse = z.infer<typeof CacheHitTrendResponseSchema>;
+
+/** `logs/charts/user-trends`. `summary.avg` is requests-per-user. */
+export const UserTrendsResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      summary: z.object({ total: z.number(), unique: z.number(), avg: z.number() }).passthrough(),
+      trend: z.array(ChartRecordSchema),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type UserTrendsResponse = z.infer<typeof UserTrendsResponseSchema>;
+
+/** `logs/charts/error-trends`. `trend[].y` is a percentage. */
+export const ErrorTrendsResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      summary: z.object({ errorPercent: z.number() }).passthrough(),
+      trend: z.array(ChartRecordSchema),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type ErrorTrendsResponse = z.infer<typeof ErrorTrendsResponseSchema>;
+
+/**
+ * `logs/charts/rescued-retries`. **`trend[].y` is an array, not a scalar** — it cannot share
+ * {@link ChartRecordSchema}. Sparse: only populated on upstream failures.
+ */
+export const RescuedRetriesResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      trend: z.array(
+        z
+          .object({
+            x: z.string(),
+            y: z.array(
+              z.object({ retry_success_count: z.number(), count: z.number() }).passthrough(),
+            ),
+          })
+          .passthrough(),
+      ),
+      total: z.number(),
+      trends: z.array(
+        z
+          .object({ x: z.string(), retry: z.array(z.unknown()), fallback: z.array(z.unknown()) })
+          .passthrough(),
+      ),
+      retryTotal: z.number(),
+      fallbackTotal: z.number(),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type RescuedRetriesResponse = z.infer<typeof RescuedRetriesResponseSchema>;
+
+/** `logs/charts/feedback-score-distribution`. Feedback is binary ±5. */
+export const FeedbackScoreDistributionResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      records: z.array(z.object({ x: z.number(), y: z.number() }).passthrough()),
+      total: z.number().nullable(),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type FeedbackScoreDistributionResponse = z.infer<
+  typeof FeedbackScoreDistributionResponseSchema
+>;
+
+/** `logs/charts/feedback-models`. `x` is the model; `y` is an object, not a number. */
+export const FeedbackModelsResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      records: z.array(
+        z
+          .object({
+            x: z.string(),
+            y: z
+              .object({ avgWeightedFeedback: z.number(), feedbackCount: z.number() })
+              .passthrough(),
+          })
+          .passthrough(),
+      ),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type FeedbackModelsResponse = z.infer<typeof FeedbackModelsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Telemetry — groups
+// ---------------------------------------------------------------------------
+
+/**
+ * One `logs/groups/{dimension}` row. The dimension key itself varies by endpoint
+ * (`model`, `ai_service`, `api_key`, `provider`, `status_code`), so only the shared
+ * columns are declared; `.passthrough()` carries the dimension key through.
+ */
+export const GroupRowSchema = z
+  .object({
+    requests: z.number(),
+    cost: z.number().optional(),
+    avg_latency: z.number().optional(),
+    avg_tokens: z.number().optional(),
+    total_tokens: z.number().optional(),
+    success_rate: z.number().optional(),
+    last_seen: z.string().optional(),
+    object: z.string(),
+  })
+  .passthrough();
+export type GroupRow = z.infer<typeof GroupRowSchema>;
+
+/** `logs/groups/{ai_service,model,api_key,provider,status_code}`. */
+export const GroupListResponseSchema = aiGatewayGroupList(GroupRowSchema);
+export type GroupListResponse = z.infer<typeof GroupListResponseSchema>;
+
+/**
+ * `logs/groups/users` — uses envelope A while every sibling uses envelope C.
+ * Not a typo; verified live. `_user: ''` means calls with no end-user id.
+ */
+export const UserGroupResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      records: z.array(
+        z.object({ _user: z.string(), count: z.number(), cost: z.number() }).passthrough(),
+      ),
+      total: z.number(),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type UserGroupResponse = z.infer<typeof UserGroupResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Telemetry — raw logs
+// ---------------------------------------------------------------------------
+
+/** One per-request row from the bare `logs` collection — the deepest granularity available. */
+export const GatewayLogRecordSchema = z
+  .object({
+    id: z.string(),
+    workspace_slug: z.string(),
+    ai_model: z.string(),
+    _user: z.string(),
+    total_units: z.number(),
+    /** Cents. */
+    cost: z.number(),
+    trace_id: z.string(),
+    /** 0/1, not boolean. */
+    is_proxy_call: z.number(),
+    created_at: z.string(),
+    /** 0/1, not boolean. */
+    is_success: z.number(),
+    /** `HIT` | `MISS` | `DISABLED`. */
+    cache_status: z.string(),
+    retry_success_count: z.number(),
+    mode: z.string(),
+    last_used_option_index: z.number(),
+    /** 200 success, 446 AIRS security block (cost 0), 400 validation. */
+    response_status_code: z.number(),
+    request_url: z.string(),
+    request_method: z.string(),
+    ai_org: z.string(),
+    api_key_id: z.string(),
+    license_id: z.string(),
+    log_store_file_path_format: z.string(),
+    metadataKey: z.array(z.string()),
+    metadataValue: z.array(z.string()),
+    prompt_slug: z.string(),
+    feedback: z.array(z.unknown()),
+  })
+  .passthrough();
+export type GatewayLogRecord = z.infer<typeof GatewayLogRecordSchema>;
+
+/** Bare `logs`. `capturedTotal` is always 0 upstream; `total` is the full-period count. */
+export const GatewayLogsResponseSchema = aiGatewayEnvelope(
+  z
+    .object({
+      records: z.array(GatewayLogRecordSchema),
+      total: z.number(),
+      capturedTotal: z.number(),
+      ...quotaFlag,
+    })
+    .passthrough(),
+);
+export type GatewayLogsResponse = z.infer<typeof GatewayLogsResponseSchema>;

--- a/src/models/ai-gateway.ts
+++ b/src/models/ai-gateway.ts
@@ -54,16 +54,16 @@ const quotaFlag = { isQuotaExceeded: z.boolean() };
 // ---------------------------------------------------------------------------
 
 /** A `{x, y}` time-bucket, optionally carrying a bucket average. */
-export const ChartRecordSchema = z
+export const GatewayChartRecordSchema = z
   .object({ x: z.string(), y: z.number(), avg: z.number().optional() })
   .passthrough();
-export type ChartRecord = z.infer<typeof ChartRecordSchema>;
+export type GatewayChartRecord = z.infer<typeof GatewayChartRecordSchema>;
 
 /** `logs/charts/cost`. **`y` and `total` are in cents.** */
 export const CostChartResponseSchema = aiGatewayEnvelope(
   z
     .object({
-      records: z.array(ChartRecordSchema),
+      records: z.array(GatewayChartRecordSchema),
       total: z.number(),
       avg: z.number(),
       ...quotaFlag,
@@ -76,7 +76,7 @@ export type CostChartResponse = z.infer<typeof CostChartResponseSchema>;
 export const CountChartResponseSchema = aiGatewayEnvelope(
   z
     .object({
-      records: z.array(ChartRecordSchema),
+      records: z.array(GatewayChartRecordSchema),
       total: z.number().nullable(),
       ...quotaFlag,
     })
@@ -181,7 +181,7 @@ export const UserTrendsResponseSchema = aiGatewayEnvelope(
   z
     .object({
       summary: z.object({ total: z.number(), unique: z.number(), avg: z.number() }).passthrough(),
-      trend: z.array(ChartRecordSchema),
+      trend: z.array(GatewayChartRecordSchema),
       ...quotaFlag,
     })
     .passthrough(),
@@ -193,7 +193,7 @@ export const ErrorTrendsResponseSchema = aiGatewayEnvelope(
   z
     .object({
       summary: z.object({ errorPercent: z.number() }).passthrough(),
-      trend: z.array(ChartRecordSchema),
+      trend: z.array(GatewayChartRecordSchema),
       ...quotaFlag,
     })
     .passthrough(),
@@ -202,7 +202,7 @@ export type ErrorTrendsResponse = z.infer<typeof ErrorTrendsResponseSchema>;
 
 /**
  * `logs/charts/rescued-retries`. **`trend[].y` is an array, not a scalar** — it cannot share
- * {@link ChartRecordSchema}. Sparse: only populated on upstream failures.
+ * {@link GatewayChartRecordSchema}. Sparse: only populated on upstream failures.
  */
 export const RescuedRetriesResponseSchema = aiGatewayEnvelope(
   z
@@ -211,9 +211,11 @@ export const RescuedRetriesResponseSchema = aiGatewayEnvelope(
         z
           .object({
             x: z.string(),
-            y: z.array(
-              z.object({ retry_success_count: z.number(), count: z.number() }).passthrough(),
-            ),
+            // Element shape unobserved — sample tenants only ever produced an empty array.
+            // Treated like the sibling trends[].retry/fallback below until a tenant with
+            // actual gateway retries lets us confirm the real shape. See open questions in
+            // PRD-ai-gateway-client.md.
+            y: z.array(z.unknown()),
           })
           .passthrough(),
       ),
@@ -274,7 +276,7 @@ export type FeedbackModelsResponse = z.infer<typeof FeedbackModelsResponseSchema
  * (`model`, `ai_service`, `api_key`, `provider`, `status_code`), so only the shared
  * columns are declared; `.passthrough()` carries the dimension key through.
  */
-export const GroupRowSchema = z
+export const GatewayGroupRowSchema = z
   .object({
     requests: z.number(),
     cost: z.number().optional(),
@@ -286,10 +288,10 @@ export const GroupRowSchema = z
     object: z.string(),
   })
   .passthrough();
-export type GroupRow = z.infer<typeof GroupRowSchema>;
+export type GatewayGroupRow = z.infer<typeof GatewayGroupRowSchema>;
 
 /** `logs/groups/{ai_service,model,api_key,provider,status_code}`. */
-export const GroupListResponseSchema = aiGatewayGroupList(GroupRowSchema);
+export const GroupListResponseSchema = aiGatewayGroupList(GatewayGroupRowSchema);
 export type GroupListResponse = z.infer<typeof GroupListResponseSchema>;
 
 /**
@@ -500,7 +502,7 @@ export type ListApiKeysResponse = z.infer<typeof ListApiKeysResponseSchema>;
 // ---------------------------------------------------------------------------
 
 /** An organisation-level provider integration. */
-export const IntegrationSchema = z
+export const GatewayIntegrationSchema = z
   .object({
     id: z.string(),
     organisation_id: z.string().optional(),
@@ -519,8 +521,8 @@ export const IntegrationSchema = z
     object: z.string(),
   })
   .passthrough();
-export type Integration = z.infer<typeof IntegrationSchema>;
-export const ListIntegrationsResponseSchema = aiGatewayList(IntegrationSchema);
+export type GatewayIntegration = z.infer<typeof GatewayIntegrationSchema>;
+export const ListIntegrationsResponseSchema = aiGatewayList(GatewayIntegrationSchema);
 export type ListIntegrationsResponse = z.infer<typeof ListIntegrationsResponseSchema>;
 
 /** `integrations/{id}/models` — per-model enablement for one integration. */
@@ -569,7 +571,7 @@ export type ListMcpIntegrationsResponse = z.infer<typeof ListMcpIntegrationsResp
 // ---------------------------------------------------------------------------
 
 /** A deployment list row. */
-export const DeploymentSchema = z
+export const GatewayDeploymentSchema = z
   .object({
     id: z.string(),
     name: z.string(),
@@ -586,10 +588,10 @@ export const DeploymentSchema = z
     object: z.string(),
   })
   .passthrough();
-export type Deployment = z.infer<typeof DeploymentSchema>;
+export type GatewayDeployment = z.infer<typeof GatewayDeploymentSchema>;
 
 /** Deployment detail — adds credentials (masked), auth settings, and bound workspaces. */
-export const DeploymentDetailSchema = DeploymentSchema.extend({
+export const DeploymentDetailSchema = GatewayDeploymentSchema.extend({
   credentials: z.object({ username: z.string(), password: z.string() }).passthrough().optional(),
   deployment_config: z.record(z.unknown()).nullable(),
   auth_settings: z
@@ -607,7 +609,7 @@ export const DeploymentDetailSchema = DeploymentSchema.extend({
 export type DeploymentDetail = z.infer<typeof DeploymentDetailSchema>;
 
 /**
- * `POST /deployments` response — a 5-field creation receipt, **not** a {@link Deployment}.
+ * `POST /deployments` response — a 5-field creation receipt, **not** a {@link GatewayDeployment}.
  * Verified live 2026-07-27.
  *
  * This is the only time `credentials.password` and `client_auth` are readable; the detail
@@ -625,7 +627,7 @@ export const DeploymentCreateResponseSchema = z
   .passthrough();
 export type DeploymentCreateResponse = z.infer<typeof DeploymentCreateResponseSchema>;
 
-export const ListDeploymentsResponseSchema = aiGatewayList(DeploymentSchema);
+export const ListDeploymentsResponseSchema = aiGatewayList(GatewayDeploymentSchema);
 export type ListDeploymentsResponse = z.infer<typeof ListDeploymentsResponseSchema>;
 
 // ---------------------------------------------------------------------------
@@ -633,7 +635,7 @@ export type ListDeploymentsResponse = z.infer<typeof ListDeploymentsResponseSche
 // ---------------------------------------------------------------------------
 
 /** A gateway plugin binding (e.g. the Prisma AIRS scanner). Credentials arrive masked. */
-export const PluginSchema = z
+export const GatewayPluginSchema = z
   .object({
     id: z.string(),
     integration_id: z.string(),
@@ -648,8 +650,8 @@ export const PluginSchema = z
     object: z.string(),
   })
   .passthrough();
-export type Plugin = z.infer<typeof PluginSchema>;
-export const ListPluginsResponseSchema = aiGatewayList(PluginSchema);
+export type GatewayPlugin = z.infer<typeof GatewayPluginSchema>;
+export const ListPluginsResponseSchema = aiGatewayList(GatewayPluginSchema);
 export type ListPluginsResponse = z.infer<typeof ListPluginsResponseSchema>;
 
 /** `organisations/self`. Wrapped in `{success, data}` unlike the other admin resources. */
@@ -671,7 +673,7 @@ export type AuthSettingsResponse = z.infer<typeof AuthSettingsResponseSchema>;
  * credentials (private keys, API keys) submitted through the SCM UI. The sibling
  * `request_headers` field IS masked. Never log this record wholesale.
  */
-export const AuditLogRecordSchema = z
+export const GatewayAuditLogRecordSchema = z
   .object({
     timestamp: z.string(),
     method: z.string(),
@@ -691,10 +693,10 @@ export const AuditLogRecordSchema = z
     country: z.string(),
   })
   .passthrough();
-export type AuditLogRecord = z.infer<typeof AuditLogRecordSchema>;
+export type GatewayAuditLogRecord = z.infer<typeof GatewayAuditLogRecordSchema>;
 
 /** `audit-logs` — a bare `{records}` object, neither list envelope. */
-export const AuditLogsResponseSchema = z
-  .object({ records: z.array(AuditLogRecordSchema) })
+export const GatewayAuditLogsResponseSchema = z
+  .object({ records: z.array(GatewayAuditLogRecordSchema) })
   .passthrough();
-export type AuditLogsResponse = z.infer<typeof AuditLogsResponseSchema>;
+export type GatewayAuditLogsResponse = z.infer<typeof GatewayAuditLogsResponseSchema>;

--- a/src/models/ai-gateway.ts
+++ b/src/models/ai-gateway.ts
@@ -19,8 +19,13 @@ import { z } from 'zod';
 const aiGatewayEnvelope = <T extends z.ZodTypeAny>(data: T) =>
   z.object({ success: z.boolean(), data }).passthrough();
 
-/** Envelope B: `{ object, total, data[] }` — config and admin collections. */
-export const aiGatewayList = <T extends z.ZodTypeAny>(item: T) =>
+/**
+ * Envelope B: `{ object, total, data[] }` — config and admin collections.
+ *
+ * Module-private like its two siblings: it is only ever applied within this file, and
+ * exporting it would put an internal factory on the package's public API surface.
+ */
+const aiGatewayList = <T extends z.ZodTypeAny>(item: T) =>
   z
     .object({
       object: z.string(),

--- a/src/models/ai-gateway.ts
+++ b/src/models/ai-gateway.ts
@@ -431,8 +431,11 @@ export type ListWorkspacesResponse = z.infer<typeof ListWorkspacesResponseSchema
 // ---------------------------------------------------------------------------
 
 /**
- * A gateway config. **`config` is a JSON-encoded STRING, not an object** — the wire type is
- * preserved rather than silently parsed. Use `JSON.parse(config)` at the call site.
+ * A gateway config **list row** — 12 fields. The list read (`GET /configs?workspace_id=`)
+ * returns a strict subset of the detail read; it does NOT carry `config`, `format`, `type`,
+ * or `version_id`. See {@link GatewayConfigDetailSchema} for the detail shape, and
+ * {@link GatewayDeploymentSchema}/{@link GatewayDeploymentDetailSchema} for the same
+ * list-vs-detail split already established for deployments.
  */
 export const GatewayConfigSchema = z
   .object({
@@ -448,10 +451,6 @@ export const GatewayConfigSchema = z
     created_at: z.string(),
     last_updated_at: z.string(),
     workspace_id: z.string(),
-    config: z.string(),
-    format: z.string(),
-    type: z.string(),
-    version_id: z.string(),
     object: z.string(),
   })
   .passthrough();
@@ -459,6 +458,21 @@ export type GatewayConfig = z.infer<typeof GatewayConfigSchema>;
 
 export const ListConfigsResponseSchema = aiGatewayList(GatewayConfigSchema);
 export type ListConfigsResponse = z.infer<typeof ListConfigsResponseSchema>;
+
+/**
+ * Config detail (`GET /configs/{id}`) — adds `config`, `format`, `type`, `version_id` on top
+ * of the list row. **`config` is a JSON-encoded STRING, not an object** — the wire type is
+ * preserved rather than silently parsed. Use `JSON.parse(config)` at the call site. Same
+ * request/response asymmetry as `mcp-integrations.configurations`, see
+ * {@link McpIntegrationSchema}.
+ */
+export const GatewayConfigDetailSchema = GatewayConfigSchema.extend({
+  config: z.string(),
+  format: z.string(),
+  type: z.string(),
+  version_id: z.string(),
+}).passthrough();
+export type GatewayConfigDetail = z.infer<typeof GatewayConfigDetailSchema>;
 
 // ---------------------------------------------------------------------------
 // Guardrails / providers / API keys (data plane)
@@ -537,11 +551,44 @@ export type GatewayIntegrationModelsResponse = z.infer<
   typeof GatewayIntegrationModelsResponseSchema
 >;
 
+/**
+ * One `integrations/{id}/workspaces.workspaces[]` element — a workspace bound to the
+ * integration. `usage_limits`, `rate_limits`, and `last_reset_at` are observed `null` on a
+ * healthy tenant.
+ */
+export const GatewayIntegrationWorkspaceSchema = z
+  .object({
+    id: z.string(),
+    usage_limits: z.record(z.unknown()).nullable(),
+    rate_limits: z.record(z.unknown()).nullable(),
+    enabled: z.boolean(),
+    status: z.string(),
+    created_at: z.string(),
+    last_updated_at: z.string(),
+    last_reset_at: z.string().nullable(),
+  })
+  .passthrough();
+export type GatewayIntegrationWorkspace = z.infer<typeof GatewayIntegrationWorkspaceSchema>;
+
+/**
+ * `integrations/{id}/workspaces.global_workspace_access` — **an object, not a boolean**
+ * despite the field name (the request-side `GatewayIntegrationWorkspacesRequest` DOES send a
+ * plain boolean here; only the response is an object).
+ */
+export const GatewayGlobalWorkspaceAccessSchema = z
+  .object({
+    enabled: z.boolean(),
+    rate_limits: z.record(z.unknown()).nullable(),
+    usage_limits: z.record(z.unknown()).nullable(),
+  })
+  .passthrough();
+export type GatewayGlobalWorkspaceAccess = z.infer<typeof GatewayGlobalWorkspaceAccessSchema>;
+
 /** `integrations/{id}/workspaces` — which workspaces may use this integration. */
 export const GatewayIntegrationWorkspacesResponseSchema = z
   .object({
-    workspaces: z.array(z.record(z.unknown())),
-    global_workspace_access: z.boolean(),
+    workspaces: z.array(GatewayIntegrationWorkspaceSchema),
+    global_workspace_access: GatewayGlobalWorkspaceAccessSchema,
     object: z.string(),
   })
   .passthrough();
@@ -561,7 +608,12 @@ export const McpIntegrationSchema = z
     url: z.string(),
     auth_type: z.string(),
     transport: z.string(),
-    configurations: z.record(z.unknown()),
+    /**
+     * JSON-encoded STRING on reads — the same request/response asymmetry as
+     * `configs.config` (see {@link GatewayConfigDetailSchema}). The CREATE request
+     * (`McpIntegrationCreateRequest.configurations`) sends an object; this is the read shape.
+     */
+    configurations: z.string(),
     created_at: z.string(),
     last_updated_at: z.string(),
   })

--- a/src/models/ai-gateway.ts
+++ b/src/models/ai-gateway.ts
@@ -526,24 +526,28 @@ export const ListIntegrationsResponseSchema = aiGatewayList(GatewayIntegrationSc
 export type ListIntegrationsResponse = z.infer<typeof ListIntegrationsResponseSchema>;
 
 /** `integrations/{id}/models` — per-model enablement for one integration. */
-export const IntegrationModelsResponseSchema = z
+export const GatewayIntegrationModelsResponseSchema = z
   .object({
     models: z.array(z.object({ slug: z.string(), enabled: z.boolean() }).passthrough()),
     allow_all_models: z.boolean(),
     object: z.string(),
   })
   .passthrough();
-export type IntegrationModelsResponse = z.infer<typeof IntegrationModelsResponseSchema>;
+export type GatewayIntegrationModelsResponse = z.infer<
+  typeof GatewayIntegrationModelsResponseSchema
+>;
 
 /** `integrations/{id}/workspaces` — which workspaces may use this integration. */
-export const IntegrationWorkspacesResponseSchema = z
+export const GatewayIntegrationWorkspacesResponseSchema = z
   .object({
     workspaces: z.array(z.record(z.unknown())),
     global_workspace_access: z.boolean(),
     object: z.string(),
   })
   .passthrough();
-export type IntegrationWorkspacesResponse = z.infer<typeof IntegrationWorkspacesResponseSchema>;
+export type GatewayIntegrationWorkspacesResponse = z.infer<
+  typeof GatewayIntegrationWorkspacesResponseSchema
+>;
 
 /** An MCP server integration. */
 export const McpIntegrationSchema = z
@@ -591,7 +595,7 @@ export const GatewayDeploymentSchema = z
 export type GatewayDeployment = z.infer<typeof GatewayDeploymentSchema>;
 
 /** Deployment detail — adds credentials (masked), auth settings, and bound workspaces. */
-export const DeploymentDetailSchema = GatewayDeploymentSchema.extend({
+export const GatewayDeploymentDetailSchema = GatewayDeploymentSchema.extend({
   credentials: z.object({ username: z.string(), password: z.string() }).passthrough().optional(),
   deployment_config: z.record(z.unknown()).nullable(),
   auth_settings: z
@@ -606,7 +610,7 @@ export const DeploymentDetailSchema = GatewayDeploymentSchema.extend({
   client_auth: z.string().optional(),
   workspaces: z.array(z.object({ id: z.string(), slug: z.string() }).passthrough()).optional(),
 }).passthrough();
-export type DeploymentDetail = z.infer<typeof DeploymentDetailSchema>;
+export type GatewayDeploymentDetail = z.infer<typeof GatewayDeploymentDetailSchema>;
 
 /**
  * `POST /deployments` response — a 5-field creation receipt, **not** a {@link GatewayDeployment}.
@@ -615,7 +619,7 @@ export type DeploymentDetail = z.infer<typeof DeploymentDetailSchema>;
  * This is the only time `credentials.password` and `client_auth` are readable; the detail
  * read masks them. Capture them at creation or they are unrecoverable.
  */
-export const DeploymentCreateResponseSchema = z
+export const GatewayDeploymentCreateResponseSchema = z
   .object({
     id: z.string(),
     client_auth: z.string(),
@@ -625,7 +629,7 @@ export const DeploymentCreateResponseSchema = z
     object: z.string(),
   })
   .passthrough();
-export type DeploymentCreateResponse = z.infer<typeof DeploymentCreateResponseSchema>;
+export type GatewayDeploymentCreateResponse = z.infer<typeof GatewayDeploymentCreateResponseSchema>;
 
 export const ListDeploymentsResponseSchema = aiGatewayList(GatewayDeploymentSchema);
 export type ListDeploymentsResponse = z.infer<typeof ListDeploymentsResponseSchema>;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -376,3 +376,4 @@ export * from './model-security.js';
 export * from './red-team-enums.js';
 export * from './red-team.js';
 export * from './red-team-network-broker.js';
+export * from './ai-gateway.js';

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -27,3 +27,19 @@ export function assertLength(value: string, min: number, max: number, fieldName:
     );
   }
 }
+
+/**
+ * @internal
+ * Throw `AISecSDKException(USER_REQUEST_PAYLOAD_ERROR)` if `value` is not a plain numeric-string
+ * id (`/^\d+$/`). Use for identifiers that are numeric but not UUIDs (e.g. AI Gateway's
+ * `tsgId`/`organisationId`) — rejects `/` or `..` so the value can't reshape a path built by
+ * string interpolation.
+ */
+export function assertNumericId(value: string, fieldName: string): void {
+  if (!/^\d+$/.test(value)) {
+    throw new AISecSDKException(
+      `Invalid ${fieldName}: ${value}`,
+      ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+    );
+  }
+}

--- a/test/ai-gateway/api-keys-client.spec.ts
+++ b/test/ai-gateway/api-keys-client.spec.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayApiKeysClient } from '../../src/ai-gateway/api-keys-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const wsId = '16f7e90d-382a-4e78-b577-1b01eb5f8297';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('AIGatewayApiKeysClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayApiKeysClient;
+
+  beforeEach(() => {
+    client = new AIGatewayApiKeysClient({
+      baseUrl: 'https://gw.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('routes service and user keys to separate sub-collections', async () => {
+    mockFetch({ object: 'list', total: 0, data: [] });
+    await client.listService({ workspaceId: wsId });
+    expect(
+      new URL((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string).pathname,
+    ).toBe('/api-keys/service');
+
+    mockFetch({ object: 'list', total: 0, data: [] });
+    await client.listUser({ workspaceId: wsId });
+    expect(
+      new URL((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string).pathname,
+    ).toBe('/api-keys/user');
+  });
+
+  it('POSTs a service key create to /api-keys/service', async () => {
+    mockFetch({});
+    await client.createService({
+      name: 'ci-runner',
+      scopes: ['completions.write', 'logs.write'],
+      organisation_id: '1852583913',
+      workspace_id: wsId,
+      type: 'workspace',
+    });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/api-keys/service');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('POSTs a user key create to /api-keys/user with user_id', async () => {
+    mockFetch({});
+    await client.createUser({
+      name: 'calvin-laptop',
+      scopes: ['completions.write'],
+      organisation_id: '1852583913',
+      workspace_id: wsId,
+      type: 'workspace',
+      user_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+    });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/api-keys/user');
+    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.user_id).toBe('fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f');
+  });
+
+  it('PUTs updateService to /api-keys/service/{keyId}', async () => {
+    mockFetch({});
+    const keyId = '11111111-1111-4111-8111-111111111111';
+    await client.updateService(keyId, {
+      name: 'ci-runner',
+      scopes: ['completions.write'],
+      organisation_id: '1852583913',
+      workspace_id: wsId,
+      type: 'workspace',
+    });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe(`/api-keys/service/${keyId}`);
+    expect((init as RequestInit).method).toBe('PUT');
+  });
+
+  it('PUTs updateUser to /api-keys/user/{keyId}', async () => {
+    mockFetch({});
+    const keyId = '11111111-1111-4111-8111-111111111111';
+    await client.updateUser(keyId, {
+      name: 'calvin-laptop',
+      scopes: ['completions.write'],
+      organisation_id: '1852583913',
+      workspace_id: wsId,
+      type: 'workspace',
+      user_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+    });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe(`/api-keys/user/${keyId}`);
+    expect((init as RequestInit).method).toBe('PUT');
+  });
+
+  it('does not add a combined api-keys list method', () => {
+    expect((client as unknown as Record<string, unknown>)['list']).toBeUndefined();
+  });
+
+  it('rejects a non-UUID workspaceId in listService() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.listService({ workspaceId: 'not-a-uuid' })).rejects.toThrow(
+      AISecSDKException,
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-UUID workspace_id in createService() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.createService({
+        name: 'ci-runner',
+        scopes: ['completions.write'],
+        organisation_id: '1852583913',
+        workspace_id: 'not-a-uuid',
+        type: 'workspace',
+      }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-UUID keyId in updateService() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.updateService('not-a-uuid', {
+        name: 'ci-runner',
+        scopes: ['completions.write'],
+        organisation_id: '1852583913',
+        workspace_id: wsId,
+        type: 'workspace',
+      }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('accepts a numeric-string organisation_id (TSG) rather than requiring a UUID', async () => {
+    mockFetch({});
+    await expect(
+      client.createService({
+        name: 'ci-runner',
+        scopes: ['completions.write'],
+        organisation_id: '1852583913',
+        workspace_id: wsId,
+        type: 'workspace',
+      }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/test/ai-gateway/audit-logs-client.spec.ts
+++ b/test/ai-gateway/audit-logs-client.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayAuditLogsClient } from '../../src/ai-gateway/audit-logs-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('AIGatewayAuditLogsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayAuditLogsClient;
+
+  beforeEach(() => {
+    client = new AIGatewayAuditLogsClient({
+      baseUrl: 'https://admin.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('serializes start/end as ISO-8601 Z strings', async () => {
+    mockFetch({ records: [] });
+    await client.list({
+      start: new Date('2026-07-20T00:00:00Z'),
+      end: new Date('2026-07-27T00:00:00Z'),
+    });
+
+    const u = new URL((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string);
+    expect(u.pathname).toBe('/audit-logs');
+    expect(u.searchParams.get('start_time')).toBe('2026-07-20T00:00:00.000Z');
+    expect(u.searchParams.get('end_time')).toBe('2026-07-27T00:00:00.000Z');
+  });
+
+  it('GETs the audit-logs path and returns the bare records envelope', async () => {
+    const record = {
+      timestamp: '2026-07-26T12:00:00.000Z',
+      method: 'POST',
+      uri: '/v2/integrations',
+      request_id: 'req-1',
+      request_body: '{"key":"sk-live-super-secret"}',
+      query_params: '',
+      request_headers: '{"authorization":"***MASKED***"}',
+      user_id: 'user-1',
+      user_type: 'human',
+      organisation_id: '1852583913',
+      workspace_id: 'ws-1',
+      response_status_code: 200,
+      resource_type: 'integration',
+      action: 'create',
+      client_ip: '10.0.0.1',
+      country: 'US',
+    };
+    mockFetch({ records: [record] });
+
+    const res = await client.list({
+      start: new Date('2026-07-20T00:00:00Z'),
+      end: new Date('2026-07-27T00:00:00Z'),
+    });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/audit-logs');
+    expect((init as RequestInit).method).toBe('GET');
+    expect(res.records).toHaveLength(1);
+    expect(res.records[0].request_body).toBe('{"key":"sk-live-super-secret"}');
+    expect(res.records[0].request_headers).toBe('{"authorization":"***MASKED***"}');
+  });
+});

--- a/test/ai-gateway/client.spec.ts
+++ b/test/ai-gateway/client.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { AIGatewayClient } from '../../src/ai-gateway/client.js';
 import { AISecSDKException } from '../../src/errors.js';
 
@@ -47,16 +47,9 @@ describe('AIGatewayClient', () => {
     expect(() => new AIGatewayClient()).toThrow(AISecSDKException);
   });
 
-  it('honours endpoint overrides', () => {
-    const gw = new AIGatewayClient({
-      clientId: 'cid',
-      clientSecret: 'sec',
-      tsgId: '1',
-      dataEndpoint: 'https://api.sase.paloaltonetworks.com/ai_gw/v2',
-      adminEndpoint: 'https://api.sase.paloaltonetworks.com/ai_gw/admin/v2',
-    });
-    expect(gw).toBeInstanceOf(AIGatewayClient);
-  });
+  // "honours endpoint overrides" as its own weak toBeInstanceOf-only test was removed —
+  // the 'plane assignment' block below already proves overrides are honoured, per
+  // sub-client, by asserting the resolved baseUrl for both dataEndpoint and adminEndpoint.
 
   describe('plane assignment', () => {
     // Deliberately-distinguishable overrides so a swapped/mis-wired sub-client is caught
@@ -108,6 +101,51 @@ describe('AIGatewayClient', () => {
 
     it.each(cases)('$name is wired to $expectedOrigin', ({ accessor, expectedOrigin }) => {
       expect(baseUrlOf(accessor())).toBe(expectedOrigin);
+    });
+  });
+
+  describe('x-tsg-id on the wire', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    // Every AI Gateway request goes through TsgHeaderAuth wrapping OAuthAuth (see
+    // src/ai-gateway/client.ts), which is only unit-tested in isolation (test/http/tsg-header.spec.ts).
+    // Nothing else proves x-tsg-id actually reaches the outgoing fetch() call once a real
+    // AIGatewayClient is constructed end-to-end. This stubs both hops — the OAuth token
+    // exchange, then the API call — and asserts the header on the second (API) request.
+    it('sends x-tsg-id on the outgoing API request, after a stubbed OAuth exchange', async () => {
+      const tokenResp = { access_token: 'tok', token_type: 'bearer', expires_in: 3600 };
+      const apiResp = { object: 'list', total: 0, data: [] };
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(tokenResp),
+          text: () => Promise.resolve(JSON.stringify(tokenResp)),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify(apiResp)),
+        });
+      globalThis.fetch = fetchMock;
+
+      const gw = new AIGatewayClient({
+        clientId: 'cid',
+        clientSecret: 'sec',
+        tsgId: '1852583913',
+        numRetries: 0,
+      });
+      await gw.workspaces.list();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const [, init] = fetchMock.mock.calls[1] as [string, { headers: Record<string, string> }];
+      expect(init.headers['x-tsg-id']).toBe('1852583913');
     });
   });
 });

--- a/test/ai-gateway/client.spec.ts
+++ b/test/ai-gateway/client.spec.ts
@@ -57,4 +57,57 @@ describe('AIGatewayClient', () => {
     });
     expect(gw).toBeInstanceOf(AIGatewayClient);
   });
+
+  describe('plane assignment', () => {
+    // Deliberately-distinguishable overrides so a swapped/mis-wired sub-client is caught
+    // by URL rather than passing by coincidence (e.g. both endpoints defaulting to the
+    // same host in some other test).
+    const DATA_ENDPOINT = 'https://data.test';
+    const ADMIN_ENDPOINT = 'https://admin.test';
+
+    const gw = new AIGatewayClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1852583913',
+      dataEndpoint: DATA_ENDPOINT,
+      adminEndpoint: ADMIN_ENDPOINT,
+    });
+
+    // Each sub-client stores its resolved base URL in a private `baseUrl` field. There is
+    // no public accessor for it (and this test must not add one to production code just to
+    // observe it), so we reach past the type system with a narrow, test-only cast. This is
+    // deliberate: it is the least invasive way to assert which plane each sub-client was
+    // actually wired to, which is exactly the property a data/admin swap would break.
+    const baseUrlOf = (client: object): string =>
+      (client as unknown as { baseUrl: string }).baseUrl;
+
+    interface PlaneCase {
+      name: string;
+      accessor: () => object;
+      expectedOrigin: string;
+    }
+
+    const cases: PlaneCase[] = [
+      { name: 'telemetry', accessor: () => gw.telemetry, expectedOrigin: DATA_ENDPOINT },
+      { name: 'workspaces', accessor: () => gw.workspaces, expectedOrigin: DATA_ENDPOINT },
+      { name: 'configs', accessor: () => gw.configs, expectedOrigin: DATA_ENDPOINT },
+      { name: 'guardrails', accessor: () => gw.guardrails, expectedOrigin: DATA_ENDPOINT },
+      { name: 'providers', accessor: () => gw.providers, expectedOrigin: DATA_ENDPOINT },
+      { name: 'apiKeys', accessor: () => gw.apiKeys, expectedOrigin: DATA_ENDPOINT },
+      { name: 'integrations', accessor: () => gw.integrations, expectedOrigin: ADMIN_ENDPOINT },
+      {
+        name: 'mcpIntegrations',
+        accessor: () => gw.mcpIntegrations,
+        expectedOrigin: ADMIN_ENDPOINT,
+      },
+      { name: 'deployments', accessor: () => gw.deployments, expectedOrigin: ADMIN_ENDPOINT },
+      { name: 'plugins', accessor: () => gw.plugins, expectedOrigin: ADMIN_ENDPOINT },
+      { name: 'organisations', accessor: () => gw.organisations, expectedOrigin: ADMIN_ENDPOINT },
+      { name: 'auditLogs', accessor: () => gw.auditLogs, expectedOrigin: ADMIN_ENDPOINT },
+    ];
+
+    it.each(cases)('$name is wired to $expectedOrigin', ({ accessor, expectedOrigin }) => {
+      expect(baseUrlOf(accessor())).toBe(expectedOrigin);
+    });
+  });
 });

--- a/test/ai-gateway/client.spec.ts
+++ b/test/ai-gateway/client.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AIGatewayClient } from '../../src/ai-gateway/client.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+describe('AIGatewayClient', () => {
+  const saved = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.PANW_AI_GW_CLIENT_ID;
+    delete process.env.PANW_AI_GW_CLIENT_SECRET;
+    delete process.env.PANW_AI_GW_TSG_ID;
+    delete process.env.PANW_MGMT_CLIENT_ID;
+    delete process.env.PANW_MGMT_CLIENT_SECRET;
+    delete process.env.PANW_MGMT_TSG_ID;
+  });
+
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it('constructs every sub-client from explicit options', () => {
+    const gw = new AIGatewayClient({ clientId: 'cid', clientSecret: 'sec', tsgId: '1852583913' });
+
+    expect(gw.telemetry).toBeDefined();
+    expect(gw.workspaces).toBeDefined();
+    expect(gw.configs).toBeDefined();
+    expect(gw.guardrails).toBeDefined();
+    expect(gw.providers).toBeDefined();
+    expect(gw.apiKeys).toBeDefined();
+    expect(gw.integrations).toBeDefined();
+    expect(gw.mcpIntegrations).toBeDefined();
+    expect(gw.deployments).toBeDefined();
+    expect(gw.plugins).toBeDefined();
+    expect(gw.organisations).toBeDefined();
+    expect(gw.auditLogs).toBeDefined();
+  });
+
+  it('falls back to PANW_MGMT_* when PANW_AI_GW_* is unset', () => {
+    process.env.PANW_MGMT_CLIENT_ID = 'mgmt-id';
+    process.env.PANW_MGMT_CLIENT_SECRET = 'mgmt-secret';
+    process.env.PANW_MGMT_TSG_ID = '1852583913';
+
+    expect(() => new AIGatewayClient()).not.toThrow();
+  });
+
+  it('throws MISSING_VARIABLE when no credentials resolve', () => {
+    expect(() => new AIGatewayClient()).toThrow(AISecSDKException);
+  });
+
+  it('honours endpoint overrides', () => {
+    const gw = new AIGatewayClient({
+      clientId: 'cid',
+      clientSecret: 'sec',
+      tsgId: '1',
+      dataEndpoint: 'https://api.sase.paloaltonetworks.com/ai_gw/v2',
+      adminEndpoint: 'https://api.sase.paloaltonetworks.com/ai_gw/admin/v2',
+    });
+    expect(gw).toBeInstanceOf(AIGatewayClient);
+  });
+});

--- a/test/ai-gateway/configs-client.spec.ts
+++ b/test/ai-gateway/configs-client.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { AIGatewayConfigsClient } from '../../src/ai-gateway/configs-client.js';
 import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
 
 const wsId = '16f7e90d-382a-4e78-b577-1b01eb5f8297';
 const cfgId = '764cf9cd-4ebf-449e-b669-08149b0fbbbc';
@@ -72,5 +73,23 @@ describe('AIGatewayConfigsClient', () => {
     const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
     expect(typeof body.config).toBe('object');
     expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('rejects list with an invalid workspaceId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.list({ workspaceId: 'not-a-uuid' })).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects update with an invalid body.workspace_id before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.update(cfgId, {
+        name: 'test',
+        workspace_id: 'not-a-uuid',
+        config: {},
+      }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });

--- a/test/ai-gateway/configs-client.spec.ts
+++ b/test/ai-gateway/configs-client.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayConfigsClient } from '../../src/ai-gateway/configs-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+
+const wsId = '16f7e90d-382a-4e78-b577-1b01eb5f8297';
+const cfgId = '764cf9cd-4ebf-449e-b669-08149b0fbbbc';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+const sampleConfig = {
+  id: cfgId,
+  name: 'claude-code',
+  slug: 'pc-claude-e46fe6',
+  organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+  is_default: 0,
+  status: 'active',
+  owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+  updated_by: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+  created_at: '2026-07-17T00:42:44.000Z',
+  last_updated_at: '2026-07-17T00:42:44.000Z',
+  workspace_id: wsId,
+  config: '{"provider":"@anthropic-prod"}',
+  format: 'json',
+  type: 'ORG_CONFIG',
+  version_id: 'v1',
+  object: 'config',
+};
+
+describe('AIGatewayConfigsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayConfigsClient;
+
+  beforeEach(() => {
+    client = new AIGatewayConfigsClient({
+      baseUrl: 'https://gw.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('sends workspace_id as a query param on list', async () => {
+    mockFetch({ object: 'list', total: 1, data: [sampleConfig] });
+    await client.list({ workspaceId: wsId });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const u = new URL(url as string);
+    expect(u.pathname).toBe('/configs');
+    expect(u.searchParams.get('workspace_id')).toBe(wsId);
+  });
+
+  it('POSTs a config with the config body as an OBJECT', async () => {
+    mockFetch({});
+    await client.create({
+      name: 'vertex-airs',
+      workspace_id: wsId,
+      config: { retry: { attempts: 3 }, cache: { mode: 'simple' } },
+    });
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
+    expect(typeof body.config).toBe('object');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+});

--- a/test/ai-gateway/configs-client.spec.ts
+++ b/test/ai-gateway/configs-client.spec.ts
@@ -17,6 +17,7 @@ function mockFetch(data: unknown) {
   });
 }
 
+// List row — 12 fields, no config/format/type/version_id.
 const sampleConfig = {
   id: cfgId,
   name: 'claude-code',
@@ -29,11 +30,16 @@ const sampleConfig = {
   created_at: '2026-07-17T00:42:44.000Z',
   last_updated_at: '2026-07-17T00:42:44.000Z',
   workspace_id: wsId,
+  object: 'config',
+};
+
+// Detail read — adds config/format/type/version_id on top of the list row.
+const sampleConfigDetail = {
+  ...sampleConfig,
   config: '{"provider":"@anthropic-prod"}',
   format: 'json',
   type: 'ORG_CONFIG',
   version_id: 'v1',
-  object: 'config',
 };
 
 describe('AIGatewayConfigsClient', () => {
@@ -51,14 +57,24 @@ describe('AIGatewayConfigsClient', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('sends workspace_id as a query param on list', async () => {
+  it('sends workspace_id as a query param on list, returning list rows with no config field', async () => {
     mockFetch({ object: 'list', total: 1, data: [sampleConfig] });
-    await client.list({ workspaceId: wsId });
+    const res = await client.list({ workspaceId: wsId });
 
+    expect((res.data[0] as unknown as { config?: string }).config).toBeUndefined();
     const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     const u = new URL(url as string);
     expect(u.pathname).toBe('/configs');
     expect(u.searchParams.get('workspace_id')).toBe(wsId);
+  });
+
+  it('fetches one config detail, including config as a JSON string', async () => {
+    mockFetch(sampleConfigDetail);
+    const res = await client.get(cfgId);
+
+    expect(res.config).toBe('{"provider":"@anthropic-prod"}');
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`https://gw.example.com/configs/${cfgId}`);
   });
 
   it('POSTs a config with the config body as an OBJECT', async () => {

--- a/test/ai-gateway/deployments-client.spec.ts
+++ b/test/ai-gateway/deployments-client.spec.ts
@@ -110,4 +110,10 @@ describe('AIGatewayDeploymentsClient', () => {
     await expect(client.delete('not-a-uuid', '1852583913')).rejects.toThrow(AISecSDKException);
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
+
+  it('rejects delete with a non-numeric organisationId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.delete(depId, 'not-numeric')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
 });

--- a/test/ai-gateway/deployments-client.spec.ts
+++ b/test/ai-gateway/deployments-client.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayDeploymentsClient } from '../../src/ai-gateway/deployments-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const depId = '21414819-485e-4ba3-b3d3-3e1815580e43';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown, text?: string) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(text ?? JSON.stringify(data)),
+  });
+}
+
+const sampleDeployment = {
+  id: depId,
+  name: 'talos',
+  slug: 'dp-talos-f3b74e',
+  type: 'production',
+  status: 'active',
+  created_at: '2026-07-17T00:42:44.000Z',
+  last_updated_at: '2026-07-17T00:42:44.000Z',
+  last_synced_at: null,
+  last_resynced_at: null,
+  is_default: 0,
+  created_by: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+  object: 'deployment',
+};
+
+describe('AIGatewayDeploymentsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayDeploymentsClient;
+
+  beforeEach(() => {
+    client = new AIGatewayDeploymentsClient({
+      baseUrl: 'https://admin.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('lists deployments', async () => {
+    mockFetch({ object: 'list', total: 1, data: [sampleDeployment] });
+    const res = await client.list();
+
+    expect(res.data[0].slug).toBe('dp-talos-f3b74e');
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/deployments');
+  });
+
+  it('fetches one deployment', async () => {
+    mockFetch({
+      ...sampleDeployment,
+      credentials: { username: 'u', password: '***' },
+      deployment_config: null,
+    });
+    const res = await client.get(depId);
+
+    expect(res.name).toBe('talos');
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`https://admin.example.com/deployments/${depId}`);
+  });
+
+  it('parses the create RECEIPT, which is not a deployment record', async () => {
+    mockFetch({
+      id: depId,
+      client_auth: 'client-auth-abc',
+      credentials: { username: '1852583913', password: 's3cret' },
+      organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+      object: 'deployment',
+    });
+
+    const res = await client.create({
+      name: 'prod',
+      type: 'production',
+      organisation_id: '1852583913',
+      auth_settings: { allow_all_workspaces: true },
+    });
+
+    expect(res.credentials.password).toBe('s3cret');
+    expect((res as unknown as { name?: string }).name).toBeUndefined();
+    expect((res as unknown as { slug?: string }).slug).toBeUndefined();
+    expect((res as unknown as { status?: string }).status).toBeUndefined();
+  });
+
+  it('tolerates DELETE returning 200 with an empty body', async () => {
+    mockFetch(undefined, '');
+    await expect(client.delete(depId, '1852583913')).resolves.toBeUndefined();
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((init as RequestInit).method).toBe('DELETE');
+    expect(new URL(url as string).searchParams.get('organisation_id')).toBe('1852583913');
+  });
+
+  it('rejects get with an invalid deploymentId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.get('not-a-uuid')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects delete with an invalid deploymentId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.delete('not-a-uuid', '1852583913')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/ai-gateway/guardrails-client.spec.ts
+++ b/test/ai-gateway/guardrails-client.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayGuardrailsClient } from '../../src/ai-gateway/guardrails-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const wsId = '16f7e90d-382a-4e78-b577-1b01eb5f8297';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('AIGatewayGuardrailsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayGuardrailsClient;
+
+  beforeEach(() => {
+    client = new AIGatewayGuardrailsClient({
+      baseUrl: 'https://gw.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('lists guardrails scoped to a workspace', async () => {
+    mockFetch({ object: 'list', total: 1, data: [{ id: 'pg-prisma-099a16', name: 'PrismaAIRS' }] });
+    const res = await client.list({ workspaceId: wsId });
+
+    expect(res.data[0].id).toBe('pg-prisma-099a16');
+    const u = new URL((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string);
+    expect(u.pathname).toBe('/guardrails');
+    expect(u.searchParams.get('workspace_id')).toBe(wsId);
+  });
+
+  it('POSTs a guardrail with checks and actions', async () => {
+    mockFetch({});
+    await client.create({
+      workspace_id: wsId,
+      name: 'PrismaAIRS',
+      checks: [
+        {
+          id: 'panw.prisma-airs.intercept',
+          parameters: { profile_name: 'AI Gateway - Strict' },
+          is_enabled: true,
+        },
+      ],
+      actions: { deny: false, async: false, sequential: false },
+    });
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((init as RequestInit).method).toBe('POST');
+    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
+    expect(Array.isArray(body.checks)).toBe(true);
+  });
+
+  it('rejects a non-UUID workspaceId in list() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.list({ workspaceId: 'not-a-uuid' })).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-UUID workspace_id in create() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.create({
+        workspace_id: 'not-a-uuid',
+        name: 'PrismaAIRS',
+        checks: [],
+        actions: {},
+      }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/ai-gateway/integrations-client.spec.ts
+++ b/test/ai-gateway/integrations-client.spec.ts
@@ -157,6 +157,27 @@ describe('AIGatewayIntegrationsClient', () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  it('rejects create with an invalid body.ai_provider_id before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.create({
+        organisation_id: '1852583913',
+        ai_provider_id: 'not-a-uuid',
+        name: 'openai-prod',
+        slug: 'openai-prod',
+      }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects update with an invalid body.ai_provider_id before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.update(intId, { ai_provider_id: 'not-a-uuid' })).rejects.toThrow(
+      AISecSDKException,
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it('rejects delete with an invalid integrationId before issuing a request', async () => {
     globalThis.fetch = vi.fn();
     await expect(client.delete('not-a-uuid', '1852583913')).rejects.toThrow(AISecSDKException);

--- a/test/ai-gateway/integrations-client.spec.ts
+++ b/test/ai-gateway/integrations-client.spec.ts
@@ -109,11 +109,27 @@ describe('AIGatewayIntegrationsClient', () => {
     expect((init as RequestInit).method).toBe('PUT');
   });
 
-  it('reads the workspaces sub-resource', async () => {
-    mockFetch({ workspaces: [], global_workspace_access: true, object: 'list' });
+  it('reads the workspaces sub-resource, where global_workspace_access is an object', async () => {
+    mockFetch({
+      workspaces: [
+        {
+          id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+          usage_limits: null,
+          rate_limits: null,
+          enabled: true,
+          status: 'active',
+          created_at: '2026-07-16T15:48:18.000Z',
+          last_updated_at: '2026-07-17T12:25:22.000Z',
+          last_reset_at: null,
+        },
+      ],
+      global_workspace_access: { enabled: false, rate_limits: null, usage_limits: null },
+      object: 'integration',
+    });
     const res = await client.getWorkspaces(intId);
 
-    expect(res.global_workspace_access).toBe(true);
+    expect(res.global_workspace_access.enabled).toBe(false);
+    expect(res.workspaces[0].enabled).toBe(true);
     const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(url).toBe(`https://admin.example.com/integrations/${intId}/workspaces`);
   });

--- a/test/ai-gateway/integrations-client.spec.ts
+++ b/test/ai-gateway/integrations-client.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayIntegrationsClient } from '../../src/ai-gateway/integrations-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const intId = 'f6692544-3265-49be-9711-bbdcebc079e4';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+const sampleIntegration = {
+  id: intId,
+  organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+  name: 'openai-calvin',
+  owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+  status: 'active',
+  created_at: '2026-07-17T00:42:44.000Z',
+  last_updated_at: '2026-07-17T00:42:44.000Z',
+  slug: 'openai-calvin',
+  tags: null,
+  description: null,
+  workspace_id: null,
+  ai_provider_id: 'de7d7d50-31cd-11ee-b93b-0e06f1aa7f7c',
+  object: 'integration',
+};
+
+describe('AIGatewayIntegrationsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayIntegrationsClient;
+
+  beforeEach(() => {
+    client = new AIGatewayIntegrationsClient({
+      baseUrl: 'https://admin.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('lists organisation integrations', async () => {
+    mockFetch({ object: 'list', total: 1, data: [sampleIntegration] });
+    const res = await client.list();
+
+    expect(res.data[0].slug).toBe('openai-calvin');
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/integrations');
+  });
+
+  it('fetches one integration', async () => {
+    mockFetch(sampleIntegration);
+    const res = await client.get(intId);
+
+    expect(res.name).toBe('openai-calvin');
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`https://admin.example.com/integrations/${intId}`);
+  });
+
+  it('POSTs a new integration', async () => {
+    mockFetch({});
+    await client.create({
+      organisation_id: '1852583913',
+      ai_provider_id: 'de7d7d50-31cd-11ee-b93b-0e06f1aa7f7c',
+      name: 'openai-prod',
+      slug: 'openai-prod',
+    });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/integrations');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('PUTs an integration update', async () => {
+    mockFetch({});
+    await client.update(intId, { name: 'openai-prod' });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`https://admin.example.com/integrations/${intId}`);
+    expect((init as RequestInit).method).toBe('PUT');
+  });
+
+  it('reads the models sub-resource', async () => {
+    mockFetch({
+      models: [{ slug: 'gpt-4', enabled: true }],
+      allow_all_models: false,
+      object: 'list',
+    });
+    const res = await client.getModels(intId);
+
+    expect(res.models[0].slug).toBe('gpt-4');
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`https://admin.example.com/integrations/${intId}/models`);
+  });
+
+  it('PUTs the models sub-resource', async () => {
+    mockFetch({});
+    await client.setModels(intId, { models: [{ slug: 'gpt-4', enabled: false }] });
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((init as RequestInit).method).toBe('PUT');
+  });
+
+  it('reads the workspaces sub-resource', async () => {
+    mockFetch({ workspaces: [], global_workspace_access: true, object: 'list' });
+    const res = await client.getWorkspaces(intId);
+
+    expect(res.global_workspace_access).toBe(true);
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`https://admin.example.com/integrations/${intId}/workspaces`);
+  });
+
+  it('PUTs the workspaces sub-resource', async () => {
+    mockFetch({});
+    await client.setWorkspaces(intId, { global_workspace_access: true });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`https://admin.example.com/integrations/${intId}/workspaces`);
+    expect((init as RequestInit).method).toBe('PUT');
+  });
+
+  it('sends organisation_id as a query param on delete', async () => {
+    mockFetch({});
+    await client.delete(intId, '1852583913');
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((init as RequestInit).method).toBe('DELETE');
+    expect(new URL(url as string).searchParams.get('organisation_id')).toBe('1852583913');
+  });
+
+  it('resolves delete to undefined on an empty 200 body', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(''),
+    });
+    await expect(client.delete(intId, '1852583913')).resolves.toBeUndefined();
+  });
+
+  it('rejects get with an invalid integrationId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.get('not-a-uuid')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects update with an invalid integrationId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.update('not-a-uuid', { name: 'x' })).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects delete with an invalid integrationId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.delete('not-a-uuid', '1852583913')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects setModels with an invalid integrationId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.setModels('not-a-uuid', { models: [{ slug: 'gpt-4', enabled: true }] }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects setWorkspaces with an invalid integrationId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.setWorkspaces('not-a-uuid', { global_workspace_access: true }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/ai-gateway/integrations-client.spec.ts
+++ b/test/ai-gateway/integrations-client.spec.ts
@@ -184,6 +184,12 @@ describe('AIGatewayIntegrationsClient', () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  it('rejects delete with a non-numeric organisationId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.delete(intId, 'not-numeric')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it('rejects setModels with an invalid integrationId before issuing a request', async () => {
     globalThis.fetch = vi.fn();
     await expect(

--- a/test/ai-gateway/mcp-integrations-client.spec.ts
+++ b/test/ai-gateway/mcp-integrations-client.spec.ts
@@ -26,7 +26,8 @@ const sampleMcpIntegration = {
   url: 'https://mcp.context7.com/mcp',
   auth_type: 'none',
   transport: 'http',
-  configurations: {},
+  // JSON-encoded STRING on reads — the CREATE request sends an object; see the schema comment.
+  configurations: '{}',
   created_at: '2026-07-17T00:42:44.000Z',
   last_updated_at: '2026-07-17T00:42:44.000Z',
 };
@@ -46,11 +47,12 @@ describe('AIGatewayMcpIntegrationsClient', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('lists organisation MCP integrations', async () => {
+  it('lists organisation MCP integrations, keeping configurations as a JSON string', async () => {
     mockFetch({ object: 'list', total: 1, data: [sampleMcpIntegration] });
     const res = await client.list();
 
     expect(res.data[0].name).toBe('Context 7');
+    expect(typeof res.data[0].configurations).toBe('string');
     const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(new URL(url as string).pathname).toBe('/mcp-integrations');
     expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]).toMatchObject({

--- a/test/ai-gateway/mcp-integrations-client.spec.ts
+++ b/test/ai-gateway/mcp-integrations-client.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayMcpIntegrationsClient } from '../../src/ai-gateway/mcp-integrations-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const mcpId = '2a6f4e2e-6f5a-4a1f-9d0e-9b2b6f6c3a11';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+const sampleMcpIntegration = {
+  id: mcpId,
+  organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+  name: 'Context 7',
+  owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+  status: 'active',
+  type: 'MCP_INTEGRATION',
+  url: 'https://mcp.context7.com/mcp',
+  auth_type: 'none',
+  transport: 'http',
+  configurations: {},
+  created_at: '2026-07-17T00:42:44.000Z',
+  last_updated_at: '2026-07-17T00:42:44.000Z',
+};
+
+describe('AIGatewayMcpIntegrationsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayMcpIntegrationsClient;
+
+  beforeEach(() => {
+    client = new AIGatewayMcpIntegrationsClient({
+      baseUrl: 'https://admin.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('lists organisation MCP integrations', async () => {
+    mockFetch({ object: 'list', total: 1, data: [sampleMcpIntegration] });
+    const res = await client.list();
+
+    expect(res.data[0].name).toBe('Context 7');
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/mcp-integrations');
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]).toMatchObject({
+      method: 'GET',
+    });
+  });
+
+  it('POSTs a new MCP integration', async () => {
+    mockFetch({});
+    await client.create({
+      name: 'Context 7',
+      organisation_id: '1852583913',
+      slug: 'context-7',
+      url: 'https://mcp.context7.com/mcp',
+      auth_type: 'none',
+      transport: 'http',
+    });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/mcp-integrations');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('PUTs the workspaces sub-resource', async () => {
+    mockFetch({});
+    await client.setWorkspaces(mcpId, { global_workspace_access: true });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`https://admin.example.com/mcp-integrations/${mcpId}/workspaces`);
+    expect((init as RequestInit).method).toBe('PUT');
+  });
+
+  it('rejects setWorkspaces with an invalid mcpIntegrationId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.setWorkspaces('not-a-uuid', { global_workspace_access: true }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/ai-gateway/organisations-client.spec.ts
+++ b/test/ai-gateway/organisations-client.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayOrganisationsClient } from '../../src/ai-gateway/organisations-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('AIGatewayOrganisationsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayOrganisationsClient;
+
+  beforeEach(() => {
+    client = new AIGatewayOrganisationsClient({
+      baseUrl: 'https://admin.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('GETs /organisations/self', async () => {
+    mockFetch({ success: true, data: { name: 'Acme Corp' } });
+    const res = await client.getSelf();
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/organisations/self');
+    expect((init as RequestInit).method).toBe('GET');
+    expect(res.data.name).toBe('Acme Corp');
+  });
+
+  it('PUTs /organisations/self with the given body', async () => {
+    mockFetch({});
+    await client.updateSelf({ name: 'Acme Corp' });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/organisations/self');
+    expect((init as RequestInit).method).toBe('PUT');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ name: 'Acme Corp' });
+  });
+
+  it('GETs /organisations/{tsgId}/auth-settings', async () => {
+    mockFetch({
+      success: true,
+      data: { auth_settings: {}, domains: ['acme.com'], scim_token: 'scim-secret-token' },
+    });
+    const res = await client.getAuthSettings('1852583913');
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/organisations/1852583913/auth-settings');
+    expect((init as RequestInit).method).toBe('GET');
+    expect(res.data.scim_token).toBe('scim-secret-token');
+  });
+
+  it('PUTs /organisations/{tsgId}/auth-settings with the given body', async () => {
+    mockFetch({});
+    await client.updateAuthSettings('1852583913', { domains: ['acme.com'] });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/organisations/1852583913/auth-settings');
+    expect((init as RequestInit).method).toBe('PUT');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ domains: ['acme.com'] });
+  });
+
+  it('accepts a numeric-string tsgId without UUID validation', async () => {
+    mockFetch({ success: true, data: {} });
+    await expect(client.getAuthSettings('1852583913')).resolves.toBeDefined();
+  });
+});

--- a/test/ai-gateway/organisations-client.spec.ts
+++ b/test/ai-gateway/organisations-client.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { AIGatewayOrganisationsClient } from '../../src/ai-gateway/organisations-client.js';
 import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
 
 function passthroughAuth(): AuthAdapter {
   return { prepare: async (req) => req };
@@ -71,8 +72,23 @@ describe('AIGatewayOrganisationsClient', () => {
     expect(JSON.parse((init as RequestInit).body as string)).toEqual({ domains: ['acme.com'] });
   });
 
-  it('accepts a numeric-string tsgId without UUID validation', async () => {
-    mockFetch({ success: true, data: {} });
-    await expect(client.getAuthSettings('1852583913')).resolves.toBeDefined();
+  it('rejects a non-numeric tsgId in getAuthSettings() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.getAuthSettings('not-numeric')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-numeric tsgId in updateAuthSettings() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.updateAuthSettings('not-numeric', { domains: ['acme.com'] }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a tsgId containing a path-traversal segment', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.getAuthSettings('../self')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });

--- a/test/ai-gateway/plugins-client.spec.ts
+++ b/test/ai-gateway/plugins-client.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayPluginsClient } from '../../src/ai-gateway/plugins-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const integrationId = '232e45c4-809a-11f1-af60-2ca2a760eb7b';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+const samplePlugin = {
+  id: 'a9f2e8db-1efe-49a7-a45b-b45cade4d861',
+  integration_id: integrationId,
+  credentials: { AIRS_API_KEY: 'sn*****Gul' },
+  owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+  created_at: '2026-07-17T00:42:44.000Z',
+  last_updated_at: '2026-07-17T00:42:44.000Z',
+  status: 'active',
+  integration_slug: 'panw-prisma-airs',
+  plugin_provider_id: 'b1e2e8db-1efe-49a7-a45b-b45cade4d861',
+  plugin_provider_slug: 'panw-prisma-airs',
+  object: 'plugin',
+};
+
+describe('AIGatewayPluginsClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayPluginsClient;
+
+  beforeEach(() => {
+    client = new AIGatewayPluginsClient({
+      baseUrl: 'https://admin.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('lists organisation plugins', async () => {
+    mockFetch({ object: 'list', total: 1, data: [samplePlugin] });
+    const res = await client.list();
+
+    expect(res.data[0].integration_slug).toBe('panw-prisma-airs');
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/plugins');
+    expect((init as RequestInit).method).toBe('GET');
+  });
+
+  it('POSTs a new plugin binding', async () => {
+    mockFetch({});
+    await client.create({
+      organisation_id: '1852583913',
+      integration_id: integrationId,
+      credentials: { AIRS_API_KEY: 'secret' },
+    });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/plugins');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('rejects create with an invalid integration_id before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.create({
+        organisation_id: '1852583913',
+        integration_id: 'not-a-uuid',
+        credentials: { AIRS_API_KEY: 'secret' },
+      }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/ai-gateway/providers-client.spec.ts
+++ b/test/ai-gateway/providers-client.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayProvidersClient } from '../../src/ai-gateway/providers-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const wsId = '16f7e90d-382a-4e78-b577-1b01eb5f8297';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+describe('AIGatewayProvidersClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayProvidersClient;
+
+  beforeEach(() => {
+    client = new AIGatewayProvidersClient({
+      baseUrl: 'https://gw.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('lists providers scoped to a workspace', async () => {
+    mockFetch({
+      object: 'list',
+      total: 1,
+      data: [{ id: 'f6692544-3265-49be-9711-bbdcebc079e4', slug: 'openai-calvin' }],
+    });
+    const res = await client.list({ workspaceId: wsId });
+
+    expect(res.data[0].slug).toBe('openai-calvin');
+    const u = new URL((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string);
+    expect(u.pathname).toBe('/providers');
+    expect(u.searchParams.get('workspace_id')).toBe(wsId);
+  });
+
+  it('POSTs a provider binding to /providers', async () => {
+    mockFetch({});
+    await client.create({
+      workspace_id: wsId,
+      ai_provider_id: 'de7d7d50-31cd-11ee-b93b-0e06f1aa7f7c',
+      integration_id: 'f6692544-3265-49be-9711-bbdcebc079e4',
+      name: 'openai-calvin',
+      slug: 'openai-calvin',
+    });
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/providers');
+    expect((init as RequestInit).method).toBe('POST');
+    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.slug).toBe('openai-calvin');
+  });
+
+  it('rejects a non-UUID workspaceId in list() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.list({ workspaceId: 'not-a-uuid' })).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-UUID workspace_id in create() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.create({
+        workspace_id: 'not-a-uuid',
+        ai_provider_id: 'de7d7d50-31cd-11ee-b93b-0e06f1aa7f7c',
+        integration_id: 'f6692544-3265-49be-9711-bbdcebc079e4',
+        name: 'openai-calvin',
+        slug: 'openai-calvin',
+      }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/ai-gateway/providers-client.spec.ts
+++ b/test/ai-gateway/providers-client.spec.ts
@@ -81,4 +81,32 @@ describe('AIGatewayProvidersClient', () => {
     ).rejects.toThrow(AISecSDKException);
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
+
+  it('rejects a non-UUID ai_provider_id in create() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.create({
+        workspace_id: wsId,
+        ai_provider_id: 'not-a-uuid',
+        integration_id: 'f6692544-3265-49be-9711-bbdcebc079e4',
+        name: 'openai-calvin',
+        slug: 'openai-calvin',
+      }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-UUID integration_id in create() before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(
+      client.create({
+        workspace_id: wsId,
+        ai_provider_id: 'de7d7d50-31cd-11ee-b93b-0e06f1aa7f7c',
+        integration_id: 'not-a-uuid',
+        name: 'openai-calvin',
+        slug: 'openai-calvin',
+      }),
+    ).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
 });

--- a/test/ai-gateway/telemetry-client.spec.ts
+++ b/test/ai-gateway/telemetry-client.spec.ts
@@ -113,3 +113,75 @@ describe('AIGatewayTelemetryClient', () => {
     }
   });
 });
+
+describe('AIGatewayTelemetryClient groups and logs', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayTelemetryClient;
+
+  beforeEach(() => {
+    client = new AIGatewayTelemetryClient({
+      baseUrl: 'https://gw.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+      tsgId: '1852583913',
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('joins columns with commas on groupBy', async () => {
+    mockFetch({
+      object: 'list',
+      is_quota_exceeded: false,
+      total: 1,
+      data: [{ model: 'm', requests: 1, object: 'log' }],
+    });
+    await client.groupBy('model', { workspaceSlug: 'ws-x', columns: ['cost', 'total_tokens'] });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const u = new URL(url as string);
+    expect(u.pathname).toBe('/logs/groups/model');
+    expect(u.searchParams.get('columns')).toBe('cost,total_tokens');
+  });
+
+  it('byUser uses the plural path and the OTHER envelope', async () => {
+    mockFetch({
+      success: true,
+      data: { records: [{ _user: '', count: 2, cost: 1 }], total: 1, isQuotaExceeded: false },
+    });
+    const res = await client.byUser({ workspaceSlug: 'ws-x' });
+
+    expect(res.data.records[0].count).toBe(2);
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/logs/groups/users');
+  });
+
+  it('logs() hits the BARE path and passes pageSize/statusCode', async () => {
+    mockFetch({
+      success: true,
+      data: { records: [], total: 0, capturedTotal: 0, isQuotaExceeded: false },
+    });
+    await client.logs({ workspaceSlug: 'ws-x', pageSize: 25, statusCode: 446 });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const u = new URL(url as string);
+    expect(u.pathname).toBe('/logs');
+    expect(u.searchParams.get('pageSize')).toBe('25');
+    expect(u.searchParams.get('statusCode')).toBe('446');
+  });
+
+  it('omits log filters that were not supplied', async () => {
+    mockFetch({
+      success: true,
+      data: { records: [], total: 0, capturedTotal: 0, isQuotaExceeded: false },
+    });
+    await client.logs({ workspaceSlug: 'ws-x' });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const u = new URL(url as string);
+    expect(u.searchParams.has('statusCode')).toBe(false);
+    expect(u.searchParams.has('traceId')).toBe(false);
+  });
+});

--- a/test/ai-gateway/telemetry-client.spec.ts
+++ b/test/ai-gateway/telemetry-client.spec.ts
@@ -112,6 +112,135 @@ describe('AIGatewayTelemetryClient', () => {
       expect(u.pathname).toBe(path);
     }
   });
+
+  // Chart slugs are bespoke and unguessable (see constants.ts AI_GW_CHART_METRICS) — a typo
+  // in any one of them ships as a silent runtime 404. This table drives every chart method
+  // plus byStatusCode through a minimal-but-valid response body for its schema and asserts
+  // the exact request path, so a slug regression fails here by name instead of in prod.
+  const allChartCases: [string, string, unknown][] = [
+    [
+      'cost',
+      '/logs/charts/cost',
+      { data: { records: [], total: 0, avg: 0, isQuotaExceeded: false } },
+    ],
+    [
+      'requests',
+      '/logs/charts/requests',
+      { data: { records: [], total: 0, isQuotaExceeded: false } },
+    ],
+    [
+      'latency',
+      '/logs/charts/latency',
+      { data: { records: [], total: 0, p50: 0, p90: 0, p99: 0, isQuotaExceeded: false } },
+    ],
+    [
+      'tokens',
+      '/logs/charts/tokens',
+      {
+        data: {
+          records: [],
+          total: 0,
+          avg: 0,
+          total_request_units: 0,
+          total_response_units: 0,
+          isQuotaExceeded: false,
+        },
+      },
+    ],
+    ['errors', '/logs/charts/errors', { data: { records: [], total: 0, isQuotaExceeded: false } }],
+    ['users', '/logs/charts/users', { data: { records: [], total: 0, isQuotaExceeded: false } }],
+    [
+      'cacheSummary',
+      '/logs/charts/cache-summary',
+      {
+        data: {
+          summary: { cacheHits: 0, avgCacheLatency: null, totalRequests: 0, cacheSpeedup: 0 },
+          isQuotaExceeded: false,
+        },
+      },
+    ],
+    [
+      'cacheHitTrend',
+      '/logs/charts/cache-hit-trend',
+      {
+        data: {
+          trend: [],
+          total: 0,
+          summary: { totalCacheHits: 0, hitRate: 0 },
+          isQuotaExceeded: false,
+        },
+      },
+    ],
+    [
+      'userTrends',
+      '/logs/charts/user-trends',
+      { data: { summary: { total: 0, unique: 0, avg: 0 }, trend: [], isQuotaExceeded: false } },
+    ],
+    [
+      'errorTrends',
+      '/logs/charts/error-trends',
+      { data: { summary: { errorPercent: 0 }, trend: [], isQuotaExceeded: false } },
+    ],
+    [
+      'rescuedRetries',
+      '/logs/charts/rescued-retries',
+      {
+        data: {
+          trend: [],
+          total: 0,
+          trends: [],
+          retryTotal: 0,
+          fallbackTotal: 0,
+          isQuotaExceeded: false,
+        },
+      },
+    ],
+    [
+      'feedbackTrend',
+      '/logs/charts/feedback-trend',
+      { data: { records: [], total: 0, isQuotaExceeded: false } },
+    ],
+    [
+      'feedbackWeighted',
+      '/logs/charts/feedback-weighted',
+      { data: { records: [], total: 0, isQuotaExceeded: false } },
+    ],
+    [
+      'feedbackScoreDistribution',
+      '/logs/charts/feedback-score-distribution',
+      { data: { records: [], total: 0, isQuotaExceeded: false } },
+    ],
+    [
+      'feedbackModels',
+      '/logs/charts/feedback-models',
+      { data: { records: [], isQuotaExceeded: false } },
+    ],
+  ];
+
+  it.each(allChartCases)('%s routes to the exact chart path %s', async (method, path, data) => {
+    mockFetch({ success: true, ...(data as object) });
+    await (
+      client[method as keyof AIGatewayTelemetryClient] as (o: {
+        workspaceSlug: string;
+      }) => Promise<unknown>
+    )({ workspaceSlug: 'ws-x' });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname, `${method} routed to the wrong path`).toBe(path);
+  });
+
+  it('byStatusCode routes to /logs/groups/status_code', async () => {
+    mockFetch({
+      object: 'list',
+      is_quota_exceeded: false,
+      total: 0,
+      data: [],
+    });
+    await client.byStatusCode({ workspaceSlug: 'ws-x' });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(new URL(url as string).pathname).toBe('/logs/groups/status_code');
+  });
 });
 
 describe('AIGatewayTelemetryClient groups and logs', () => {

--- a/test/ai-gateway/telemetry-client.spec.ts
+++ b/test/ai-gateway/telemetry-client.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayTelemetryClient } from '../../src/ai-gateway/telemetry-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+const costBody = {
+  success: true,
+  data: {
+    records: [{ x: '2026-07-20T05:00:00.000Z', y: 1.5, avg: 1 }],
+    total: 3,
+    avg: 1.5,
+    isQuotaExceeded: false,
+  },
+};
+
+describe('AIGatewayTelemetryClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayTelemetryClient;
+
+  beforeEach(() => {
+    client = new AIGatewayTelemetryClient({
+      baseUrl: 'https://gw.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+      tsgId: '1852583913',
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('GETs logs/charts/cost with all four window params', async () => {
+    mockFetch(costBody);
+    const res = await client.cost({ workspaceSlug: 'ws-x' });
+
+    expect(res.data.total).toBe(3);
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const u = new URL(url as string);
+    expect(u.pathname).toBe('/logs/charts/cost');
+    expect(u.searchParams.get('organisationId')).toBe('1852583913');
+    expect(u.searchParams.get('workspaceSlug')).toBe('ws-x');
+    expect(u.searchParams.get('timeOfGenerationMin')).toBeTruthy();
+    expect(u.searchParams.get('timeOfGenerationMax')).toBeTruthy();
+  });
+
+  it('percent-encodes the + in the timezone offset', async () => {
+    mockFetch(costBody);
+    await client.cost({ workspaceSlug: 'ws-x' });
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url as string).not.toMatch(/timeOfGenerationMin=[^&]*\+/);
+  });
+
+  it('routes each chart method to its own bespoke slug', async () => {
+    const cases: [keyof AIGatewayTelemetryClient, string, unknown][] = [
+      [
+        'userTrends',
+        '/logs/charts/user-trends',
+        {
+          success: true,
+          data: { summary: { total: 1, unique: 1, avg: 1 }, trend: [], isQuotaExceeded: false },
+        },
+      ],
+      [
+        'errorTrends',
+        '/logs/charts/error-trends',
+        {
+          success: true,
+          data: { summary: { errorPercent: 0 }, trend: [], isQuotaExceeded: false },
+        },
+      ],
+      [
+        'cacheSummary',
+        '/logs/charts/cache-summary',
+        {
+          success: true,
+          data: {
+            summary: { cacheHits: 0, avgCacheLatency: null, totalRequests: 1, cacheSpeedup: 0 },
+            isQuotaExceeded: false,
+          },
+        },
+      ],
+    ];
+
+    for (const [method, path, body] of cases) {
+      mockFetch(body);
+      await (client[method] as (o: { workspaceSlug: string }) => Promise<unknown>)({
+        workspaceSlug: 'ws-x',
+      });
+      const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const u = new URL(calls[calls.length - 1][0] as string);
+      expect(u.pathname).toBe(path);
+    }
+  });
+});

--- a/test/ai-gateway/telemetry-client.spec.ts
+++ b/test/ai-gateway/telemetry-client.spec.ts
@@ -56,10 +56,19 @@ describe('AIGatewayTelemetryClient', () => {
   });
 
   it('percent-encodes the + in the timezone offset', async () => {
-    mockFetch(costBody);
-    await client.cost({ workspaceSlug: 'ws-x' });
-    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(url as string).not.toMatch(/timeOfGenerationMin=[^&]*\+/);
+    // Force a positive UTC offset so the '+' path is exercised on any host.
+    const spy = vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-120); // UTC+02:00
+    try {
+      mockFetch(costBody);
+      await client.cost({ workspaceSlug: 'ws-x' });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      // The offset must arrive percent-encoded: a literal '+' decodes to a space and 400s.
+      expect(url as string).toContain('%2B02%3A00');
+      expect(url as string).not.toMatch(/timeOfGenerationMin=[^&]*\+/);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('routes each chart method to its own bespoke slug', async () => {

--- a/test/ai-gateway/window.spec.ts
+++ b/test/ai-gateway/window.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { toOffsetIso, serializeWindow } from '../../src/ai-gateway/window.js';
+
+describe('toOffsetIso', () => {
+  it('emits ISO-8601 with a numeric offset, not Z', () => {
+    const s = toOffsetIso(new Date('2026-07-20T12:00:00Z'));
+    expect(s).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/);
+  });
+});
+
+describe('serializeWindow', () => {
+  it('defaults to a 7-day window and includes the tsg as organisationId', () => {
+    const p = serializeWindow('1852583913', { workspaceSlug: 'ws-x' });
+    expect(p.organisationId).toBe('1852583913');
+    expect(p.workspaceSlug).toBe('ws-x');
+    expect(p.timeOfGenerationMin).toBeDefined();
+    expect(p.timeOfGenerationMax).toBeDefined();
+  });
+
+  it('honours explicit start/end over days', () => {
+    const p = serializeWindow('1', {
+      workspaceSlug: 'ws-x',
+      days: 30,
+      start: new Date('2026-07-01T00:00:00Z'),
+      end: new Date('2026-07-08T00:00:00Z'),
+    });
+    expect(
+      p.timeOfGenerationMin.startsWith('2026-06-30') ||
+        p.timeOfGenerationMin.startsWith('2026-07-01'),
+    ).toBe(true);
+  });
+});

--- a/test/ai-gateway/workspaces-client.spec.ts
+++ b/test/ai-gateway/workspaces-client.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AIGatewayWorkspacesClient } from '../../src/ai-gateway/workspaces-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+
+const wsId = '16f7e90d-382a-4e78-b577-1b01eb5f8297';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+const sampleWorkspace = {
+  id: wsId,
+  slug: 'ws-main-a-349e0e',
+  name: 'talos_k8s_cluster',
+  icon: null,
+  description: 'Default workspace',
+  created_at: '2026-07-16T15:48:18.000Z',
+  last_updated_at: '2026-07-17T12:25:22.000Z',
+  is_default: 0,
+  status: 'active',
+  scope_name: 'main_airs_workspace_1852583913',
+  object: 'workspace',
+};
+
+describe('AIGatewayWorkspacesClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: AIGatewayWorkspacesClient;
+
+  beforeEach(() => {
+    client = new AIGatewayWorkspacesClient({
+      baseUrl: 'https://gw.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('GETs /workspaces with no params', async () => {
+    mockFetch({ object: 'list', total: 1, data: [sampleWorkspace] });
+    const res = await client.list();
+
+    expect(res.data[0].slug).toBe('ws-main-a-349e0e');
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('https://gw.example.com/workspaces');
+  });
+
+  it('rejects a non-UUID id before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.get('not-a-uuid')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/http-retry.spec.ts
+++ b/test/http-retry.spec.ts
@@ -94,6 +94,48 @@ describe('extractErrorMessage', () => {
   it('handles empty body', () => {
     expect(extractErrorMessage('', 500)).toBe('API error 500');
   });
+
+  it('surfaces AI Gateway data.message with errorCode AB01', () => {
+    expect(
+      extractErrorMessage(
+        JSON.stringify({
+          success: false,
+          data: { message: 'Invalid request', errorCode: 'AB01', request_id: 'req-1' },
+        }),
+        400,
+      ),
+    ).toBe('Invalid request (errorCode: AB01)');
+  });
+
+  it('surfaces AI Gateway data.message with errorCode AB02 (missing workspace_id)', () => {
+    expect(
+      extractErrorMessage(
+        JSON.stringify({
+          success: false,
+          data: { message: 'workspace_id is required', errorCode: 'AB02', request_id: 'req-2' },
+        }),
+        404,
+      ),
+    ).toBe('workspace_id is required (errorCode: AB02)');
+  });
+
+  it('surfaces AI Gateway data.message with errorCode AB03 (missing workspace scope)', () => {
+    expect(
+      extractErrorMessage(
+        JSON.stringify({
+          success: false,
+          data: { message: 'Access denied', errorCode: 'AB03', request_id: 'req-3' },
+        }),
+        403,
+      ),
+    ).toBe('Access denied (errorCode: AB03)');
+  });
+
+  it('falls back to msg field for SCM OPA-deny bodies', () => {
+    expect(extractErrorMessage(JSON.stringify({ msg: 'Access denied' }), 403)).toBe(
+      'Access denied',
+    );
+  });
 });
 
 describe('executeWithRetry', () => {

--- a/test/http/tsg-header.spec.ts
+++ b/test/http/tsg-header.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TsgHeaderAuth } from '../../src/http/auth/tsg-header.js';
+import type { AuthAdapter, PreparedRequest } from '../../src/http/types.js';
+
+function baseReq(): PreparedRequest {
+  return { method: 'GET', url: new URL('https://example.com/x'), headers: { A: '1' } };
+}
+
+describe('TsgHeaderAuth', () => {
+  it('adds x-tsg-id and preserves inner headers', async () => {
+    const inner: AuthAdapter = {
+      prepare: async (r) => ({ ...r, headers: { ...r.headers, Authorization: 'Bearer t' } }),
+    };
+    const auth = new TsgHeaderAuth(inner, '1852583913');
+
+    const out = await auth.prepare(baseReq());
+
+    expect(out.headers['x-tsg-id']).toBe('1852583913');
+    expect(out.headers.Authorization).toBe('Bearer t');
+    expect(out.headers.A).toBe('1');
+  });
+
+  it('delegates onUnauthorized to the inner adapter', async () => {
+    const onUnauthorized = vi.fn().mockResolvedValue(true);
+    const inner: AuthAdapter = { prepare: async (r) => r, onUnauthorized };
+    const auth = new TsgHeaderAuth(inner, '123');
+
+    const res = new Response(null, { status: 401 });
+    await expect(auth.onUnauthorized(res)).resolves.toBe(true);
+    expect(onUnauthorized).toHaveBeenCalledWith(res);
+  });
+
+  it('returns false when the inner adapter has no onUnauthorized', async () => {
+    const auth = new TsgHeaderAuth({ prepare: async (r) => r }, '123');
+    await expect(auth.onUnauthorized(new Response(null, { status: 401 }))).resolves.toBe(false);
+  });
+});

--- a/test/models/ai-gateway.spec.ts
+++ b/test/models/ai-gateway.spec.ts
@@ -6,6 +6,11 @@ import {
   GroupListResponseSchema,
   UserGroupResponseSchema,
   GatewayLogsResponseSchema,
+  ListWorkspacesResponseSchema,
+  ListConfigsResponseSchema,
+  ListDeploymentsResponseSchema,
+  DeploymentCreateResponseSchema,
+  AuditLogsResponseSchema,
 } from '../../src/models/ai-gateway.js';
 
 describe('AI Gateway telemetry schemas', () => {
@@ -123,5 +128,119 @@ describe('AI Gateway telemetry schemas', () => {
       data: { records: [], total: 0, avg: 0, isQuotaExceeded: false, brandNewField: 'x' },
     });
     expect((r.data as Record<string, unknown>).brandNewField).toBe('x');
+  });
+});
+
+describe('AI Gateway resource schemas', () => {
+  it('parses a workspace list', () => {
+    const r = ListWorkspacesResponseSchema.parse({
+      object: 'list',
+      total: 1,
+      data: [
+        {
+          id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+          slug: 'ws-main-a-349e0e',
+          name: 'talos_k8s_cluster',
+          icon: null,
+          description: 'Default workspace',
+          created_at: '2026-07-16T15:48:18.000Z',
+          last_updated_at: '2026-07-17T12:25:22.000Z',
+          is_default: 0,
+          status: 'active',
+          scope_name: 'main_airs_workspace_1852583913',
+          object: 'workspace',
+        },
+      ],
+    });
+    expect(r.data[0].scope_name).toBe('main_airs_workspace_1852583913');
+  });
+
+  it('keeps config.config as an unparsed JSON STRING', () => {
+    const r = ListConfigsResponseSchema.parse({
+      object: 'list',
+      total: 1,
+      data: [
+        {
+          id: '764cf9cd-4ebf-449e-b669-08149b0fbbbc',
+          name: 'claude-code',
+          slug: 'pc-claude-e46fe6',
+          organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+          is_default: 0,
+          status: 'active',
+          owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+          updated_by: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+          created_at: '2026-07-17T00:42:44.000Z',
+          last_updated_at: '2026-07-17T00:42:44.000Z',
+          workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+          config: '{"provider":"@anthropic-prod"}',
+          format: 'json',
+          type: 'ORG_CONFIG',
+          version_id: 'v1',
+          object: 'config',
+        },
+      ],
+    });
+    expect(typeof r.data[0].config).toBe('string');
+  });
+
+  it('parses a deployment list row (11 fields, no credentials)', () => {
+    const r = ListDeploymentsResponseSchema.parse({
+      object: 'list',
+      total: 1,
+      data: [
+        {
+          id: '32e8314e-7e68-4384-aacb-a476f6c3f91d',
+          name: 'talos',
+          slug: 'dp-talos-f3b74e',
+          type: 'production',
+          status: 'active',
+          created_at: '2026-07-16T15:50:06.000Z',
+          last_updated_at: '2026-07-16T15:50:06.000Z',
+          last_synced_at: '2026-07-27T10:27:00.000Z',
+          last_resynced_at: null,
+          is_default: 1,
+          created_by: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+          object: 'deployment',
+        },
+      ],
+    });
+    expect(r.data[0].last_resynced_at).toBeNull();
+  });
+
+  it('parses the deployment CREATE receipt, which is NOT the record shape', () => {
+    const r = DeploymentCreateResponseSchema.parse({
+      id: '21414819-485e-4ba3-b3d3-3e1815580e43',
+      client_auth: 'client-auth-1edUcNFlbaTSueWe5gdlcmSCHPRO',
+      credentials: { username: '1852583913', password: 's3cret' },
+      organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+      object: 'deployment',
+    });
+    expect(r.credentials.password).toBe('s3cret');
+  });
+
+  it('parses audit logs (records, not the list envelope)', () => {
+    const r = AuditLogsResponseSchema.parse({
+      records: [
+        {
+          timestamp: '2026-07-24T21:04:11.000Z',
+          method: 'DELETE',
+          uri: '/ai_gw/admin/v2/deployments/abc',
+          request_id: '600be074-d9d6-4fca-a8ec-5090f22138d6',
+          request_body: '{}',
+          query_params: '{}',
+          request_headers: '{}',
+          user_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+          user_type: 'user',
+          organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+          workspace_id: '',
+          response_status_code: 200,
+          resource_type: 'admin',
+          action: '',
+          client_ip: '::ffff:127.0.0.1',
+          country: '',
+        },
+      ],
+    });
+    expect(r.records[0].method).toBe('DELETE');
   });
 });

--- a/test/models/ai-gateway.spec.ts
+++ b/test/models/ai-gateway.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CostChartResponseSchema,
+  LatencyChartResponseSchema,
+  RescuedRetriesResponseSchema,
+  GroupListResponseSchema,
+  UserGroupResponseSchema,
+  GatewayLogsResponseSchema,
+} from '../../src/models/ai-gateway.js';
+
+describe('AI Gateway telemetry schemas', () => {
+  it('parses a cost chart (values in cents)', () => {
+    const r = CostChartResponseSchema.parse({
+      success: true,
+      data: {
+        records: [{ x: '2026-07-20T05:00:00.000Z', y: 68064.028, avg: 20.342 }],
+        total: 411082.598,
+        avg: 19.981,
+        isQuotaExceeded: false,
+      },
+    });
+    expect(r.data.total).toBe(411082.598);
+  });
+
+  it('parses per-bucket latency percentiles', () => {
+    const r = LatencyChartResponseSchema.parse({
+      success: true,
+      data: {
+        records: [
+          { x: '2026-07-20T05:00:00.000Z', y: 2296.845, p50: 1855, p90: 3570, p99: 8611.8 },
+        ],
+        total: 2202.043,
+        p50: 1750,
+        p90: 3599.9,
+        p99: 8329.14,
+        isQuotaExceeded: false,
+      },
+    });
+    expect(r.data.records[0].p99).toBe(8611.8);
+  });
+
+  it('parses rescued-retries where record y is an ARRAY', () => {
+    const r = RescuedRetriesResponseSchema.parse({
+      success: true,
+      data: {
+        trend: [{ x: '2026-07-20T05:00:00.000Z', y: [] }],
+        total: 0,
+        trends: [{ x: '2026-07-20T05:00:00.000Z', retry: [], fallback: [] }],
+        retryTotal: 0,
+        fallbackTotal: 0,
+        isQuotaExceeded: false,
+      },
+    });
+    expect(r.data.trend[0].y).toEqual([]);
+  });
+
+  it('parses a groups row using the snake_case quota flag', () => {
+    const r = GroupListResponseSchema.parse({
+      object: 'list',
+      is_quota_exceeded: false,
+      total: 1,
+      data: [{ model: 'claude-sonnet-5', requests: 10506, cost: 29704.16, object: 'log' }],
+    });
+    expect(r.data[0].requests).toBe(10506);
+  });
+
+  it('parses groups/users, which uses the OTHER envelope', () => {
+    const r = UserGroupResponseSchema.parse({
+      success: true,
+      data: {
+        records: [{ _user: '', count: 25748, cost: 411060.85 }],
+        total: 1,
+        isQuotaExceeded: false,
+      },
+    });
+    expect(r.data.records[0]._user).toBe('');
+  });
+
+  it('parses a log record with 0/1 integer booleans and null-safe fields', () => {
+    const r = GatewayLogsResponseSchema.parse({
+      success: true,
+      data: {
+        records: [
+          {
+            id: '11111111-1111-4111-8111-111111111111',
+            workspace_slug: 'ws-main-a-349e0e',
+            ai_model: 'claude-sonnet-5',
+            _user: '',
+            total_units: 63809,
+            cost: 1.383,
+            trace_id: 'claude-code-calvin',
+            is_proxy_call: 0,
+            created_at: '2026-07-27T10:48:22.059Z',
+            is_success: 1,
+            cache_status: 'DISABLED',
+            retry_success_count: 0,
+            mode: 'single',
+            last_used_option_index: -1,
+            response_status_code: 200,
+            request_url: 'https://api.anthropic.com/v1/messages',
+            request_method: 'POST',
+            ai_org: 'anthropic',
+            api_key_id: 'k1',
+            license_id: '22222222-2222-4222-8222-222222222222',
+            log_store_file_path_format: 'v2',
+            metadataKey: [],
+            metadataValue: [],
+            prompt_slug: '',
+            feedback: [],
+          },
+        ],
+        total: 25750,
+        isQuotaExceeded: false,
+        capturedTotal: 0,
+      },
+    });
+    expect(r.data.records[0].is_success).toBe(1);
+  });
+
+  it('tolerates unknown upstream fields (passthrough)', () => {
+    const r = CostChartResponseSchema.parse({
+      success: true,
+      data: { records: [], total: 0, avg: 0, isQuotaExceeded: false, brandNewField: 'x' },
+    });
+    expect((r.data as Record<string, unknown>).brandNewField).toBe('x');
+  });
+});

--- a/test/models/ai-gateway.spec.ts
+++ b/test/models/ai-gateway.spec.ts
@@ -9,7 +9,7 @@ import {
   ListWorkspacesResponseSchema,
   ListConfigsResponseSchema,
   ListDeploymentsResponseSchema,
-  DeploymentCreateResponseSchema,
+  GatewayDeploymentCreateResponseSchema,
   GatewayAuditLogsResponseSchema,
 } from '../../src/models/ai-gateway.js';
 
@@ -226,7 +226,7 @@ describe('AI Gateway resource schemas', () => {
   });
 
   it('parses the deployment CREATE receipt, which is NOT the record shape', () => {
-    const r = DeploymentCreateResponseSchema.parse({
+    const r = GatewayDeploymentCreateResponseSchema.parse({
       id: '21414819-485e-4ba3-b3d3-3e1815580e43',
       client_auth: 'client-auth-1edUcNFlbaTSueWe5gdlcmSCHPRO',
       credentials: { username: '1852583913', password: 's3cret' },

--- a/test/models/ai-gateway.spec.ts
+++ b/test/models/ai-gateway.spec.ts
@@ -8,9 +8,12 @@ import {
   GatewayLogsResponseSchema,
   ListWorkspacesResponseSchema,
   ListConfigsResponseSchema,
+  GatewayConfigDetailSchema,
   ListDeploymentsResponseSchema,
   GatewayDeploymentCreateResponseSchema,
   GatewayAuditLogsResponseSchema,
+  ListMcpIntegrationsResponseSchema,
+  GatewayIntegrationWorkspacesResponseSchema,
 } from '../../src/models/ai-gateway.js';
 
 describe('AI Gateway telemetry schemas', () => {
@@ -173,7 +176,7 @@ describe('AI Gateway resource schemas', () => {
     expect(r.data[0].scope_name).toBe('main_airs_workspace_1852583913');
   });
 
-  it('keeps config.config as an unparsed JSON STRING', () => {
+  it('parses a config LIST row — 12 fields, no config/format/type/version_id', () => {
     const r = ListConfigsResponseSchema.parse({
       object: 'list',
       total: 1,
@@ -190,15 +193,80 @@ describe('AI Gateway resource schemas', () => {
           created_at: '2026-07-17T00:42:44.000Z',
           last_updated_at: '2026-07-17T00:42:44.000Z',
           workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
-          config: '{"provider":"@anthropic-prod"}',
-          format: 'json',
-          type: 'ORG_CONFIG',
-          version_id: 'v1',
           object: 'config',
         },
       ],
     });
-    expect(typeof r.data[0].config).toBe('string');
+    expect(r.data[0].status).toBe('active');
+    expect((r.data[0] as unknown as { config?: string }).config).toBeUndefined();
+    expect((r.data[0] as unknown as { format?: string }).format).toBeUndefined();
+  });
+
+  it('parses a config DETAIL read, which adds config/format/type/version_id', () => {
+    const r = GatewayConfigDetailSchema.parse({
+      id: '764cf9cd-4ebf-449e-b669-08149b0fbbbc',
+      name: 'claude-code',
+      slug: 'pc-claude-e46fe6',
+      organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+      is_default: 0,
+      status: 'active',
+      owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+      updated_by: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+      created_at: '2026-07-17T00:42:44.000Z',
+      last_updated_at: '2026-07-17T00:42:44.000Z',
+      workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+      config: '{"provider":"@anthropic-prod"}',
+      format: 'json',
+      type: 'ORG_CONFIG',
+      version_id: 'v1',
+      object: 'config',
+    });
+    expect(typeof r.config).toBe('string');
+  });
+
+  it('parses an MCP integration, keeping configurations as an unparsed JSON STRING', () => {
+    const r = ListMcpIntegrationsResponseSchema.parse({
+      object: 'list',
+      total: 1,
+      data: [
+        {
+          id: '2a6f4e2e-6f5a-4a1f-9d0e-9b2b6f6c3a11',
+          organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+          name: 'Context 7',
+          owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+          status: 'active',
+          type: 'MCP_INTEGRATION',
+          url: 'https://mcp.context7.com/mcp',
+          auth_type: 'none',
+          transport: 'http',
+          configurations: '{}',
+          created_at: '2026-07-17T00:42:44.000Z',
+          last_updated_at: '2026-07-17T00:42:44.000Z',
+        },
+      ],
+    });
+    expect(typeof r.data[0].configurations).toBe('string');
+  });
+
+  it('parses integration workspaces, where global_workspace_access is an OBJECT not a boolean', () => {
+    const r = GatewayIntegrationWorkspacesResponseSchema.parse({
+      workspaces: [
+        {
+          id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+          usage_limits: null,
+          rate_limits: null,
+          enabled: true,
+          status: 'active',
+          created_at: '2026-07-16T15:48:18.000Z',
+          last_updated_at: '2026-07-17T12:25:22.000Z',
+          last_reset_at: null,
+        },
+      ],
+      global_workspace_access: { enabled: false, rate_limits: null, usage_limits: null },
+      object: 'integration',
+    });
+    expect(r.global_workspace_access.enabled).toBe(false);
+    expect(r.workspaces[0].enabled).toBe(true);
   });
 
   it('parses a deployment list row (11 fields, no credentials)', () => {

--- a/test/models/ai-gateway.spec.ts
+++ b/test/models/ai-gateway.spec.ts
@@ -10,7 +10,7 @@ import {
   ListConfigsResponseSchema,
   ListDeploymentsResponseSchema,
   DeploymentCreateResponseSchema,
-  AuditLogsResponseSchema,
+  GatewayAuditLogsResponseSchema,
 } from '../../src/models/ai-gateway.js';
 
 describe('AI Gateway telemetry schemas', () => {
@@ -59,6 +59,24 @@ describe('AI Gateway telemetry schemas', () => {
     expect(r.data.trend[0].y).toEqual([]);
   });
 
+  it('accepts an unobserved-shape rescued-retries trend[].y element', () => {
+    // y's element shape has never been observed on a live tenant (only empty arrays so far).
+    // It's typed z.array(z.unknown()) like its trends[].retry/fallback siblings — confirm it
+    // doesn't reject whatever shape a tenant with actual retries eventually sends.
+    const r = RescuedRetriesResponseSchema.parse({
+      success: true,
+      data: {
+        trend: [{ x: '2026-07-20T05:00:00.000Z', y: [{ anything: 'goes', count: 3 }, 42, 'x'] }],
+        total: 3,
+        trends: [{ x: '2026-07-20T05:00:00.000Z', retry: [], fallback: [] }],
+        retryTotal: 0,
+        fallbackTotal: 0,
+        isQuotaExceeded: false,
+      },
+    });
+    expect(r.data.trend[0].y).toHaveLength(3);
+  });
+
   it('parses a groups row using the snake_case quota flag', () => {
     const r = GroupListResponseSchema.parse({
       object: 'list',
@@ -81,7 +99,7 @@ describe('AI Gateway telemetry schemas', () => {
     expect(r.data.records[0]._user).toBe('');
   });
 
-  it('parses a log record with 0/1 integer booleans and null-safe fields', () => {
+  it('parses a log record with 0/1 integer booleans', () => {
     const r = GatewayLogsResponseSchema.parse({
       success: true,
       data: {
@@ -219,7 +237,7 @@ describe('AI Gateway resource schemas', () => {
   });
 
   it('parses audit logs (records, not the list envelope)', () => {
-    const r = AuditLogsResponseSchema.parse({
+    const r = GatewayAuditLogsResponseSchema.parse({
       records: [
         {
           timestamp: '2026-07-24T21:04:11.000Z',

--- a/test/validators.spec.ts
+++ b/test/validators.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { assertUuid, assertLength } from '../src/validators.js';
+import { assertUuid, assertLength, assertNumericId } from '../src/validators.js';
 import { AISecSDKException, ErrorType } from '../src/errors.js';
 
 describe('assertUuid', () => {
@@ -80,6 +80,50 @@ describe('assertLength', () => {
       expect(msg).toMatch(/sessionId/);
       expect(msg).toMatch(/5/);
       expect(msg).toMatch(/20/);
+    }
+  });
+});
+
+describe('assertNumericId', () => {
+  it('accepts a plain numeric string', () => {
+    expect(() => assertNumericId('1852583913', 'tsgId')).not.toThrow();
+  });
+
+  it('accepts a single digit', () => {
+    expect(() => assertNumericId('0', 'tsgId')).not.toThrow();
+  });
+
+  it('throws on empty string', () => {
+    expect(() => assertNumericId('', 'tsgId')).toThrow(AISecSDKException);
+  });
+
+  it('throws on a UUID', () => {
+    expect(() => assertNumericId('550e8400-e29b-41d4-a716-446655440000', 'organisationId')).toThrow(
+      AISecSDKException,
+    );
+  });
+
+  it('throws on a value with a path-traversal segment', () => {
+    expect(() => assertNumericId('../self', 'tsgId')).toThrow(AISecSDKException);
+  });
+
+  it('throws on a value with a slash', () => {
+    expect(() => assertNumericId('123/456', 'tsgId')).toThrow(AISecSDKException);
+  });
+
+  it('throws on a negative number', () => {
+    expect(() => assertNumericId('-123', 'tsgId')).toThrow(AISecSDKException);
+  });
+
+  it('throws USER_REQUEST_PAYLOAD_ERROR and embeds field name in error message', () => {
+    try {
+      assertNumericId('bad', 'tsgId');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AISecSDKException);
+      expect((err as AISecSDKException).errorType).toBe(ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+      expect((err as Error).message).toContain('tsgId');
+      expect((err as Error).message).toContain('bad');
     }
   });
 });


### PR DESCRIPTION
Adds `AIGatewayClient`, a fifth resource-client subsystem covering the SCM-managed Prisma
AIRS AI Gateway across its telemetry and configuration planes.

Schemas were derived from live responses against a real tenant — this API has no published
OpenAPI spec. Full endpoint inventory, response shapes, and landmines are documented in
`PRD-ai-gateway-client.md`.

## Notes for reviewers

- `TsgHeaderAuth` is the only new plumbing; it composes over `OAuthAuth` and leaves the four
  existing clients untouched.
- The two planes need different SCM role scopes on the same service account — see the
  `AIGatewayClient` class docs. A service account needs **both** an admin role at tenant-root
  scope and `view_only_admin` (or higher) on the `main_airs_workspace_<TSG>` scope, or half
  the API 403s.
- Costs are returned in cents, unconverted, matching the wire.
- `auditLogs.list()` can return unredacted secrets from the upstream API; the method carries
  a `@remarks` warning rather than silently altering the response.