### PR TITLE
feat(ai-gateway): verify write schemas for configs/guardrails/providers

### DIFF
--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v0.14.1
+
+### AI Gateway write-response schemas, verified against a live tenant
+
+Tightens three AI Gateway create responses that were previously typed permissively: `configs.create()`, `guardrails.create()`, and `providers.create()` now return resource-specific receipt schemas (`GatewayConfigCreateResponse`, `GatewayGuardrailCreateResponse`, `GatewayProviderCreateResponse`) instead of the generic passthrough shape. All three confirmed live: `configs`/`guardrails` return `{id, version_id, slug, object}`; `providers` returns `{id, slug, object}` with **no** `version_id`. As with `deployments.create()`, these are receipts, not the full record — do not read `name`/`config`/`checks`/`actions`/etc. off them.
+
+Adds `configs.delete()`, `guardrails.delete()`, and `providers.delete()` (`DELETE /ai_gw/v2/{resource}/{id}`). Unlike `deployments.delete()`, which archives (the record survives in `list()` with `status: 'archived'`), these three are **hard deletes** — the object is gone from `list()` entirely. None take an `organisation_id` query param.
+
+Adds `guardrails.get(guardrailId)`, modeled as `GatewayGuardrailDetail` from a verified live response (`checks[]`, `actions` with optional `on_success`/`on_fail` feedback, `version_id`, nullable `updated_by`). The list-row `Guardrail` schema is now tightened to what `list()` actually returns (no `checks`/`actions`/`version_id`).
+
+Fixes a documentation typo: the guardrail check id is `panw-prisma-airs.intercept` (hyphen, then dot), not `panw.prisma-airs.intercept` as previously shown in examples and guides.
+
 ## v0.14.0
 
 ### AI Gateway support

--- a/docs-site/docs/guides/ai-gateway-api.mdx
+++ b/docs-site/docs/guides/ai-gateway-api.mdx
@@ -239,6 +239,35 @@ const routing = JSON.parse(detail.config) as Record<string, unknown>;
 ```
 :::
 
+Guardrails also have a detail read, with the same list/detail split:
+
+```ts
+const guardrail = await gw.guardrails.get(guardrails.data[0].id);
+console.log(guardrail.checks[0].id); // e.g. 'panw-prisma-airs.intercept'
+```
+
+:::info[create() returns a receipt, not the record]
+`configs.create()`, `guardrails.create()`, and `providers.create()` all return a minimal creation receipt rather than the resource they just created — the same pattern as `deployments.create()`. `configs`/`guardrails` receipts carry `{ id, version_id, slug, object }`; `providers` receipts have **no `version_id`**: `{ id, slug, object }`. Call the matching `get()` (or `list()`, for providers) for the full record.
+
+```ts
+const receipt = await gw.configs.create({
+  name: 'vertex-airs',
+  workspace_id: workspaceId,
+  config: { retry: { attempts: 3 } },
+});
+const full = await gw.configs.get(receipt.id);
+```
+:::
+
+:::warning[configs/guardrails/providers delete() is a HARD delete]
+Unlike `deployments.delete()` (which archives — see the Admin Plane gotcha below), `configs.delete()`, `guardrails.delete()`, and `providers.delete()` all **permanently remove** the resource: it disappears from the corresponding `list()` entirely. None of the three take an `organisation_id` query param.
+
+```ts
+await gw.configs.delete(receipt.id);
+// receipt.id no longer appears in gw.configs.list()
+```
+:::
+
 ## Admin Plane
 
 Organisation-level resources, not scoped to a single workspace: deployments, provider integrations, MCP integrations, plugins, and organisation/auth settings.
@@ -280,7 +309,7 @@ const summary = audit.records.map((r) => `${r.timestamp} ${r.method} ${r.uri.spl
 - **Costs are in cents, everywhere.** `telemetry.cost().data.total`, `groupBy(...).data[].cost`, `byUser(...).data.records[].cost` — none of them are dollars. Divide by 100 yourself: `(cents / 100).toFixed(2)`.
 - **Workspace slug vs. id.** Telemetry (`gw.telemetry.*`) is keyed by `workspaceSlug`; config-plane lists (`gw.configs.list`, `gw.guardrails.list`, `gw.providers.list`, `gw.apiKeys.list*`) are keyed by `workspaceId`. Both come off the same `gw.workspaces.list()` row — `ws.slug` and `ws.id` — but passing one where the other is expected fails.
 - **`configs.list()` and `configs.get()` are different shapes** — the list read omits `config`/`format`/`type`/`version_id`, and `config` is a JSON string on the detail read, not an object. See the callout above.
-- **`deployments.delete()` is a soft delete.** It returns `200` with an empty body, and the record persists in `deployments.list()` with `status: 'archived'`. There is no observed hard-delete.
+- **Delete semantics differ by resource — there is no gateway-wide convention.** `deployments.delete()` is the one **soft delete**: it returns `200` with an empty body and the record persists in `deployments.list()` with `status: 'archived'`. `configs.delete()`, `guardrails.delete()`, and `providers.delete()` are **hard deletes** — the resource vanishes from its `list()` entirely. Don't assume one behavior generalizes to the other.
 - **`deployments.create()` is the only place credentials are ever readable.** It returns a 5-field receipt — `{ id, client_auth, credentials: { username, password }, organisation_id, object }` — not a deployment record, and `credentials.password` / `client_auth` are masked on every subsequent `deployments.get()`. Capture them from the create response or not at all:
 
   ```ts
@@ -339,7 +368,7 @@ For the complete, per-method list with input/output shapes (`AIGatewayClient` an
 
 ## Testing against a live tenant
 
-Unit tests run against recorded fixtures written by the same person who wrote the schemas, so they can't catch a schema that disagrees with the live API. `scripts/smoke-ai-gateway.ts` exists specifically to catch that class of bug: it calls all 42 read methods across both planes against a real tenant and reports which parse cleanly.
+Unit tests run against recorded fixtures written by the same person who wrote the schemas, so they can't catch a schema that disagrees with the live API. `scripts/smoke-ai-gateway.ts` exists specifically to catch that class of bug: it calls all 43 read methods across both planes against a real tenant and reports which parse cleanly.
 
 It is opt-in, read-only, and **not** part of CI or `npm test` — it needs live credentials and hits a real tenant. It has already caught 3 real schema mismatches before they shipped (a config list/detail shape confusion, an MCP integration field typed as an object when the API returns a JSON string, and an integration's workspace-binding flag typed as a boolean when the API returns an object).
 

--- a/examples/ai-gateway.ts
+++ b/examples/ai-gateway.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 /**
- * AI Gateway usage examples — Prisma AIRS SDK (v0.14.0).
+ * AI Gateway usage examples — Prisma AIRS SDK (v0.14.1).
  *
  * Every call below is READ-ONLY; write calls are shown as comments at the bottom instead of
  * being executed. Verified against a live tenant.
@@ -115,6 +115,10 @@ async function main(): Promise<void> {
   console.log(
     `  guardrails=${guardrails.total}  providers=${providers.total}  serviceKeys=${svcKeys.total}`,
   );
+  if (guardrails.data[0]) {
+    const detail = await gw.guardrails.get(guardrails.data[0].id); // detail read
+    console.log(`  guardrail "${detail.name}" check id: ${detail.checks[0]?.id}`);
+  }
 
   // ── 8. Admin plane. Same client, same credentials, different role scope.
   //      delete() is a SOFT delete — records persist as status:'archived'.
@@ -187,20 +191,33 @@ async function main(): Promise<void> {
   //   // receipt.credentials.password — capture now; the detail read masks it
   //   const full = await gw.deployments.get(receipt.id);
   //
-  // config is sent as an OBJECT but read back as a JSON string:
-  //   await gw.configs.create({
+  // config is sent as an OBJECT but read back as a JSON string. create() returns a
+  // { id, version_id, slug, object } RECEIPT, not the record — call configs.get() for that:
+  //   const cfgReceipt = await gw.configs.create({
   //     name: 'vertex-airs', workspace_id: workspaceId,
   //     config: { retry: { attempts: 3 }, cache: { mode: 'simple' } },
   //   });
+  //   await gw.configs.delete(cfgReceipt.id);  // HARD delete — vanishes from list(), unlike deployments
   //
-  //   await gw.guardrails.create({
+  // guardrails.create() also returns a { id, version_id, slug, object } RECEIPT.
+  // Note the real check id is 'panw-prisma-airs.intercept' (hyphen, then dot before "intercept"):
+  //   const grReceipt = await gw.guardrails.create({
   //     workspace_id: workspaceId, name: 'PrismaAIRS',
-  //     checks: [{ id: 'panw.prisma-airs.intercept',
+  //     checks: [{ id: 'panw-prisma-airs.intercept',
   //                parameters: { profile_name: 'AI Gateway - Strict' }, is_enabled: true }],
   //     actions: { deny: false, async: false, sequential: false },
   //   });
+  //   await gw.guardrails.delete(grReceipt.id);  // HARD delete — vanishes from list()
   //
-  //   await gw.deployments.delete(id, '1852583913');  // archives, does not remove
+  // providers.create() returns a { id, slug, object } RECEIPT — no version_id, unlike
+  // configs/guardrails above:
+  //   const pReceipt = await gw.providers.create({
+  //     workspace_id: workspaceId, ai_provider_id: '...', integration_id: '...',
+  //     name: 'openai-calvin', slug: 'openai-calvin',
+  //   });
+  //   await gw.providers.delete(pReceipt.id);  // HARD delete — vanishes from list()
+  //
+  //   await gw.deployments.delete(id, '1852583913');  // SOFT delete — archives, does not remove
 }
 
 main().catch((e: unknown) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/scripts/smoke-ai-gateway.ts
+++ b/scripts/smoke-ai-gateway.ts
@@ -3,7 +3,7 @@
  * @internal
  * AI Gateway live smoke test.
  *
- * Calls every AI Gateway READ method (41 total) against a real tenant and reports which
+ * Calls every AI Gateway READ method (43 total) against a real tenant and reports which
  * parse cleanly. Unit tests use recorded fixtures written by the same person who wrote the
  * schemas, so they cannot catch a schema that disagrees with the live API — this is the one
  * mechanism that can. See PRD-ai-gateway-client.md in the Obsidian vault for the schema
@@ -106,6 +106,8 @@ async function main(): Promise<void> {
   await check('workspaces.get', () => gw.workspaces.get(wsId));
   await check('configs.list', () => gw.configs.list({ workspaceId: wsId }));
   await check('guardrails.list', () => gw.guardrails.list({ workspaceId: wsId }));
+  const grs = await gw.guardrails.list({ workspaceId: wsId }).catch(() => null);
+  if (grs?.data?.[0]) await check('guardrails.get', () => gw.guardrails.get(grs.data[0].id));
   await check('providers.list', () => gw.providers.list({ workspaceId: wsId }));
   await check('apiKeys.listService', () => gw.apiKeys.listService({ workspaceId: wsId }));
   await check('apiKeys.listUser', () => gw.apiKeys.listUser({ workspaceId: wsId }));

--- a/src/ai-gateway/configs-client.ts
+++ b/src/ai-gateway/configs-client.ts
@@ -5,9 +5,11 @@ import { assertUuid } from '../validators.js';
 import {
   ListConfigsResponseSchema,
   GatewayConfigDetailSchema,
+  GatewayConfigCreateResponseSchema,
   GatewayWriteResponseSchema,
   type ListConfigsResponse,
   type GatewayConfigDetail,
+  type GatewayConfigCreateResponse,
   type GatewayWriteResponse,
 } from '../models/ai-gateway.js';
 import type { AIGatewaySubClientOptions, AIGatewayWorkspaceScopedListOptions } from './types.js';
@@ -96,28 +98,35 @@ export class AIGatewayConfigsClient {
 
   /**
    * Create a config.
+   *
+   * @remarks
+   * The response is a **creation receipt** — `{ id, version_id, slug, object }` — not a
+   * {@link GatewayConfigDetail}. Call {@link get} for the full record. Verified live
+   * 2026-07-28.
+   *
    * @param body - Name, workspace UUID, and the routing config object.
-   * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
+   * @returns The creation receipt.
    * @example
    * ```ts
    * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
    * const gw = new AIGatewayClient();
    *
-   * await gw.configs.create({
+   * const receipt = await gw.configs.create({
    *   name: 'vertex-airs',
    *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
    *   config: { retry: { attempts: 3 }, cache: { mode: 'simple' } },
    * });
+   * // receipt => { id: '...', version_id: '...', slug: 'pc-sdk-ve-14620d', object: 'config' }
    * ```
    */
-  async create(body: GatewayConfigCreateRequest): Promise<GatewayWriteResponse> {
+  async create(body: GatewayConfigCreateRequest): Promise<GatewayConfigCreateResponse> {
     assertUuid(body.workspace_id, 'workspace_id');
     return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: AI_GW_CONFIGS_PATH,
       body,
-      responseSchema: GatewayWriteResponseSchema,
+      responseSchema: GatewayConfigCreateResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });
@@ -149,6 +158,39 @@ export class AIGatewayConfigsClient {
       path: `${AI_GW_CONFIGS_PATH}/${configId}`,
       body,
       responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Delete a config.
+   *
+   * @remarks
+   * This is a **hard delete** — unlike {@link AIGatewayDeploymentsClient.delete | deployments.delete}
+   * (which archives), the config disappears from {@link list} entirely. Verified live
+   * 2026-07-28. No `organisation_id` query param is required, unlike deployments/integrations.
+   *
+   * @param configId - Config UUID.
+   * @returns Nothing.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.configs.delete('764cf9cd-4ebf-449e-b669-08149b0fbbbc');
+   * // the config no longer appears in gw.configs.list()
+   * ```
+   */
+  async delete(configId: string): Promise<void> {
+    assertUuid(configId, 'configId');
+    // The API returns 200 with an empty body. request() resolves to undefined whenever
+    // no responseSchema is supplied, regardless of allowEmptyBody — see
+    // deployments-client.ts's delete() for the fuller explanation.
+    await request({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_CONFIGS_PATH}/${configId}`,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/ai-gateway/deployments-client.ts
+++ b/src/ai-gateway/deployments-client.ts
@@ -134,9 +134,13 @@ export class AIGatewayDeploymentsClient {
    * Archive a deployment.
    *
    * @remarks
-   * This is a **soft delete**. The API returns 200 with an empty body and the record
-   * persists with `status: 'archived'`, still visible in {@link list}. There is no
-   * observed hard-delete.
+   * This is a **soft delete** — the one exception to the gateway's usual delete semantics.
+   * The API returns 200 with an empty body and the record persists with `status:
+   * 'archived'`, still visible in {@link list}. There is no observed hard-delete for
+   * deployments specifically. Contrast with {@link AIGatewayConfigsClient.delete |
+   * configs.delete}, {@link AIGatewayGuardrailsClient.delete | guardrails.delete}, and
+   * {@link AIGatewayProvidersClient.delete | providers.delete}, all of which hard-delete —
+   * do not assume archive-on-delete is a gateway-wide convention.
    *
    * @param deploymentId - Deployment UUID.
    * @param organisationId - The TSG as a numeric string; sent as a query param.

--- a/src/ai-gateway/guardrails-client.ts
+++ b/src/ai-gateway/guardrails-client.ts
@@ -4,9 +4,11 @@ import type { AuthAdapter } from '../http/types.js';
 import { assertUuid } from '../validators.js';
 import {
   ListGuardrailsResponseSchema,
-  GatewayWriteResponseSchema,
+  GatewayGuardrailDetailSchema,
+  GatewayGuardrailCreateResponseSchema,
   type ListGuardrailsResponse,
-  type GatewayWriteResponse,
+  type GatewayGuardrailDetail,
+  type GatewayGuardrailCreateResponse,
 } from '../models/ai-gateway.js';
 import type { AIGatewaySubClientOptions, AIGatewayWorkspaceScopedListOptions } from './types.js';
 
@@ -65,30 +67,96 @@ export class AIGatewayGuardrailsClient {
   }
 
   /**
-   * Create a guardrail.
-   * @param body - Workspace UUID, name, checks, and pass/fail actions.
-   * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
+   * Fetch one guardrail.
+   * @param guardrailId - Guardrail UUID.
+   * @returns Guardrail detail — adds `checks`, `actions`, and `version_id` on top of the list
+   * row.
    * @example
    * ```ts
    * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
    * const gw = new AIGatewayClient();
    *
-   * await gw.guardrails.create({
-   *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
-   *   name: 'PrismaAIRS',
-   *   checks: [{ id: 'panw.prisma-airs.intercept', parameters: { profile_name: 'AI Gateway - Strict' }, is_enabled: true }],
-   *   actions: { deny: false, async: false, sequential: false },
-   * });
+   * const g = await gw.guardrails.get('9f6c2a8e-2b3d-4e5f-8a9b-0c1d2e3f4a5b');
+   * // g.checks[0].id => 'panw-prisma-airs.intercept'
    * ```
    */
-  async create(body: GatewayGuardrailCreateRequest): Promise<GatewayWriteResponse> {
+  async get(guardrailId: string): Promise<GatewayGuardrailDetail> {
+    assertUuid(guardrailId, 'guardrailId');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_GUARDRAILS_PATH}/${guardrailId}`,
+      responseSchema: GatewayGuardrailDetailSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Create a guardrail.
+   *
+   * @remarks
+   * The response is a **creation receipt** — `{ id, version_id, slug, object }` — not a
+   * {@link GatewayGuardrailDetail}. Call {@link get} for the full record. Verified live
+   * 2026-07-28.
+   *
+   * @param body - Workspace UUID, name, checks, and pass/fail actions.
+   * @returns The creation receipt.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const receipt = await gw.guardrails.create({
+   *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+   *   name: 'PrismaAIRS',
+   *   checks: [{ id: 'panw-prisma-airs.intercept', parameters: { profile_name: 'AI Gateway - Strict' }, is_enabled: true }],
+   *   actions: { deny: false, async: false, sequential: false },
+   * });
+   * // receipt => { id: '...', version_id: '...', slug: 'pg-sdk-ve-874b62', object: 'guardrail' }
+   * ```
+   */
+  async create(body: GatewayGuardrailCreateRequest): Promise<GatewayGuardrailCreateResponse> {
     assertUuid(body.workspace_id, 'workspace_id');
     return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: AI_GW_GUARDRAILS_PATH,
       body,
-      responseSchema: GatewayWriteResponseSchema,
+      responseSchema: GatewayGuardrailCreateResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Delete a guardrail.
+   *
+   * @remarks
+   * This is a **hard delete** — unlike {@link AIGatewayDeploymentsClient.delete | deployments.delete}
+   * (which archives), the guardrail disappears from {@link list} entirely. Verified live
+   * 2026-07-28. No `organisation_id` query param is required, unlike deployments/integrations.
+   *
+   * @param guardrailId - Guardrail UUID.
+   * @returns Nothing.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.guardrails.delete('9f6c2a8e-2b3d-4e5f-8a9b-0c1d2e3f4a5b');
+   * // the guardrail no longer appears in gw.guardrails.list()
+   * ```
+   */
+  async delete(guardrailId: string): Promise<void> {
+    assertUuid(guardrailId, 'guardrailId');
+    // The API returns 200 with an empty body. request() resolves to undefined whenever
+    // no responseSchema is supplied, regardless of allowEmptyBody — see
+    // deployments-client.ts's delete() for the fuller explanation.
+    await request({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_GUARDRAILS_PATH}/${guardrailId}`,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/ai-gateway/providers-client.ts
+++ b/src/ai-gateway/providers-client.ts
@@ -4,9 +4,9 @@ import type { AuthAdapter } from '../http/types.js';
 import { assertUuid } from '../validators.js';
 import {
   ListProvidersResponseSchema,
-  GatewayWriteResponseSchema,
+  GatewayProviderCreateResponseSchema,
   type ListProvidersResponse,
-  type GatewayWriteResponse,
+  type GatewayProviderCreateResponse,
 } from '../models/ai-gateway.js';
 import type { AIGatewaySubClientOptions, AIGatewayWorkspaceScopedListOptions } from './types.js';
 
@@ -63,23 +63,31 @@ export class AIGatewayProvidersClient {
 
   /**
    * Create a provider.
+   *
+   * @remarks
+   * The response is a **creation receipt** — `{ id, slug, object }` — not a {@link
+   * GatewayProvider}. Note it has **no `version_id`**, unlike the sibling receipts for
+   * {@link AIGatewayConfigsClient.create | configs.create} and {@link
+   * AIGatewayGuardrailsClient.create | guardrails.create}. Verified live 2026-07-28.
+   *
    * @param body - Workspace UUID, upstream provider id, integration id, name, and slug.
-   * @returns The raw create response. Shape unverified against a live tenant — see the PRD.
+   * @returns The creation receipt.
    * @example
    * ```ts
    * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
    * const gw = new AIGatewayClient();
    *
-   * await gw.providers.create({
+   * const receipt = await gw.providers.create({
    *   workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
    *   ai_provider_id: 'de7d7d50-31cd-11ee-b93b-0e06f1aa7f7c',
    *   integration_id: 'f6692544-3265-49be-9711-bbdcebc079e4',
    *   name: 'openai-calvin',
    *   slug: 'openai-calvin',
    * });
+   * // receipt => { id: '...', slug: 'sdk-verify-delete-me-provider', object: 'provider' }
    * ```
    */
-  async create(body: GatewayProviderCreateRequest): Promise<GatewayWriteResponse> {
+  async create(body: GatewayProviderCreateRequest): Promise<GatewayProviderCreateResponse> {
     assertUuid(body.workspace_id, 'workspace_id');
     assertUuid(body.ai_provider_id, 'ai_provider_id');
     assertUuid(body.integration_id, 'integration_id');
@@ -88,7 +96,40 @@ export class AIGatewayProvidersClient {
       baseUrl: this.baseUrl,
       path: AI_GW_PROVIDERS_PATH,
       body,
-      responseSchema: GatewayWriteResponseSchema,
+      responseSchema: GatewayProviderCreateResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Delete a provider.
+   *
+   * @remarks
+   * This is a **hard delete** — unlike {@link AIGatewayDeploymentsClient.delete | deployments.delete}
+   * (which archives), the provider disappears from {@link list} entirely. Verified live
+   * 2026-07-28. No `organisation_id` query param is required, unlike deployments/integrations.
+   *
+   * @param providerId - Provider UUID.
+   * @returns Nothing.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.providers.delete('f6692544-3265-49be-9711-bbdcebc079e4');
+   * // the provider no longer appears in gw.providers.list()
+   * ```
+   */
+  async delete(providerId: string): Promise<void> {
+    assertUuid(providerId, 'providerId');
+    // The API returns 200 with an empty body. request() resolves to undefined whenever
+    // no responseSchema is supplied, regardless of allowEmptyBody — see
+    // deployments-client.ts's delete() for the fuller explanation.
+    await request({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${AI_GW_PROVIDERS_PATH}/${providerId}`,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.14.0';
+export const SDK_VERSION = '0.14.1';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/models/ai-gateway.ts
+++ b/src/models/ai-gateway.ts
@@ -372,10 +372,14 @@ export type GatewayLogsResponse = z.infer<typeof GatewayLogsResponseSchema>;
 /**
  * Placeholder for write responses whose shape has NOT been verified against a live tenant.
  *
- * Verifying `deployments` proved a create response can differ completely from the record it
- * creates (5-field receipt vs 15-field record), so these shapes cannot be inferred from the
- * corresponding read. Tighten each into a named schema as it is verified. See
- * PRD-ai-gateway-client.md "Testing".
+ * Verifying `deployments`, `configs`, `guardrails`, and `providers` create responses proved
+ * every create returns a minimal receipt rather than the record it creates — never inferable
+ * from the corresponding read. See {@link GatewayDeploymentCreateResponseSchema}, {@link
+ * GatewayConfigCreateResponseSchema}, {@link GatewayGuardrailCreateResponseSchema}, and {@link
+ * GatewayProviderCreateResponseSchema} for the four now-verified receipts. This placeholder
+ * still covers every remaining unverified write (all `update()` PUT responses, plus
+ * `api-keys`/`integrations`/`mcp-integrations`/`workspaces`/`plugins` create responses).
+ * Tighten each into a named schema as it is verified. See PRD-ai-gateway-client.md "Testing".
  */
 export const GatewayWriteResponseSchema = z.object({}).passthrough();
 export type GatewayWriteResponse = z.infer<typeof GatewayWriteResponseSchema>;
@@ -474,17 +478,107 @@ export const GatewayConfigDetailSchema = GatewayConfigSchema.extend({
 }).passthrough();
 export type GatewayConfigDetail = z.infer<typeof GatewayConfigDetailSchema>;
 
+/**
+ * `POST /configs` response — a 4-field creation receipt, **not** a {@link GatewayConfig} or
+ * {@link GatewayConfigDetail}. Verified live 2026-07-28 (create -> read -> delete cycle).
+ * Confirms the "create returns a receipt, not the record" pattern first established for
+ * {@link GatewayDeploymentCreateResponseSchema} also holds for configs. Call {@link
+ * GatewayConfigDetailSchema}'s `get()` for the full record.
+ */
+export const GatewayConfigCreateResponseSchema = z
+  .object({
+    id: z.string(),
+    version_id: z.string(),
+    slug: z.string(),
+    object: z.string(),
+  })
+  .passthrough();
+export type GatewayConfigCreateResponse = z.infer<typeof GatewayConfigCreateResponseSchema>;
+
 // ---------------------------------------------------------------------------
-// Guardrails / providers / API keys (data plane)
+// Guardrails (data plane) — list row, detail, and create receipt, verified live
 // ---------------------------------------------------------------------------
 
-/** A workspace guardrail. Field set beyond the identifiers is tenant-dependent. */
+/**
+ * A guardrail **list row** (`GET /guardrails?workspace_id=`) — 10 fields. It does NOT carry
+ * `checks`, `actions`, or `version_id`; see {@link GatewayGuardrailDetailSchema} for those.
+ * Verified live 2026-07-28.
+ */
 export const GatewayGuardrailSchema = z
-  .object({ id: z.string(), name: z.string().optional(), object: z.string().optional() })
+  .object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string(),
+    organisation_id: z.string(),
+    status: z.string(),
+    owner_id: z.string(),
+    updated_by: z.string().nullable(),
+    created_at: z.string(),
+    last_updated_at: z.string(),
+    workspace_id: z.string(),
+    object: z.string(),
+  })
   .passthrough();
 export type GatewayGuardrail = z.infer<typeof GatewayGuardrailSchema>;
 export const ListGuardrailsResponseSchema = aiGatewayList(GatewayGuardrailSchema);
 export type ListGuardrailsResponse = z.infer<typeof ListGuardrailsResponseSchema>;
+
+/** One `on_success`/`on_fail` feedback action. Absent entirely on guardrails created without them. */
+const guardrailFeedbackActionSchema = z
+  .object({
+    feedback: z
+      .object({ value: z.number(), weight: z.number(), metadata: z.string() })
+      .passthrough(),
+  })
+  .passthrough();
+
+/**
+ * Guardrail detail (`GET /guardrails/{id}`) — adds `checks`, `actions`, and `version_id` on
+ * top of the list row. Verified live 2026-07-28.
+ */
+export const GatewayGuardrailDetailSchema = GatewayGuardrailSchema.extend({
+  checks: z.array(
+    z
+      .object({
+        /** e.g. `panw-prisma-airs.intercept`, the Prisma AIRS intercept check. */
+        id: z.string(),
+        parameters: z.record(z.unknown()),
+        is_enabled: z.boolean(),
+      })
+      .passthrough(),
+  ),
+  actions: z
+    .object({
+      deny: z.boolean(),
+      async: z.boolean(),
+      sequential: z.boolean(),
+      /** Absent when the guardrail was created without a pass/fail feedback action. */
+      on_success: guardrailFeedbackActionSchema.optional(),
+      on_fail: guardrailFeedbackActionSchema.optional(),
+    })
+    .passthrough(),
+  version_id: z.string(),
+}).passthrough();
+export type GatewayGuardrailDetail = z.infer<typeof GatewayGuardrailDetailSchema>;
+
+/**
+ * `POST /guardrails` response — a 4-field creation receipt, **not** a {@link GatewayGuardrail}
+ * or {@link GatewayGuardrailDetail}. Verified live 2026-07-28. Same receipt pattern as
+ * {@link GatewayConfigCreateResponseSchema}.
+ */
+export const GatewayGuardrailCreateResponseSchema = z
+  .object({
+    id: z.string(),
+    version_id: z.string(),
+    slug: z.string(),
+    object: z.string(),
+  })
+  .passthrough();
+export type GatewayGuardrailCreateResponse = z.infer<typeof GatewayGuardrailCreateResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Providers (data plane)
+// ---------------------------------------------------------------------------
 
 /** A workspace-scoped AI provider binding. */
 export const GatewayProviderSchema = z
@@ -498,6 +592,25 @@ export const GatewayProviderSchema = z
 export type GatewayProvider = z.infer<typeof GatewayProviderSchema>;
 export const ListProvidersResponseSchema = aiGatewayList(GatewayProviderSchema);
 export type ListProvidersResponse = z.infer<typeof ListProvidersResponseSchema>;
+
+/**
+ * `POST /providers` response — a 3-field creation receipt, **not** a {@link GatewayProvider}.
+ * Verified live 2026-07-28. **No `version_id`** — unlike its {@link
+ * GatewayConfigCreateResponseSchema} and {@link GatewayGuardrailCreateResponseSchema}
+ * siblings. Do not add one speculatively.
+ */
+export const GatewayProviderCreateResponseSchema = z
+  .object({
+    id: z.string(),
+    slug: z.string(),
+    object: z.string(),
+  })
+  .passthrough();
+export type GatewayProviderCreateResponse = z.infer<typeof GatewayProviderCreateResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// API keys (data plane)
+// ---------------------------------------------------------------------------
 
 /** A service or user API key. The secret itself is only returned at creation. */
 export const GatewayApiKeySchema = z

--- a/test/ai-gateway/configs-client.spec.ts
+++ b/test/ai-gateway/configs-client.spec.ts
@@ -77,9 +77,14 @@ describe('AIGatewayConfigsClient', () => {
     expect(url).toBe(`https://gw.example.com/configs/${cfgId}`);
   });
 
-  it('POSTs a config with the config body as an OBJECT', async () => {
-    mockFetch({});
-    await client.create({
+  it('POSTs a config with the config body as an OBJECT, and parses the create RECEIPT', async () => {
+    mockFetch({
+      id: cfgId,
+      version_id: 'v1',
+      slug: 'pc-sdk-ve-14620d',
+      object: 'config',
+    });
+    const receipt = await client.create({
       name: 'vertex-airs',
       workspace_id: wsId,
       config: { retry: { attempts: 3 }, cache: { mode: 'simple' } },
@@ -89,6 +94,33 @@ describe('AIGatewayConfigsClient', () => {
     const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
     expect(typeof body.config).toBe('object');
     expect((init as RequestInit).method).toBe('POST');
+
+    // The create receipt does NOT carry the full record's fields.
+    expect(receipt.slug).toBe('pc-sdk-ve-14620d');
+    expect((receipt as unknown as { name?: string }).name).toBeUndefined();
+    expect((receipt as unknown as { config?: string }).config).toBeUndefined();
+    expect((receipt as unknown as { status?: string }).status).toBeUndefined();
+  });
+
+  it('DELETEs a config with no organisation_id param and no responseSchema', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(''),
+    });
+    await expect(client.delete(cfgId)).resolves.toBeUndefined();
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const u = new URL(url as string);
+    expect(u.pathname).toBe(`/configs/${cfgId}`);
+    expect(u.searchParams.get('organisation_id')).toBeNull();
+    expect((init as RequestInit).method).toBe('DELETE');
+  });
+
+  it('rejects delete with an invalid configId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.delete('not-a-uuid')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it('rejects list with an invalid workspaceId before issuing a request', async () => {

--- a/test/ai-gateway/guardrails-client.spec.ts
+++ b/test/ai-gateway/guardrails-client.spec.ts
@@ -4,17 +4,48 @@ import type { AuthAdapter } from '../../src/http/types.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 const wsId = '16f7e90d-382a-4e78-b577-1b01eb5f8297';
+const grId = '9f6c2a8e-2b3d-4e5f-8a9b-0c1d2e3f4a5b';
 
 function passthroughAuth(): AuthAdapter {
   return { prepare: async (req) => req };
 }
-function mockFetch(data: unknown) {
+function mockFetch(data: unknown, text?: string) {
   globalThis.fetch = vi.fn().mockResolvedValue({
     ok: true,
     status: 200,
-    text: () => Promise.resolve(JSON.stringify(data)),
+    text: () => Promise.resolve(text ?? JSON.stringify(data)),
   });
 }
+
+// Detail read (GET /guardrails/{id}) — real shape, verified live.
+const sampleGuardrailDetail = {
+  checks: [
+    {
+      id: 'panw-prisma-airs.intercept',
+      parameters: { profile_name: 'AI Gateway - Strict', ai_model: '', app_user: '' },
+      is_enabled: true,
+    },
+  ],
+  actions: {
+    deny: false,
+    async: false,
+    sequential: false,
+    on_success: { feedback: { value: 5, weight: 1, metadata: '' } },
+    on_fail: { feedback: { value: -5, weight: 1, metadata: '' } },
+  },
+  version_id: 'v1',
+  created_at: '2026-07-17T00:42:44.000Z',
+  id: grId,
+  name: 'PrismaAIRS',
+  slug: 'pg-prisma-099a16',
+  organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+  status: 'active',
+  owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+  updated_by: null,
+  last_updated_at: '2026-07-17T00:42:44.000Z',
+  workspace_id: wsId,
+  object: 'guardrail',
+};
 
 describe('AIGatewayGuardrailsClient', () => {
   const originalFetch = globalThis.fetch;
@@ -31,24 +62,60 @@ describe('AIGatewayGuardrailsClient', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('lists guardrails scoped to a workspace', async () => {
-    mockFetch({ object: 'list', total: 1, data: [{ id: 'pg-prisma-099a16', name: 'PrismaAIRS' }] });
+  it('lists guardrails scoped to a workspace, returning list rows with no checks/actions', async () => {
+    mockFetch({
+      object: 'list',
+      total: 1,
+      data: [
+        {
+          id: grId,
+          name: 'PrismaAIRS',
+          slug: 'pg-prisma-099a16',
+          organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+          status: 'active',
+          owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+          updated_by: null,
+          created_at: '2026-07-17T00:42:44.000Z',
+          last_updated_at: '2026-07-17T00:42:44.000Z',
+          workspace_id: wsId,
+          object: 'guardrail',
+        },
+      ],
+    });
     const res = await client.list({ workspaceId: wsId });
 
-    expect(res.data[0].id).toBe('pg-prisma-099a16');
+    expect(res.data[0].slug).toBe('pg-prisma-099a16');
+    expect(res.data[0].updated_by).toBeNull();
+    expect((res.data[0] as unknown as { checks?: unknown }).checks).toBeUndefined();
     const u = new URL((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string);
     expect(u.pathname).toBe('/guardrails');
     expect(u.searchParams.get('workspace_id')).toBe(wsId);
   });
 
-  it('POSTs a guardrail with checks and actions', async () => {
-    mockFetch({});
-    await client.create({
+  it('fetches one guardrail detail, with the real panw-prisma-airs.intercept check id', async () => {
+    mockFetch(sampleGuardrailDetail);
+    const res = await client.get(grId);
+
+    expect(res.checks[0].id).toBe('panw-prisma-airs.intercept');
+    expect(res.actions.on_success?.feedback.value).toBe(5);
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`https://gw.example.com/guardrails/${grId}`);
+  });
+
+  it('rejects get with an invalid guardrailId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.get('not-a-uuid')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs a guardrail with checks and actions, and parses the create RECEIPT', async () => {
+    mockFetch({ id: grId, version_id: 'v1', slug: 'pg-sdk-ve-874b62', object: 'guardrail' });
+    const receipt = await client.create({
       workspace_id: wsId,
       name: 'PrismaAIRS',
       checks: [
         {
-          id: 'panw.prisma-airs.intercept',
+          id: 'panw-prisma-airs.intercept',
           parameters: { profile_name: 'AI Gateway - Strict' },
           is_enabled: true,
         },
@@ -60,6 +127,29 @@ describe('AIGatewayGuardrailsClient', () => {
     expect((init as RequestInit).method).toBe('POST');
     const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
     expect(Array.isArray(body.checks)).toBe(true);
+
+    // The create receipt does NOT carry the full record's fields.
+    expect(receipt.slug).toBe('pg-sdk-ve-874b62');
+    expect((receipt as unknown as { name?: string }).name).toBeUndefined();
+    expect((receipt as unknown as { checks?: unknown }).checks).toBeUndefined();
+    expect((receipt as unknown as { actions?: unknown }).actions).toBeUndefined();
+  });
+
+  it('DELETEs a guardrail with no organisation_id param and no responseSchema', async () => {
+    mockFetch(undefined, '');
+    await expect(client.delete(grId)).resolves.toBeUndefined();
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const u = new URL(url as string);
+    expect(u.pathname).toBe(`/guardrails/${grId}`);
+    expect(u.searchParams.get('organisation_id')).toBeNull();
+    expect((init as RequestInit).method).toBe('DELETE');
+  });
+
+  it('rejects delete with an invalid guardrailId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.delete('not-a-uuid')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it('rejects a non-UUID workspaceId in list() before issuing a request', async () => {

--- a/test/ai-gateway/providers-client.spec.ts
+++ b/test/ai-gateway/providers-client.spec.ts
@@ -4,15 +4,16 @@ import type { AuthAdapter } from '../../src/http/types.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 const wsId = '16f7e90d-382a-4e78-b577-1b01eb5f8297';
+const providerId = 'f6692544-3265-49be-9711-bbdcebc079e4';
 
 function passthroughAuth(): AuthAdapter {
   return { prepare: async (req) => req };
 }
-function mockFetch(data: unknown) {
+function mockFetch(data: unknown, text?: string) {
   globalThis.fetch = vi.fn().mockResolvedValue({
     ok: true,
     status: 200,
-    text: () => Promise.resolve(JSON.stringify(data)),
+    text: () => Promise.resolve(text ?? JSON.stringify(data)),
   });
 }
 
@@ -45,12 +46,12 @@ describe('AIGatewayProvidersClient', () => {
     expect(u.searchParams.get('workspace_id')).toBe(wsId);
   });
 
-  it('POSTs a provider binding to /providers', async () => {
-    mockFetch({});
-    await client.create({
+  it('POSTs a provider binding to /providers, and parses the create RECEIPT (no version_id)', async () => {
+    mockFetch({ id: providerId, slug: 'sdk-verify-delete-me-provider', object: 'provider' });
+    const receipt = await client.create({
       workspace_id: wsId,
       ai_provider_id: 'de7d7d50-31cd-11ee-b93b-0e06f1aa7f7c',
-      integration_id: 'f6692544-3265-49be-9711-bbdcebc079e4',
+      integration_id: providerId,
       name: 'openai-calvin',
       slug: 'openai-calvin',
     });
@@ -60,6 +61,28 @@ describe('AIGatewayProvidersClient', () => {
     expect((init as RequestInit).method).toBe('POST');
     const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
     expect(body.slug).toBe('openai-calvin');
+
+    // The create receipt does NOT carry the full record's fields, and has NO version_id.
+    expect(receipt.slug).toBe('sdk-verify-delete-me-provider');
+    expect((receipt as unknown as { version_id?: string }).version_id).toBeUndefined();
+    expect((receipt as unknown as { name?: string }).name).toBeUndefined();
+  });
+
+  it('DELETEs a provider with no organisation_id param and no responseSchema', async () => {
+    mockFetch(undefined, '');
+    await expect(client.delete(providerId)).resolves.toBeUndefined();
+
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const u = new URL(url as string);
+    expect(u.pathname).toBe(`/providers/${providerId}`);
+    expect(u.searchParams.get('organisation_id')).toBeNull();
+    expect((init as RequestInit).method).toBe('DELETE');
+  });
+
+  it('rejects delete with an invalid providerId before issuing a request', async () => {
+    globalThis.fetch = vi.fn();
+    await expect(client.delete('not-a-uuid')).rejects.toThrow(AISecSDKException);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it('rejects a non-UUID workspaceId in list() before issuing a request', async () => {

--- a/test/models/ai-gateway.spec.ts
+++ b/test/models/ai-gateway.spec.ts
@@ -9,6 +9,11 @@ import {
   ListWorkspacesResponseSchema,
   ListConfigsResponseSchema,
   GatewayConfigDetailSchema,
+  GatewayConfigCreateResponseSchema,
+  ListGuardrailsResponseSchema,
+  GatewayGuardrailDetailSchema,
+  GatewayGuardrailCreateResponseSchema,
+  GatewayProviderCreateResponseSchema,
   ListDeploymentsResponseSchema,
   GatewayDeploymentCreateResponseSchema,
   GatewayAuditLogsResponseSchema,
@@ -222,6 +227,121 @@ describe('AI Gateway resource schemas', () => {
       object: 'config',
     });
     expect(typeof r.config).toBe('string');
+  });
+
+  it('parses the config CREATE receipt, which is NOT the record shape', () => {
+    const r = GatewayConfigCreateResponseSchema.parse({
+      id: '764cf9cd-4ebf-449e-b669-08149b0fbbbc',
+      version_id: 'v1',
+      slug: 'pc-sdk-ve-14620d',
+      object: 'config',
+    });
+    expect(r.slug).toBe('pc-sdk-ve-14620d');
+    expect((r as unknown as { name?: string }).name).toBeUndefined();
+    expect((r as unknown as { config?: string }).config).toBeUndefined();
+  });
+
+  it('parses a guardrail LIST row — 11 fields, no checks/actions/version_id', () => {
+    const r = ListGuardrailsResponseSchema.parse({
+      object: 'list',
+      total: 1,
+      data: [
+        {
+          id: '9f6c2a8e-2b3d-4e5f-8a9b-0c1d2e3f4a5b',
+          name: 'PrismaAIRS',
+          slug: 'pg-prisma-099a16',
+          organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+          status: 'active',
+          owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+          updated_by: null,
+          created_at: '2026-07-17T00:42:44.000Z',
+          last_updated_at: '2026-07-17T00:42:44.000Z',
+          workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+          object: 'guardrail',
+        },
+      ],
+    });
+    expect(r.data[0].slug).toBe('pg-prisma-099a16');
+    expect(r.data[0].updated_by).toBeNull();
+    expect((r.data[0] as unknown as { checks?: unknown }).checks).toBeUndefined();
+  });
+
+  it('parses a guardrail DETAIL read, adding checks/actions/version_id', () => {
+    const r = GatewayGuardrailDetailSchema.parse({
+      checks: [
+        {
+          id: 'panw-prisma-airs.intercept',
+          parameters: { profile_name: 'AI Gateway - Strict', ai_model: '', app_user: '' },
+          is_enabled: true,
+        },
+      ],
+      actions: {
+        deny: false,
+        async: false,
+        sequential: false,
+        on_success: { feedback: { value: 5, weight: 1, metadata: '' } },
+        on_fail: { feedback: { value: -5, weight: 1, metadata: '' } },
+      },
+      version_id: 'v1',
+      created_at: '2026-07-17T00:42:44.000Z',
+      id: '9f6c2a8e-2b3d-4e5f-8a9b-0c1d2e3f4a5b',
+      name: 'PrismaAIRS',
+      slug: 'pg-prisma-099a16',
+      organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+      status: 'active',
+      owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+      updated_by: null,
+      last_updated_at: '2026-07-17T00:42:44.000Z',
+      workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+      object: 'guardrail',
+    });
+    expect(r.checks[0].id).toBe('panw-prisma-airs.intercept');
+    expect(r.actions.on_success?.feedback.value).toBe(5);
+    expect(r.updated_by).toBeNull();
+  });
+
+  it('parses a guardrail DETAIL read without on_success/on_fail (optional)', () => {
+    const r = GatewayGuardrailDetailSchema.parse({
+      checks: [],
+      actions: { deny: false, async: false, sequential: false },
+      version_id: 'v1',
+      created_at: '2026-07-17T00:42:44.000Z',
+      id: '9f6c2a8e-2b3d-4e5f-8a9b-0c1d2e3f4a5b',
+      name: 'no-feedback',
+      slug: 'pg-no-feedback',
+      organisation_id: '80f1e8db-1efe-49a7-a45b-b45cade4d861',
+      status: 'active',
+      owner_id: 'fad91538-65a9-41f7-8b9c-6e4c0e8b9c5f',
+      updated_by: null,
+      last_updated_at: '2026-07-17T00:42:44.000Z',
+      workspace_id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+      object: 'guardrail',
+    });
+    expect(r.actions.on_success).toBeUndefined();
+    expect(r.actions.on_fail).toBeUndefined();
+  });
+
+  it('parses the guardrail CREATE receipt, which is NOT the record shape', () => {
+    const r = GatewayGuardrailCreateResponseSchema.parse({
+      id: '9f6c2a8e-2b3d-4e5f-8a9b-0c1d2e3f4a5b',
+      version_id: 'v1',
+      slug: 'pg-sdk-ve-874b62',
+      object: 'guardrail',
+    });
+    expect(r.slug).toBe('pg-sdk-ve-874b62');
+    expect((r as unknown as { checks?: unknown }).checks).toBeUndefined();
+    expect((r as unknown as { actions?: unknown }).actions).toBeUndefined();
+  });
+
+  it('parses the provider CREATE receipt, which has NO version_id unlike configs/guardrails', () => {
+    const r = GatewayProviderCreateResponseSchema.parse({
+      id: 'f6692544-3265-49be-9711-bbdcebc079e4',
+      slug: 'sdk-verify-delete-me-provider',
+      object: 'provider',
+    });
+    expect(r.slug).toBe('sdk-verify-delete-me-provider');
+    expect((r as unknown as { version_id?: string }).version_id).toBeUndefined();
+    expect((r as unknown as { name?: string }).name).toBeUndefined();
   });
 
   it('parses an MCP integration, keeping configurations as an unparsed JSON STRING', () => {


### PR DESCRIPTION
## Summary
- Tighten `configs.create()`/`guardrails.create()`/`providers.create()` to resource-specific receipt schemas (verified live 2026-07-28 create→read→delete): configs/guardrails return `{id, version_id, slug, object}`, providers returns `{id, slug, object}` (no `version_id`).
- Add `configs.delete()`, `guardrails.delete()`, `providers.delete()` — hard delete (gone from `list()`), unlike `deployments.delete()` which archives.
- Add `guardrails.get()` with a verified detail schema (`checks[]`, `actions` w/ optional feedback, `version_id`); tighten the guardrail list-row schema to match reality (no checks/actions/version_id).
- Fix guardrail check id typo (`panw-prisma-airs.intercept`, not `panw.prisma-airs.intercept`) in JSDoc examples, `examples/ai-gateway.ts`, docs-site guide, README.
- Extend `scripts/smoke-ai-gateway.ts` with `guardrails.get()` (read-only, no new write calls).
- Bump to 0.14.1 (`SDK_VERSION`, `package.json`, release notes).

PRD updated in the vault (outside this repo) with the verified shapes, delete-semantics correction, and a new `AB08` error code.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npm run docs:check`
- [x] `npm run build`
- [x] `npm test` (1528 passed, up from 1514 baseline)