### PR TITLE
feat(red-team): add adapters client for custom target adapter management

### DIFF
--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -11,8 +11,8 @@ Six methods: `create()`, `list()`, `get()`, `update()`, `delete()`, and `validat
 Semantics worth knowing:
 
 - **`update()` is a full replacement (PUT), not a patch** — `name`, `script_b64`, and `prompt` are required. For `variables`, the list defines the complete key set: a provided value sets it, `null` keeps the stored value (unchanged secrets), and omitting a key deletes it.
-- **Secrets are write-only.** Response variables come back with `value: null` and `is_redacted: true` for `SECRET`-typed entries.
-- **`validate()` returns the script's execution outcome** — `{ validated, stdout, stderr, traceback }` — not an adapter record. Pass `adapter_uuid` to resolve an existing adapter's stored secrets into the run.
+- **Secrets are write-only.** `SECRET`-typed response variables come back with `is_redacted: true` and the value masked as `'**********'` (the upstream spec documents `null` here; the live API returns the placeholder — key off `is_redacted`). Pass the masked variable back together with `adapter_uuid` and the stored value is resolved server-side.
+- **`validate()` returns the script's execution outcome** — `{ validated, stdout, stderr, traceback }` — not an adapter record. You must still send the full `variables` array: `adapter_uuid` resolves redacted values *within* it, it does not supply the list. Omitting `variables` runs the script with none set, which usually surfaces as a `KeyError` in `stderr` rather than a clear error.
 - **List rows are a 7-field subset** (no `script_b64`, `tsg_id`, or `variables`); call `get()` for the full record.
 
 Target request schemas gain `adapter_uuid` and `adapter_variable_overrides` (an array of `AdapterVar`, not a map) so `CUSTOM_TARGET_ADAPTER` targets are fully typed.

--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -1,5 +1,22 @@
 # Release Notes
 
+## v0.16.0
+
+### Red Team custom target adapters
+
+New `rt.adapters` sub-client for the `/v1/adapters` management-plane API, contributed by [@thresh97](https://github.com/thresh97) — the SDK's first external contribution. Custom target adapters are Python scripts deployed into an adapter sidecar alongside the network broker client, giving full control over how attack prompts reach targets with non-standard auth, dynamic tokens, or multi-turn session state.
+
+Six methods: `create()`, `list()`, `get()`, `update()`, `delete()`, and `validate()`. Create and update take a `validate` option (default `true`, matching the server): validated scripts save as `ACTIVE`, unvalidated as `DRAFT`. Validation requires the network broker channel client (v1.4.0+) to be running and ONLINE.
+
+Semantics worth knowing:
+
+- **`update()` is a full replacement (PUT), not a patch** — `name`, `script_b64`, and `prompt` are required. For `variables`, the list defines the complete key set: a provided value sets it, `null` keeps the stored value (unchanged secrets), and omitting a key deletes it.
+- **Secrets are write-only.** Response variables come back with `value: null` and `is_redacted: true` for `SECRET`-typed entries.
+- **`validate()` returns the script's execution outcome** — `{ validated, stdout, stderr, traceback }` — not an adapter record. Pass `adapter_uuid` to resolve an existing adapter's stored secrets into the run.
+- **List rows are a 7-field subset** (no `script_b64`, `tsg_id`, or `variables`); call `get()` for the full record.
+
+Target request schemas gain `adapter_uuid` and `adapter_variable_overrides` (an array of `AdapterVar`, not a map) so `CUSTOM_TARGET_ADAPTER` targets are fully typed.
+
 ## v0.15.0
 
 ### Workspace management

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -157,6 +157,8 @@ export const RED_TEAM_ERROR_LOG_TARGET_PROFILE_PATH = '/v1/error-log/target-prof
 // API paths — red team management plane
 export const RED_TEAM_TARGET_PATH = '/v1/target';
 export const RED_TEAM_TARGET_VALIDATE_AUTH_PATH = '/v1/target/validate-auth';
+export const RED_TEAM_ADAPTER_PATH = '/v1/adapters';
+export const RED_TEAM_ADAPTER_VALIDATE_PATH = '/v1/adapters/validate';
 export const RED_TEAM_TEMPLATE_PATH = '/v1/template';
 export const RED_TEAM_EULA_PATH = '/v1/eula';
 export const RED_TEAM_INSTANCES_PATH = '/v1/instances';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.15.0';
+export const SDK_VERSION = '0.16.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/models/red-team.ts
+++ b/src/models/red-team.ts
@@ -1053,6 +1053,78 @@ export type TenantLanguagesResponse = z.infer<typeof TenantLanguagesResponseSche
 // ---------------------------------------------------------------------------
 
 /** Shared base fields for target create, update, and probe requests. */
+// ---------------------------------------------------------------------------
+// Adapter variable — used in AdapterCreateRequest.variables and
+// TargetCreateRequest.adapter_variable_overrides
+// ---------------------------------------------------------------------------
+
+export const AdapterVarTypeSchema = z.enum(['VAR', 'SECRET']);
+export type AdapterVarType = z.infer<typeof AdapterVarTypeSchema>;
+
+export const AdapterVarSchema = z.object({
+  key: z.string().max(255),
+  value: z.string().nullable().optional(),
+  type: AdapterVarTypeSchema,
+});
+export type AdapterVar = z.infer<typeof AdapterVarSchema>;
+
+// ---------------------------------------------------------------------------
+// Adapter create / update / response
+// ---------------------------------------------------------------------------
+
+export const AdapterCreateRequestSchema = z
+  .object({
+    name: z.string().max(255),
+    description: z.string().nullable().optional(),
+    script_b64: z.string(),
+    network_broker_channel_uuid: z.string().uuid().nullable().optional(),
+    variables: z.array(AdapterVarSchema).optional(),
+    /** Sample prompt used to exercise the adapter end-to-end during validation. Not stored. */
+    prompt: z.string(),
+  })
+  .strict();
+export type AdapterCreateRequest = z.infer<typeof AdapterCreateRequestSchema>;
+
+export const AdapterUpdateRequestSchema = z
+  .object({
+    name: z.string().max(255).optional(),
+    description: z.string().nullable().optional(),
+    script_b64: z.string().optional(),
+    network_broker_channel_uuid: z.string().uuid().nullable().optional(),
+    variables: z.array(AdapterVarSchema).optional(),
+    prompt: z.string().optional(),
+  })
+  .strict();
+export type AdapterUpdateRequest = z.infer<typeof AdapterUpdateRequestSchema>;
+
+export const AdapterResponseSchema = z
+  .object({
+    uuid: z.string().uuid(),
+    tsg_id: z.string().optional(), // absent from list responses, present on get/create
+    name: z.string(),
+    description: z.string().nullable().optional(),
+    status: z.string(),
+    network_broker_channel_uuid: z.string().uuid().nullable().optional(),
+    variables: z
+      .array(AdapterVarSchema.extend({ value: z.string().nullable().optional() }))
+      .optional(),
+    target_count: z.number().nullable().optional(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    created_by_user_id: z.string().uuid().nullable().optional(),
+    updated_by_user_id: z.string().uuid().nullable().optional(),
+  })
+  .passthrough();
+export type AdapterResponse = z.infer<typeof AdapterResponseSchema>;
+
+export const AdapterListSchema = z
+  .object({
+    pagination: z.object({ total_items: z.number().optional() }).passthrough().optional(),
+    data: z.array(AdapterResponseSchema).optional(),
+  })
+  .passthrough();
+export type AdapterList = z.infer<typeof AdapterListSchema>;
+
 const TargetRequestBaseFields = {
   name: z.string(),
   description: z.string().nullable().optional(),
@@ -1070,6 +1142,10 @@ const TargetRequestBaseFields = {
   additional_context: TargetAdditionalContextSchema.nullable().optional(),
   extra_info: z.record(z.unknown()).nullable().optional(),
   network_broker_channel_uuid: z.string().nullable().optional(),
+  /** UUID of the custom target adapter to use. Required when connection_type is CUSTOM_TARGET_ADAPTER. */
+  adapter_uuid: z.string().uuid().nullable().optional(),
+  /** Per-target overrides for the adapter's variables. Array of AdapterVar objects. */
+  adapter_variable_overrides: z.array(AdapterVarSchema).nullable().optional(),
 } as const;
 
 export const TargetCreateRequestSchema = z.object(TargetRequestBaseFields).strict();

--- a/src/models/red-team.ts
+++ b/src/models/red-team.ts
@@ -1049,18 +1049,20 @@ export const TenantLanguagesResponseSchema = z
 export type TenantLanguagesResponse = z.infer<typeof TenantLanguagesResponseSchema>;
 
 // ---------------------------------------------------------------------------
-// Management — Target schemas
+// Management — Custom target adapters (spec: mp-openapi 0.7.67, Adapters service)
 // ---------------------------------------------------------------------------
 
-/** Shared base fields for target create, update, and probe requests. */
-// ---------------------------------------------------------------------------
-// Adapter variable — used in AdapterCreateRequest.variables and
-// TargetCreateRequest.adapter_variable_overrides
-// ---------------------------------------------------------------------------
-
+/** Whether an adapter configuration variable is a plain var or a sensitive secret. */
 export const AdapterVarTypeSchema = z.enum(['VAR', 'SECRET']);
 export type AdapterVarType = z.infer<typeof AdapterVarTypeSchema>;
 
+/**
+ * A single adapter configuration variable, as *sent* in requests (spec `AdapterVarBase`).
+ * Also the shape of `TargetCreateRequest.adapter_variable_overrides` entries.
+ *
+ * On update, `value: null` means "keep the existing value" — the mechanism for leaving a
+ * secret unchanged, since secret values are never returned.
+ */
 export const AdapterVarSchema = z.object({
   key: z.string().max(255),
   value: z.string().nullable().optional(),
@@ -1068,15 +1070,21 @@ export const AdapterVarSchema = z.object({
 });
 export type AdapterVar = z.infer<typeof AdapterVarSchema>;
 
-// ---------------------------------------------------------------------------
-// Adapter create / update / response
-// ---------------------------------------------------------------------------
+/**
+ * A variable as *returned* in adapter responses (spec `AdapterVarResponseSchema`).
+ * Secrets are masked: `value` comes back `null` with `is_redacted: true`.
+ */
+export const AdapterVarResponseSchema = AdapterVarSchema.extend({
+  is_redacted: z.boolean().optional(),
+}).passthrough();
+export type AdapterVarResponse = z.infer<typeof AdapterVarResponseSchema>;
 
 export const AdapterCreateRequestSchema = z
   .object({
     name: z.string().max(255),
     description: z.string().nullable().optional(),
     script_b64: z.string(),
+    /** Optional while the adapter is a DRAFT; required to activate (`validate: true`). */
     network_broker_channel_uuid: z.string().uuid().nullable().optional(),
     variables: z.array(AdapterVarSchema).optional(),
     /** Sample prompt used to exercise the adapter end-to-end during validation. Not stored. */
@@ -1085,46 +1093,117 @@ export const AdapterCreateRequestSchema = z
   .strict();
 export type AdapterCreateRequest = z.infer<typeof AdapterCreateRequestSchema>;
 
+/**
+ * Update is a **full replacement** (PUT): `name`, `script_b64`, and `prompt` are required,
+ * exactly as on create — this is not a partial patch.
+ *
+ * `variables` defines the complete desired key set:
+ * - value provided → set/add the value
+ * - value `null`   → keep the existing value (unchanged secrets)
+ * - key omitted    → **delete** the variable
+ */
 export const AdapterUpdateRequestSchema = z
   .object({
-    name: z.string().max(255).optional(),
+    name: z.string().max(255),
     description: z.string().nullable().optional(),
-    script_b64: z.string().optional(),
+    script_b64: z.string(),
     network_broker_channel_uuid: z.string().uuid().nullable().optional(),
     variables: z.array(AdapterVarSchema).optional(),
-    prompt: z.string().optional(),
+    prompt: z.string(),
   })
   .strict();
 export type AdapterUpdateRequest = z.infer<typeof AdapterUpdateRequestSchema>;
 
+/**
+ * Full adapter record (spec `CustomTargetAdapterSchema`) — returned by get, create, and update.
+ * List rows use the smaller {@link AdapterListItemSchema}.
+ *
+ * `status` values are `DRAFT` | `ACTIVE`; kept as an open string per house convention so a
+ * new upstream status cannot break response parsing.
+ */
 export const AdapterResponseSchema = z
   .object({
     uuid: z.string().uuid(),
-    tsg_id: z.string().optional(), // absent from list responses, present on get/create
+    tsg_id: z.string(),
     name: z.string(),
-    description: z.string().nullable().optional(),
+    script_b64: z.string(),
     status: z.string(),
+    description: z.string().nullable().optional(),
     network_broker_channel_uuid: z.string().uuid().nullable().optional(),
-    variables: z
-      .array(AdapterVarSchema.extend({ value: z.string().nullable().optional() }))
-      .optional(),
-    target_count: z.number().nullable().optional(),
-    created_at: z.string(),
-    updated_at: z.string(),
+    variables: z.array(AdapterVarResponseSchema).optional(),
+    /** Number of targets currently referencing this adapter. */
+    target_count: z.number().int().optional(),
+    created_at: z.string().nullable().optional(),
+    updated_at: z.string().nullable().optional(),
     created_by_user_id: z.string().uuid().nullable().optional(),
     updated_by_user_id: z.string().uuid().nullable().optional(),
   })
   .passthrough();
 export type AdapterResponse = z.infer<typeof AdapterResponseSchema>;
 
+/**
+ * One list row (spec `CustomTargetAdapterListItemSchema`) — a 7-field subset. List rows carry
+ * no `script_b64`, `tsg_id`, `description`, or `variables`; call `get()` for the full record.
+ * `target_count` is populated only when the list was requested with `include_target_count`.
+ */
+export const AdapterListItemSchema = z
+  .object({
+    uuid: z.string().uuid(),
+    name: z.string(),
+    status: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    created_by_user_id: z.string().uuid().nullable().optional(),
+    target_count: z.number().int().nullable().optional(),
+  })
+  .passthrough();
+export type AdapterListItem = z.infer<typeof AdapterListItemSchema>;
+
 export const AdapterListSchema = z
   .object({
-    pagination: z.object({ total_items: z.number().optional() }).passthrough().optional(),
-    data: z.array(AdapterResponseSchema).optional(),
+    pagination: RedTeamPaginationSchema,
+    data: z.array(AdapterListItemSchema).optional(),
   })
   .passthrough();
 export type AdapterList = z.infer<typeof AdapterListSchema>;
 
+/**
+ * Request for `POST /v1/adapters/validate` (spec `CustomTargetAdapterValidateRequestSchema`).
+ * Deliberately NOT the create request: there is no `name`, `network_broker_channel_uuid` is
+ * **required**, and `adapter_uuid` may reference an existing adapter so redacted/`null`
+ * variable values are resolved from its stored secret before validation.
+ */
+export const AdapterValidateRequestSchema = z
+  .object({
+    script_b64: z.string(),
+    network_broker_channel_uuid: z.string().uuid(),
+    prompt: z.string(),
+    variables: z.array(AdapterVarSchema).optional(),
+    /** Omit when validating a brand-new adapter. */
+    adapter_uuid: z.string().uuid().nullable().optional(),
+  })
+  .strict();
+export type AdapterValidateRequest = z.infer<typeof AdapterValidateRequestSchema>;
+
+/**
+ * Result of a validation run (spec `CustomTargetAdapterValidateResponseSchema`) — the script's
+ * execution outcome, not an adapter record.
+ */
+export const AdapterValidateResponseSchema = z
+  .object({
+    validated: z.boolean(),
+    stdout: z.string().nullable().optional(),
+    stderr: z.string().nullable().optional(),
+    traceback: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type AdapterValidateResponse = z.infer<typeof AdapterValidateResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Management — Target schemas
+// ---------------------------------------------------------------------------
+
+/** Shared base fields for target create, update, and probe requests. */
 const TargetRequestBaseFields = {
   name: z.string(),
   description: z.string().nullable().optional(),

--- a/src/models/red-team.ts
+++ b/src/models/red-team.ts
@@ -1072,7 +1072,11 @@ export type AdapterVar = z.infer<typeof AdapterVarSchema>;
 
 /**
  * A variable as *returned* in adapter responses (spec `AdapterVarResponseSchema`).
- * Secrets are masked: `value` comes back `null` with `is_redacted: true`.
+ *
+ * Secrets are masked with `is_redacted: true`. The spec says the masked `value` is `null`, but a
+ * live tenant returns the literal placeholder string `'**********'` (verified 2026-08-01) — so
+ * treat `is_redacted`, not the value, as the signal. Either form round-trips: pass the variable
+ * back on validate/update alongside `adapter_uuid` and the real value is resolved from storage.
  */
 export const AdapterVarResponseSchema = AdapterVarSchema.extend({
   is_redacted: z.boolean().optional(),

--- a/src/red-team/adapters-client.ts
+++ b/src/red-team/adapters-client.ts
@@ -6,11 +6,14 @@ import { assertUuid } from '../validators.js';
 import {
   AdapterResponseSchema,
   AdapterListSchema,
+  AdapterValidateResponseSchema,
   BaseResponseSchema,
   type AdapterCreateRequest,
   type AdapterUpdateRequest,
+  type AdapterValidateRequest,
   type AdapterResponse,
   type AdapterList,
+  type AdapterValidateResponse,
   type BaseResponse,
 } from '../models/red-team.js';
 import type { RedTeamListOptions } from './scans-client.js';
@@ -148,15 +151,24 @@ export class RedTeamAdaptersClient {
   }
 
   /**
-   * Update an existing adapter.
+   * Update an adapter. **Full replacement (PUT), not a patch** — `name`, `script_b64`, and
+   * `prompt` are required just as on create. For `variables`, the list defines the complete
+   * desired key set: a provided value sets it, `null` keeps the stored value (unchanged
+   * secrets), and omitting a key **deletes** that variable.
    * @param uuid - Adapter UUID.
-   * @param body - Fields to update (all optional).
-   * @param opts - Set validate: false to save without re-running the script.
+   * @param body - The complete adapter definition.
+   * @param opts - Set validate: false to save as DRAFT without re-running the script.
    * @returns The updated adapter.
    * @example
    * ```ts
    * const updated = await rt.adapters.update('550e8400-...', {
+   *   name: 'my-keycloak-agent',
    *   script_b64: Buffer.from(newScript).toString('base64'),
+   *   prompt: 'What is the capital of France?',
+   *   variables: [
+   *     { key: 'endpoint', value: 'http://agent.svc:8080', type: 'VAR' },
+   *     { key: 'client_secret', value: null, type: 'SECRET' }, // null keeps stored secret
+   *   ],
    * });
    * ```
    */
@@ -201,28 +213,32 @@ export class RedTeamAdaptersClient {
   }
 
   /**
-   * Validate an adapter script without saving it.
-   * Runs the script against the configured target using the sample prompt.
-   * @param body - Same payload as create (minus any uuid).
-   * @returns The would-be adapter response if validation passes.
+   * Validate an adapter script without saving anything. Runs the script end-to-end through the
+   * network broker channel using the sample prompt, and returns the execution outcome —
+   * `validated` plus the script's `stdout` / `stderr` / `traceback` — not an adapter record.
+   *
+   * This endpoint has its own request shape: no `name`, `network_broker_channel_uuid` is
+   * required, and `adapter_uuid` may reference an existing adapter so `null` variable values
+   * are resolved from its stored secrets before the run.
+   * @param body - Script, channel, prompt, and optionally variables / an existing adapter UUID.
+   * @returns The validation outcome.
    * @example
    * ```ts
    * const result = await rt.adapters.validate({
-   *   name: 'test',
    *   script_b64: Buffer.from(script).toString('base64'),
    *   network_broker_channel_uuid: '550e8400-...',
-   *   variables: [],
    *   prompt: 'Hello',
    * });
+   * if (!result.validated) console.error(result.stderr ?? result.traceback);
    * ```
    */
-  async validate(body: AdapterCreateRequest): Promise<AdapterResponse> {
+  async validate(body: AdapterValidateRequest): Promise<AdapterValidateResponse> {
     return request({
       method: 'POST',
       baseUrl: this.baseUrl,
       path: RED_TEAM_ADAPTER_VALIDATE_PATH,
       body,
-      responseSchema: AdapterResponseSchema,
+      responseSchema: AdapterValidateResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/red-team/adapters-client.ts
+++ b/src/red-team/adapters-client.ts
@@ -1,0 +1,230 @@
+import { RED_TEAM_ADAPTER_PATH, RED_TEAM_ADAPTER_VALIDATE_PATH } from '../constants.js';
+import { request } from '../http/request.js';
+import type { AuthAdapter } from '../http/types.js';
+import { serializeListing } from '../listing.js';
+import { assertUuid } from '../validators.js';
+import {
+  AdapterResponseSchema,
+  AdapterListSchema,
+  BaseResponseSchema,
+  type AdapterCreateRequest,
+  type AdapterUpdateRequest,
+  type AdapterResponse,
+  type AdapterList,
+  type BaseResponse,
+} from '../models/red-team.js';
+import type { RedTeamListOptions } from './scans-client.js';
+
+/** Options for adapter create/update operations. */
+export interface AdapterOperationOptions {
+  /**
+   * Run the adapter script end-to-end against its configured target during save.
+   * When true the adapter is saved as ACTIVE on success, DRAFT on failure.
+   * When false (or omitted) the adapter is saved as DRAFT without validation.
+   * Note: requires the network channel client (v1.4.0+) to be running and ONLINE.
+   */
+  validate?: boolean;
+}
+
+/** @internal */
+export interface RedTeamAdaptersClientOptions {
+  baseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+}
+
+/**
+ * Client for Red Team custom target adapter operations (management plane).
+ *
+ * Custom target adapters are Python scripts that run inside an adapter sidecar
+ * alongside the network broker client pod. They give full control over how
+ * attack prompts are delivered to targets that use non-standard protocols,
+ * dynamic auth, or multi-turn session handling.
+ *
+ * @example
+ * ```ts
+ * import { RedTeamClient } from '@cdot65/prisma-airs-sdk';
+ * const rt = new RedTeamClient();
+ *
+ * const adapter = await rt.adapters.create({
+ *   name: 'my-keycloak-agent',
+ *   script_b64: Buffer.from(pythonScript).toString('base64'),
+ *   network_broker_channel_uuid: '550e8400-e29b-41d4-a716-446655440000',
+ *   variables: [
+ *     { key: 'endpoint', value: 'http://agent.svc:8080/v1/chat/completions', type: 'VAR' },
+ *     { key: 'client_secret', value: 'changeme', type: 'SECRET' },
+ *   ],
+ *   prompt: 'What is the capital of France?',
+ * });
+ * // adapter.status => 'ACTIVE'  (when validate=true, default)
+ * ```
+ */
+export class RedTeamAdaptersClient {
+  private readonly baseUrl: string;
+  private readonly auth: AuthAdapter;
+  private readonly numRetries: number;
+
+  constructor(opts: RedTeamAdaptersClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.auth = opts.auth;
+    this.numRetries = opts.numRetries;
+  }
+
+  /**
+   * Create a new custom target adapter.
+   * @param body - Adapter creation request (name, base64 script, variables, validation prompt).
+   * @param opts - Set validate: false to save as DRAFT without running the script.
+   * @returns The created adapter.
+   * @example
+   * ```ts
+   * const adapter = await rt.adapters.create({
+   *   name: 'my-adapter',
+   *   script_b64: Buffer.from(script).toString('base64'),
+   *   network_broker_channel_uuid: '550e8400-...',
+   *   variables: [{ key: 'endpoint', value: 'http://...', type: 'VAR' }],
+   *   prompt: 'Hello',
+   * }, { validate: true });
+   * ```
+   */
+  async create(
+    body: AdapterCreateRequest,
+    opts?: AdapterOperationOptions,
+  ): Promise<AdapterResponse> {
+    const validate = opts?.validate ?? true;
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_ADAPTER_PATH,
+      params: { validate: String(validate) },
+      body,
+      responseSchema: AdapterResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * List adapters with optional pagination.
+   * @param opts - Optional limit/skip/search.
+   * @returns Paginated list of adapters.
+   * @example
+   * ```ts
+   * const { data } = await rt.adapters.list({ limit: 20 });
+   * // data => [{ uuid: '...', name: 'my-adapter', status: 'ACTIVE' }]
+   * ```
+   */
+  async list(opts?: RedTeamListOptions): Promise<AdapterList> {
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_ADAPTER_PATH,
+      params: serializeListing(opts),
+      responseSchema: AdapterListSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Get a single adapter by UUID.
+   * @param uuid - Adapter UUID.
+   * @returns The adapter detail.
+   * @example
+   * ```ts
+   * const adapter = await rt.adapters.get('550e8400-e29b-41d4-a716-446655440000');
+   * // adapter.status => 'ACTIVE'
+   * ```
+   */
+  async get(uuid: string): Promise<AdapterResponse> {
+    assertUuid(uuid, 'adapter uuid');
+    return request({
+      method: 'GET',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_ADAPTER_PATH}/${uuid}`,
+      responseSchema: AdapterResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Update an existing adapter.
+   * @param uuid - Adapter UUID.
+   * @param body - Fields to update (all optional).
+   * @param opts - Set validate: false to save without re-running the script.
+   * @returns The updated adapter.
+   * @example
+   * ```ts
+   * const updated = await rt.adapters.update('550e8400-...', {
+   *   script_b64: Buffer.from(newScript).toString('base64'),
+   * });
+   * ```
+   */
+  async update(
+    uuid: string,
+    body: AdapterUpdateRequest,
+    opts?: AdapterOperationOptions,
+  ): Promise<AdapterResponse> {
+    assertUuid(uuid, 'adapter uuid');
+    const validate = opts?.validate ?? true;
+    return request({
+      method: 'PUT',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_ADAPTER_PATH}/${uuid}`,
+      params: { validate: String(validate) },
+      body,
+      responseSchema: AdapterResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Delete an adapter.
+   * @param uuid - Adapter UUID.
+   * @example
+   * ```ts
+   * await rt.adapters.delete('550e8400-e29b-41d4-a716-446655440000');
+   * ```
+   */
+  async delete(uuid: string): Promise<BaseResponse | undefined> {
+    assertUuid(uuid, 'adapter uuid');
+    return request<BaseResponse | undefined>({
+      method: 'DELETE',
+      baseUrl: this.baseUrl,
+      path: `${RED_TEAM_ADAPTER_PATH}/${uuid}`,
+      responseSchema: BaseResponseSchema.optional(),
+      allowEmptyBody: true,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Validate an adapter script without saving it.
+   * Runs the script against the configured target using the sample prompt.
+   * @param body - Same payload as create (minus any uuid).
+   * @returns The would-be adapter response if validation passes.
+   * @example
+   * ```ts
+   * const result = await rt.adapters.validate({
+   *   name: 'test',
+   *   script_b64: Buffer.from(script).toString('base64'),
+   *   network_broker_channel_uuid: '550e8400-...',
+   *   variables: [],
+   *   prompt: 'Hello',
+   * });
+   * ```
+   */
+  async validate(body: AdapterCreateRequest): Promise<AdapterResponse> {
+    return request({
+      method: 'POST',
+      baseUrl: this.baseUrl,
+      path: RED_TEAM_ADAPTER_VALIDATE_PATH,
+      body,
+      responseSchema: AdapterResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+}

--- a/src/red-team/client.ts
+++ b/src/red-team/client.ts
@@ -27,6 +27,7 @@ import { RedTeamCustomAttacksClient } from './custom-attacks-client.js';
 import { RedTeamEulaClient } from './eula-client.js';
 import { RedTeamInstancesClient } from './instances-client.js';
 import { RedTeamNetworkBrokerClient } from './network-broker-client.js';
+import { RedTeamAdaptersClient } from './adapters-client.js';
 import {
   ScanStatisticsResponseSchema,
   ScoreTrendResponseSchema,
@@ -96,6 +97,8 @@ export class RedTeamClient {
   public readonly instances: RedTeamInstancesClient;
   /** Network broker channel operations (distinct network broker base URL). */
   public readonly networkBroker: RedTeamNetworkBrokerClient;
+  /** Management plane custom target adapter operations. */
+  public readonly adapters: RedTeamAdaptersClient;
 
   private readonly dataEndpoint: string;
   private readonly mgmtEndpoint: string;
@@ -144,6 +147,7 @@ export class RedTeamClient {
     });
     this.eula = new RedTeamEulaClient({ baseUrl: mgmtEndpoint, auth, numRetries });
     this.instances = new RedTeamInstancesClient({ baseUrl: mgmtEndpoint, auth, numRetries });
+    this.adapters = new RedTeamAdaptersClient({ baseUrl: mgmtEndpoint, auth, numRetries });
     this.networkBroker = new RedTeamNetworkBrokerClient({
       baseUrl: networkBrokerEndpoint,
       auth,

--- a/src/red-team/index.ts
+++ b/src/red-team/index.ts
@@ -36,3 +36,8 @@ export {
   type RedTeamNetworkBrokerClientOptions,
   type ChannelListOptions,
 } from './network-broker-client.js';
+export {
+  RedTeamAdaptersClient,
+  type RedTeamAdaptersClientOptions,
+  type AdapterOperationOptions,
+} from './adapters-client.js';

--- a/test/red-team/_fixtures.ts
+++ b/test/red-team/_fixtures.ts
@@ -350,3 +350,49 @@ export function channelStatsMock(overrides: Record<string, unknown> = {}): Recor
     ...overrides,
   };
 }
+
+/** Spec-shaped CustomTargetAdapterSchema mock (get/create/update responses). */
+export function adapterMock(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    uuid: VALID_UUID,
+    tsg_id: 'tsg-1',
+    name: 'keycloak-agent',
+    script_b64: 'cHJpbnQoImhpIik=',
+    status: 'ACTIVE',
+    description: null,
+    network_broker_channel_uuid: VALID_UUID,
+    variables: [
+      { key: 'endpoint', value: 'http://agent.svc:8080', type: 'VAR', is_redacted: false },
+      { key: 'client_secret', value: null, type: 'SECRET', is_redacted: true },
+    ],
+    created_at: isoNow,
+    updated_at: isoNow,
+    created_by_user_id: VALID_UUID,
+    updated_by_user_id: null,
+    target_count: 0,
+    ...overrides,
+  };
+}
+
+/** Spec-shaped CustomTargetAdapterListItemSchema mock — 7 fields, no script/tsg_id/variables. */
+export function adapterListItemMock(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    uuid: VALID_UUID,
+    name: 'keycloak-agent',
+    status: 'DRAFT',
+    created_at: isoNow,
+    updated_at: isoNow,
+    created_by_user_id: null,
+    target_count: null,
+    ...overrides,
+  };
+}
+
+/** Spec-shaped CustomTargetAdapterValidateResponseSchema mock. */
+export function adapterValidateResultMock(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return { validated: true, stdout: 'ok', stderr: null, traceback: null, ...overrides };
+}

--- a/test/red-team/adapters-client.spec.ts
+++ b/test/red-team/adapters-client.spec.ts
@@ -106,6 +106,23 @@ describe('RedTeamAdaptersClient', () => {
       expect(secret?.is_redacted).toBe(true);
     });
 
+    // Live tenants mask secrets with the literal string '**********' rather than the `null`
+    // the spec documents (verified 2026-08-01). Both forms must parse — callers key off
+    // `is_redacted`, and either value round-trips through validate/update with adapter_uuid.
+    it('parses the masked-placeholder form of a redacted secret', async () => {
+      mockFetch(
+        adapterMock({
+          variables: [
+            { key: 'client_secret', value: '**********', type: 'SECRET', is_redacted: true },
+          ],
+        }),
+      );
+      const result = await client.get(VALID_UUID);
+      const secret = result.variables?.[0];
+      expect(secret?.value).toBe('**********');
+      expect(secret?.is_redacted).toBe(true);
+    });
+
     it('rejects a non-UUID before issuing a request', async () => {
       globalThis.fetch = vi.fn();
       await expect(client.get('not-a-uuid')).rejects.toThrow(AISecSDKException);

--- a/test/red-team/adapters-client.spec.ts
+++ b/test/red-team/adapters-client.spec.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RedTeamAdaptersClient } from '../../src/red-team/adapters-client.js';
+import type { AuthAdapter } from '../../src/http/types.js';
+import { AISecSDKException } from '../../src/errors.js';
+import {
+  VALID_UUID,
+  adapterMock,
+  adapterListItemMock,
+  adapterValidateResultMock,
+  paginatedListMock,
+} from './_fixtures.js';
+
+function passthroughAuth(): AuthAdapter {
+  return { prepare: async (req) => req };
+}
+
+function mockFetch(data: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(typeof data === 'string' ? data : JSON.stringify(data)),
+  });
+}
+
+const createBody = {
+  name: 'keycloak-agent',
+  script_b64: 'cHJpbnQoImhpIik=',
+  prompt: 'Hello',
+};
+
+describe('RedTeamAdaptersClient', () => {
+  const originalFetch = globalThis.fetch;
+  let client: RedTeamAdaptersClient;
+
+  beforeEach(() => {
+    client = new RedTeamAdaptersClient({
+      baseUrl: 'https://mgmt.example.com',
+      auth: passthroughAuth(),
+      numRetries: 0,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('create', () => {
+    it('POSTs to /v1/adapters with validate=true by default (matches the server default)', async () => {
+      mockFetch(adapterMock(), 201);
+      const result = await client.create(createBody);
+
+      expect(result.uuid).toBe(VALID_UUID);
+      expect(result.status).toBe('ACTIVE');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://mgmt.example.com/v1/adapters?validate=true');
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body as string)).toEqual(createBody);
+    });
+
+    it('serializes validate=false', async () => {
+      mockFetch(adapterMock({ status: 'DRAFT' }), 201);
+      await client.create(createBody, { validate: false });
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://mgmt.example.com/v1/adapters?validate=false');
+    });
+
+    // Spec: created_at/updated_at are nullable on CustomTargetAdapterSchema.
+    it('parses a response with null timestamps', async () => {
+      mockFetch(adapterMock({ created_at: null, updated_at: null }), 201);
+      const result = await client.create(createBody);
+      expect(result.created_at).toBeNull();
+    });
+  });
+
+  describe('list', () => {
+    // Spec: list rows are CustomTargetAdapterListItemSchema — a 7-field subset with no
+    // script_b64 / tsg_id / variables. They must parse without those fields.
+    it('GETs /v1/adapters and parses spec-shaped list items', async () => {
+      mockFetch(paginatedListMock([adapterListItemMock()]));
+      const result = await client.list({ limit: 20 });
+
+      expect(result.data?.[0].name).toBe('keycloak-agent');
+      expect(result.pagination.total_items).toBe(1);
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://mgmt.example.com/v1/adapters?limit=20');
+    });
+  });
+
+  describe('get', () => {
+    it('GETs /v1/adapters/{uuid}', async () => {
+      mockFetch(adapterMock());
+      const result = await client.get(VALID_UUID);
+
+      expect(result.script_b64).toBe('cHJpbnQoImhpIik=');
+      expect(result.tsg_id).toBe('tsg-1');
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe(`https://mgmt.example.com/v1/adapters/${VALID_UUID}`);
+    });
+
+    it('surfaces is_redacted on secret variables', async () => {
+      mockFetch(adapterMock());
+      const result = await client.get(VALID_UUID);
+      const secret = result.variables?.find((v) => v.type === 'SECRET');
+      expect(secret?.value).toBeNull();
+      expect(secret?.is_redacted).toBe(true);
+    });
+
+    it('rejects a non-UUID before issuing a request', async () => {
+      globalThis.fetch = vi.fn();
+      await expect(client.get('not-a-uuid')).rejects.toThrow(AISecSDKException);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    // Spec: PUT is a full replacement — name, script_b64, prompt all required.
+    it('PUTs the full replacement body to /v1/adapters/{uuid}', async () => {
+      mockFetch(adapterMock());
+      await client.update(VALID_UUID, createBody);
+
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe(`https://mgmt.example.com/v1/adapters/${VALID_UUID}?validate=true`);
+      expect(init.method).toBe('PUT');
+    });
+
+    it('rejects a non-UUID before issuing a request', async () => {
+      globalThis.fetch = vi.fn();
+      await expect(client.update('nope', createBody)).rejects.toThrow(AISecSDKException);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('DELETEs and resolves undefined on a 204 empty body', async () => {
+      mockFetch('', 204);
+      const result = await client.delete(VALID_UUID);
+
+      expect(result).toBeUndefined();
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe(`https://mgmt.example.com/v1/adapters/${VALID_UUID}`);
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('rejects a non-UUID before issuing a request', async () => {
+      globalThis.fetch = vi.fn();
+      await expect(client.delete('nope')).rejects.toThrow(AISecSDKException);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validate', () => {
+    // Spec: /v1/adapters/validate has its OWN request shape (no name; network broker channel
+    // required; optional adapter_uuid for stored-secret resolution) and its own response
+    // ({ validated, stdout, stderr, traceback }) — NOT the adapter record.
+    it('POSTs the validate-specific body and parses the validate-specific response', async () => {
+      mockFetch(adapterValidateResultMock());
+      const result = await client.validate({
+        script_b64: 'cHJpbnQoImhpIik=',
+        network_broker_channel_uuid: VALID_UUID,
+        prompt: 'Hello',
+      });
+
+      expect(result.validated).toBe(true);
+      expect(result.stdout).toBe('ok');
+      const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://mgmt.example.com/v1/adapters/validate');
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body as string)).not.toHaveProperty('name');
+    });
+
+    it('parses a failed validation with stderr and traceback', async () => {
+      mockFetch(
+        adapterValidateResultMock({
+          validated: false,
+          stdout: null,
+          stderr: 'ModuleNotFoundError: requests',
+          traceback: 'Traceback (most recent call last): ...',
+        }),
+      );
+      const result = await client.validate({
+        script_b64: 'cHJpbnQoImhpIik=',
+        network_broker_channel_uuid: VALID_UUID,
+        prompt: 'Hello',
+      });
+
+      expect(result.validated).toBe(false);
+      expect(result.stderr).toContain('ModuleNotFoundError');
+    });
+
+    it('forwards adapter_uuid so stored secrets can be resolved', async () => {
+      mockFetch(adapterValidateResultMock());
+      await client.validate({
+        script_b64: 'cHJpbnQoImhpIik=',
+        network_broker_channel_uuid: VALID_UUID,
+        prompt: 'Hello',
+        adapter_uuid: VALID_UUID,
+      });
+
+      const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(JSON.parse(init.body as string).adapter_uuid).toBe(VALID_UUID);
+    });
+  });
+});

--- a/test/red-team/client.spec.ts
+++ b/test/red-team/client.spec.ts
@@ -6,6 +6,7 @@ import { RedTeamCustomAttackReportsClient } from '../../src/red-team/custom-atta
 import { RedTeamTargetsClient } from '../../src/red-team/targets-client.js';
 import { RedTeamCustomAttacksClient } from '../../src/red-team/custom-attacks-client.js';
 import { RedTeamNetworkBrokerClient } from '../../src/red-team/network-broker-client.js';
+import { RedTeamAdaptersClient } from '../../src/red-team/adapters-client.js';
 import { AISecSDKException } from '../../src/errors.js';
 
 const validUuid = '550e8400-e29b-41d4-a716-446655440000';
@@ -31,6 +32,22 @@ describe('RedTeamClient', () => {
     expect(client.targets).toBeInstanceOf(RedTeamTargetsClient);
     expect(client.customAttacks).toBeInstanceOf(RedTeamCustomAttacksClient);
     expect(client.networkBroker).toBeInstanceOf(RedTeamNetworkBrokerClient);
+    expect(client.adapters).toBeInstanceOf(RedTeamAdaptersClient);
+  });
+
+  // adapters is a management-plane sub-client; a data-plane swap would send every adapter
+  // call to the wrong host. Reads the private baseUrl through a test-only cast, matching
+  // how the AI Gateway plane-wiring assertions work.
+  it('wires adapters to the management plane', () => {
+    const client = new RedTeamClient({
+      clientId: 'cid',
+      clientSecret: 'csec',
+      tsgId: '999',
+      mgmtEndpoint: 'https://mgmt.example.com',
+      dataEndpoint: 'https://data.example.com',
+    });
+    const baseUrlOf = (c: object): string => (c as unknown as { baseUrl: string }).baseUrl;
+    expect(baseUrlOf(client.adapters)).toBe('https://mgmt.example.com');
   });
 
   it('accepts a custom network broker endpoint', () => {


### PR DESCRIPTION
## Summary

Adds `rt.adapters` — a missing sub-client for the `/v1/adapters` management plane API. Custom target adapters are Python scripts deployed into an adapter sidecar pod alongside the network broker client. They give full control over how attack prompts reach targets with non-standard auth, dynamic tokens, or multi-turn session state.

Without this client, adapter management requires raw API calls. This PR puts adapters on equal footing with targets, scans, and network broker channels.

## What's added

**`src/red-team/adapters-client.ts`** — new `RedTeamAdaptersClient`:
- `rt.adapters.create(body, { validate? })` — POST /v1/adapters
- `rt.adapters.list(opts?)` — GET /v1/adapters
- `rt.adapters.get(uuid)` — GET /v1/adapters/{uuid}
- `rt.adapters.update(uuid, body, { validate? })` — PUT /v1/adapters/{uuid}
- `rt.adapters.delete(uuid)` — DELETE /v1/adapters/{uuid} (204 no-body, uses `allowEmptyBody: true`)
- `rt.adapters.validate(body)` — POST /v1/adapters/validate

**`src/models/red-team.ts`** — new Zod schemas:
- `AdapterVarType` (enum: VAR | SECRET)
- `AdapterVar` — `{ key, value, type }` — used in both adapter variables and target overrides
- `AdapterCreateRequest`, `AdapterUpdateRequest`, `AdapterResponse`, `AdapterList`
- `TargetCreateRequestSchema` / `TargetUpdateRequestSchema` extended with `adapter_uuid` and `adapter_variable_overrides` (array of AdapterVar — the API requires an array, not a dict) so CUSTOM_TARGET_ADAPTER targets are fully typed

**`src/constants.ts`** — `RED_TEAM_ADAPTER_PATH`, `RED_TEAM_ADAPTER_VALIDATE_PATH`

**`src/red-team/client.ts` + `index.ts`** — wires `this.adapters` into `RedTeamClient`; exports client + types

## Test plan

- [x] All pre-commit checks pass (lint, format, typecheck, 1528 tests — 11 pre-existing env-var-dependent failures unaffected)
- [x] **Live e2e against real API:**
  - `rt.adapters.list()` ✓
  - `rt.adapters.get(uuid)` ✓
  - `rt.adapters.create({ validate: false })` ✓ → DRAFT
  - `rt.adapters.delete(uuid)` ✓ → 204
  - `TargetCreateRequestSchema.safeParse({ adapter_uuid, adapter_variable_overrides })` ✓ valid

## Companion PR

[cdot65/prisma-airs-cli#298](https://github.com/cdot65/prisma-airs-cli/pull/298) — CLI fixes (scan category default, target init scaffold) that motivated this PR. The CLI's `airs redteam adapters` subcommand can be built on top of this client once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)