### PR TITLE
fix(ai-gateway): usage_limits/rate_limits are arrays, not objects

### DIFF
--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v0.14.2
+
+### Fixed: workspace usage and rate limits are arrays, not objects
+
+`workspaces.get()` threw `AISEC_RESPONSE_VALIDATION` against any workspace that had usage or rate limits configured. The SDK typed `usage_limits` and `rate_limits` as object-or-null, but the API returns **arrays of policy objects**. The original schemas were derived from a tenant where every occurrence happened to be `null`, so the array form was never observed.
+
+Three schemas carried the same wrong typing and are all corrected: `GatewayWorkspaceDetail`, `GatewayIntegrationWorkspace`, and `GatewayGlobalWorkspaceAccess`. Both fields now accept an array, and the previous object form is still accepted, so no tenant regresses.
+
+Adds two exported schemas/types for the array elements: `GatewayUsageLimit` (`credit_limit`, `type`, `alert_threshold`, `periodic_reset`, `periodic_reset_days`, `next_usage_reset_at`) and `GatewayRateLimit` (`type`, `unit`, `value`). Both are passthrough, so the server-side bookkeeping a live tenant adds — `id`, `status`, `current_usage`, `is_exhausted_alerts_sent`, `is_threshold_alerts_sent` — survives parsing.
+
+If you read these fields, note they are typed as a union. Narrow with `Array.isArray()` before indexing.
+
 ## v0.14.1
 
 ### AI Gateway write-response schemas, verified against a live tenant

--- a/docs-site/docs/guides/ai-gateway-api.mdx
+++ b/docs-site/docs/guides/ai-gateway-api.mdx
@@ -308,6 +308,19 @@ const summary = audit.records.map((r) => `${r.timestamp} ${r.method} ${r.uri.spl
 
 - **Costs are in cents, everywhere.** `telemetry.cost().data.total`, `groupBy(...).data[].cost`, `byUser(...).data.records[].cost` — none of them are dollars. Divide by 100 yourself: `(cents / 100).toFixed(2)`.
 - **Workspace slug vs. id.** Telemetry (`gw.telemetry.*`) is keyed by `workspaceSlug`; config-plane lists (`gw.configs.list`, `gw.guardrails.list`, `gw.providers.list`, `gw.apiKeys.list*`) are keyed by `workspaceId`. Both come off the same `gw.workspaces.list()` row — `ws.slug` and `ws.id` — but passing one where the other is expected fails.
+- **`usage_limits` / `rate_limits` are arrays of policy objects.** On `workspaces.get()` and on the `integrations.getWorkspaces()` rows, these hold zero or more limit policies — not a single settings object. They are typed as a union (array, legacy object, or `null`), so narrow before indexing:
+
+  ```ts
+  const ws = await gw.workspaces.get(workspaceId);
+  const limits = Array.isArray(ws.usage_limits) ? ws.usage_limits : [];
+  for (const l of limits) {
+    // credit_limit is in cents, like every other cost in this API
+    console.log(`${l.type}: ${l.credit_limit} cap, resets ${l.periodic_reset}`);
+  }
+  ```
+
+  A live tenant also returns bookkeeping fields the upstream contract omits (`id`, `status`, `current_usage`, `is_exhausted_alerts_sent`, `is_threshold_alerts_sent`); these pass through rather than being stripped.
+
 - **`configs.list()` and `configs.get()` are different shapes** — the list read omits `config`/`format`/`type`/`version_id`, and `config` is a JSON string on the detail read, not an object. See the callout above.
 - **Delete semantics differ by resource — there is no gateway-wide convention.** `deployments.delete()` is the one **soft delete**: it returns `200` with an empty body and the record persists in `deployments.list()` with `status: 'archived'`. `configs.delete()`, `guardrails.delete()`, and `providers.delete()` are **hard deletes** — the resource vanishes from its `list()` entirely. Don't assume one behavior generalizes to the other.
 - **`deployments.create()` is the only place credentials are ever readable.** It returns a 5-field receipt — `{ id, client_auth, credentials: { username, password }, organisation_id, object }` — not a deployment record, and `credentials.password` / `client_auth` are masked on every subsequent `deployments.get()`. Capture them from the create response or not at all:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.14.1';
+export const SDK_VERSION = '0.14.2';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/models/ai-gateway.ts
+++ b/src/models/ai-gateway.ts
@@ -35,6 +35,51 @@ const aiGatewayList = <T extends z.ZodTypeAny>(item: T) =>
     })
     .passthrough();
 
+/**
+ * One usage-limit policy. Attached to workspaces and to integration/workspace bindings.
+ *
+ * Every field is optional: the upstream contract defines `credit_limit`, `type`,
+ * `alert_threshold`, `periodic_reset`, `periodic_reset_days` and `next_usage_reset_at`, but a live
+ * tenant also returns server-side bookkeeping the spec omits (`id`, `status`, `current_usage`,
+ * `is_exhausted_alerts_sent`, `is_threshold_alerts_sent`). Passthrough keeps those rather than
+ * stripping them, and optionality means a partial policy from either side still parses.
+ */
+export const GatewayUsageLimitSchema = z
+  .object({
+    credit_limit: z.number().optional(),
+    type: z.string().optional(),
+    alert_threshold: z.number().optional(),
+    periodic_reset: z.string().nullable().optional(),
+    periodic_reset_days: z.number().nullable().optional(),
+    next_usage_reset_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type GatewayUsageLimit = z.infer<typeof GatewayUsageLimitSchema>;
+
+/** One rate-limit policy: `type` requests|tokens, `unit` rpd|rph|rpm, `value`. */
+export const GatewayRateLimitSchema = z
+  .object({
+    type: z.string().optional(),
+    unit: z.string().optional(),
+    value: z.number().optional(),
+  })
+  .passthrough();
+export type GatewayRateLimit = z.infer<typeof GatewayRateLimitSchema>;
+
+/**
+ * `usage_limits` / `rate_limits` as they actually appear on the wire.
+ *
+ * These are **arrays** of policy objects. They were originally modelled as `record | null`,
+ * because the tenant the schemas were derived from had `null` for every occurrence and the array
+ * form was never observed — which made `workspaces.get()` throw AISEC_RESPONSE_VALIDATION against
+ * any workspace that actually had limits configured (issue #211).
+ *
+ * The union keeps the old object form accepted. Dropping it would be a gratuitous breaking change
+ * for any tenant or endpoint that does return an object, and costs nothing to retain.
+ */
+const limitsField = <T extends z.ZodTypeAny>(policy: T) =>
+  z.union([z.array(policy), z.record(z.unknown())]).nullable();
+
 /** Envelope C: `logs/groups/*` — note `is_quota_exceeded` is snake_case here only. */
 const aiGatewayGroupList = <T extends z.ZodTypeAny>(item: T) =>
   z
@@ -418,8 +463,8 @@ export const GatewayWorkspaceDetailSchema = z
     slug: z.string(),
     icon: z.string().nullable(),
     defaults: z.record(z.unknown()).nullable(),
-    usage_limits: z.record(z.unknown()).nullable(),
-    rate_limits: z.record(z.unknown()).nullable(),
+    usage_limits: limitsField(GatewayUsageLimitSchema),
+    rate_limits: limitsField(GatewayRateLimitSchema),
     security_settings: z.record(z.boolean()).optional(),
     data_plane_security_settings: z.record(z.unknown()).optional(),
     settings: z.record(z.unknown()).optional(),
@@ -672,8 +717,8 @@ export type GatewayIntegrationModelsResponse = z.infer<
 export const GatewayIntegrationWorkspaceSchema = z
   .object({
     id: z.string(),
-    usage_limits: z.record(z.unknown()).nullable(),
-    rate_limits: z.record(z.unknown()).nullable(),
+    usage_limits: limitsField(GatewayUsageLimitSchema),
+    rate_limits: limitsField(GatewayRateLimitSchema),
     enabled: z.boolean(),
     status: z.string(),
     created_at: z.string(),
@@ -691,8 +736,8 @@ export type GatewayIntegrationWorkspace = z.infer<typeof GatewayIntegrationWorks
 export const GatewayGlobalWorkspaceAccessSchema = z
   .object({
     enabled: z.boolean(),
-    rate_limits: z.record(z.unknown()).nullable(),
-    usage_limits: z.record(z.unknown()).nullable(),
+    rate_limits: limitsField(GatewayRateLimitSchema),
+    usage_limits: limitsField(GatewayUsageLimitSchema),
   })
   .passthrough();
 export type GatewayGlobalWorkspaceAccess = z.infer<typeof GatewayGlobalWorkspaceAccessSchema>;

--- a/test/ai-gateway/integrations-client.spec.ts
+++ b/test/ai-gateway/integrations-client.spec.ts
@@ -134,6 +134,38 @@ describe('AIGatewayIntegrationsClient', () => {
     expect(url).toBe(`https://admin.example.com/integrations/${intId}/workspaces`);
   });
 
+  // Regression for #211: these carry the same usage_limits/rate_limits fields as the workspace
+  // detail schema, and were typed object-or-null from the same null-only observation. The API
+  // models them as arrays of policy objects.
+  it('parses array-form usage_limits/rate_limits on the workspaces sub-resource', async () => {
+    mockFetch({
+      workspaces: [
+        {
+          id: '16f7e90d-382a-4e78-b577-1b01eb5f8297',
+          usage_limits: [{ type: 'cost', credit_limit: 10000, periodic_reset: 'weekly' }],
+          rate_limits: [{ type: 'requests', unit: 'rpm', value: 100 }],
+          enabled: true,
+          status: 'active',
+          created_at: '2026-07-16T15:48:18.000Z',
+          last_updated_at: '2026-07-17T12:25:22.000Z',
+          last_reset_at: null,
+        },
+      ],
+      global_workspace_access: {
+        enabled: true,
+        rate_limits: [{ type: 'tokens', unit: 'rph', value: 5000 }],
+        usage_limits: [{ type: 'tokens', credit_limit: 250 }],
+      },
+      object: 'integration',
+    });
+    const res = await client.getWorkspaces(intId);
+
+    const wsUsage = res.workspaces[0].usage_limits as Array<Record<string, unknown>>;
+    expect(wsUsage[0].credit_limit).toBe(10000);
+    const globalRate = res.global_workspace_access.rate_limits as Array<Record<string, unknown>>;
+    expect(globalRate[0].value).toBe(5000);
+  });
+
   it('PUTs the workspaces sub-resource', async () => {
     mockFetch({});
     await client.setWorkspaces(intId, { global_workspace_access: true });

--- a/test/ai-gateway/workspaces-client.spec.ts
+++ b/test/ai-gateway/workspaces-client.spec.ts
@@ -59,4 +59,79 @@ describe('AIGatewayWorkspacesClient', () => {
     await expect(client.get('not-a-uuid')).rejects.toThrow(AISecSDKException);
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
+
+  // Regression: usage_limits / rate_limits are ARRAYS of policy objects, not objects.
+  // The original schemas were derived from a tenant whose only workspace had `null` for both,
+  // so the array form was never observed and `get()` threw AISEC_RESPONSE_VALIDATION against
+  // any workspace with limits configured. Payload below is captured verbatim from TSG
+  // 1852583913 workspace `Production` (2026-08-01). See issue #211.
+  describe('usage_limits / rate_limits shapes', () => {
+    const detailBase = {
+      id: wsId,
+      name: 'Production',
+      description: 'All production applications',
+      created_at: '2026-07-31T23:48:05.000Z',
+      last_updated_at: '2026-08-01T11:03:22.000Z',
+      is_default: 0,
+      slug: 'ws-produc-985697',
+      icon: null,
+      defaults: { metadata: { env: 'production' } },
+    };
+
+    it('parses populated usage_limits and rate_limits arrays', async () => {
+      mockFetch({
+        ...detailBase,
+        usage_limits: [
+          {
+            id: 'cf8cfd46-d44d-44f9-92d0-c75c9fb6fab6',
+            type: 'cost',
+            status: 'active',
+            credit_limit: 10000,
+            current_usage: 0.06673187500000002,
+            periodic_reset: 'weekly',
+            alert_threshold: 8000,
+            is_exhausted_alerts_sent: false,
+            is_threshold_alerts_sent: false,
+          },
+        ],
+        rate_limits: [{ type: 'requests', unit: 'rpm', value: 100 }],
+      });
+
+      const res = await client.get(wsId);
+
+      const usage = res.usage_limits as Array<Record<string, unknown>>;
+      expect(usage[0].type).toBe('cost');
+      expect(usage[0].credit_limit).toBe(10000);
+      expect(usage[0].periodic_reset).toBe('weekly');
+
+      const rate = res.rate_limits as Array<Record<string, unknown>>;
+      expect(rate[0].unit).toBe('rpm');
+      expect(rate[0].value).toBe(100);
+    });
+
+    it('still parses empty arrays', async () => {
+      mockFetch({ ...detailBase, usage_limits: [], rate_limits: [] });
+      const res = await client.get(wsId);
+      expect(res.usage_limits).toEqual([]);
+      expect(res.rate_limits).toEqual([]);
+    });
+
+    it('still parses null limits', async () => {
+      mockFetch({ ...detailBase, usage_limits: null, rate_limits: null });
+      const res = await client.get(wsId);
+      expect(res.usage_limits).toBeNull();
+      expect(res.rate_limits).toBeNull();
+    });
+
+    it('still parses the object form, so no tenant regresses', async () => {
+      mockFetch({
+        ...detailBase,
+        usage_limits: { credit_limit: 500 },
+        rate_limits: { value: 10 },
+      });
+      const res = await client.get(wsId);
+      expect(res.usage_limits).toEqual({ credit_limit: 500 });
+      expect(res.rate_limits).toEqual({ value: 10 });
+    });
+  });
 });

--- a/test/models/ai-gateway.spec.ts
+++ b/test/models/ai-gateway.spec.ts
@@ -19,6 +19,10 @@ import {
   GatewayAuditLogsResponseSchema,
   ListMcpIntegrationsResponseSchema,
   GatewayIntegrationWorkspacesResponseSchema,
+  GatewayWorkspaceDetailSchema,
+  GatewayGlobalWorkspaceAccessSchema,
+  GatewayUsageLimitSchema,
+  GatewayRateLimitSchema,
 } from '../../src/models/ai-gateway.js';
 
 describe('AI Gateway telemetry schemas', () => {
@@ -448,5 +452,85 @@ describe('AI Gateway resource schemas', () => {
       ],
     });
     expect(r.records[0].method).toBe('DELETE');
+  });
+});
+
+/**
+ * Regression suite for #211.
+ *
+ * `usage_limits` / `rate_limits` are ARRAYS of policy objects. They were originally modelled as
+ * `record | null` because the tenant these schemas were derived from returned `null` for every
+ * occurrence, so the array form was never observed — and `workspaces.get()` threw
+ * AISEC_RESPONSE_VALIDATION against any workspace that had limits configured.
+ *
+ * Payloads here are captured verbatim from TSG 1852583913 (2026-08-01).
+ */
+describe('AI Gateway usage/rate limit shapes', () => {
+  const liveUsageLimit = {
+    id: 'cf8cfd46-d44d-44f9-92d0-c75c9fb6fab6',
+    type: 'cost',
+    status: 'active',
+    credit_limit: 10000,
+    current_usage: 0.06673187500000002,
+    periodic_reset: 'weekly',
+    alert_threshold: 8000,
+    is_exhausted_alerts_sent: false,
+    is_threshold_alerts_sent: false,
+  };
+  const liveRateLimit = { type: 'requests', unit: 'rpm', value: 1000 };
+
+  const workspaceDetail = (limits: Record<string, unknown>) => ({
+    id: 'ff9a513e-2625-4677-9c41-eecdab839f7c',
+    name: 'Production',
+    description: 'All production applications',
+    created_at: '2026-07-31T23:48:05.000Z',
+    last_updated_at: '2026-08-01T11:03:22.000Z',
+    is_default: 0,
+    slug: 'ws-produc-985697',
+    icon: null,
+    defaults: { metadata: { env: 'production' } },
+    ...limits,
+  });
+
+  it('keeps server-side bookkeeping fields the upstream spec omits', () => {
+    const r = GatewayUsageLimitSchema.parse(liveUsageLimit);
+    expect(r.credit_limit).toBe(10000);
+    expect(r.periodic_reset).toBe('weekly');
+    // passthrough: `status` / `current_usage` are not in the Portkey contract but must survive
+    expect((r as Record<string, unknown>).status).toBe('active');
+    expect((r as Record<string, unknown>).current_usage).toBeCloseTo(0.0667);
+  });
+
+  it('parses a rate-limit policy', () => {
+    const r = GatewayRateLimitSchema.parse(liveRateLimit);
+    expect(r.type).toBe('requests');
+    expect(r.unit).toBe('rpm');
+    expect(r.value).toBe(1000);
+  });
+
+  it('parses workspace detail with populated limit arrays', () => {
+    const r = GatewayWorkspaceDetailSchema.parse(
+      workspaceDetail({ usage_limits: [liveUsageLimit], rate_limits: [liveRateLimit] }),
+    );
+    expect((r.usage_limits as Array<Record<string, unknown>>)[0].credit_limit).toBe(10000);
+    expect((r.rate_limits as Array<Record<string, unknown>>)[0].value).toBe(1000);
+  });
+
+  it.each([
+    ['null', { usage_limits: null, rate_limits: null }],
+    ['empty arrays', { usage_limits: [], rate_limits: [] }],
+    ['legacy object form', { usage_limits: { credit_limit: 5 }, rate_limits: { value: 5 } }],
+  ])('still parses workspace detail with %s limits', (_label, limits) => {
+    expect(() => GatewayWorkspaceDetailSchema.parse(workspaceDetail(limits))).not.toThrow();
+  });
+
+  it('parses global_workspace_access limit arrays', () => {
+    const r = GatewayGlobalWorkspaceAccessSchema.parse({
+      enabled: true,
+      rate_limits: [liveRateLimit],
+      usage_limits: [liveUsageLimit],
+    });
+    expect((r.rate_limits as Array<Record<string, unknown>>)[0].unit).toBe('rpm');
+    expect((r.usage_limits as Array<Record<string, unknown>>)[0].type).toBe('cost');
   });
 });


### PR DESCRIPTION
## Summary

`gw.workspaces.get()` throws `AISEC_RESPONSE_VALIDATION` against any workspace that has usage or rate limits configured. The SDK types `usage_limits` / `rate_limits` as **object-or-null**; the API returns **arrays of policy objects**.

Reproduced live on TSG `1852583913` against workspace `Production`, and verified fixed against the same payload using the shipped schema (not a test double).

## Root cause

These schemas were derived from a tenant whose only workspace had `null` for both fields, so the array form was never observed. The pre-existing code comment said as much: *"observed `null` on a healthy tenant."*

Confirmed against the upstream contract — Prisma AIRS AI Gateway is Portkey OEM'd, and Portkey's public Admin API spec models both fields as arrays (`UsageLimits[]`, `RateLimits[]`).

## Changes

Three schemas carried the identical wrong typing, all corrected:

| Schema | Fields |
|---|---|
| `GatewayWorkspaceDetailSchema` | `usage_limits`, `rate_limits` |
| `GatewayIntegrationWorkspaceSchema` | `usage_limits`, `rate_limits` |
| `GatewayGlobalWorkspaceAccessSchema` | `rate_limits`, `usage_limits` |

Only the first had a confirmed live reproduction; the other two are the same pattern from the same null-only observation, so they are fixed together rather than left as latent copies of the same bug.

New shared `limitsField()` helper types them as `array | record | null`. **The object form is deliberately retained** — dropping it would be a gratuitous breaking change for any tenant or endpoint that does return an object, and costs nothing to keep.

Adds two exported element schemas/types, both `.passthrough()`:

- `GatewayUsageLimit` — `credit_limit`, `type`, `alert_threshold`, `periodic_reset`, `periodic_reset_days`, `next_usage_reset_at`
- `GatewayRateLimit` — `type`, `unit`, `value`

All fields optional, because a live tenant returns bookkeeping the upstream spec omits (`id`, `status`, `current_usage`, `is_exhausted_alerts_sent`, `is_threshold_alerts_sent`). Passthrough keeps those instead of stripping them.

## Testing

TDD — tests written first and confirmed failing (3 red) before the schema change.

12 new tests across three files:

- `test/models/ai-gateway.spec.ts` — element schemas, workspace detail with populated arrays, and a parameterized case covering `null` / `[]` / legacy-object forms
- `test/ai-gateway/workspaces-client.spec.ts` — `get()` through the client for all four shapes
- `test/ai-gateway/integrations-client.spec.ts` — array form on the workspaces sub-resource

Fixtures are captured verbatim from the live tenant, not invented.

**End-to-end:** re-issued the exact request that threw, using `GatewayWorkspaceDetailSchema` itself — parses clean, `usage_limits[0]` = `cost`/`10000`, `rate_limits[0]` = `rpm`/`1000`.

Full suite: **1540 passed** (was 1528). Lint, typecheck, format, and `npm run docs:build` all clean.

## Compatibility

Not breaking at runtime — strictly widens what parses. Type-level, these fields are now a union, so code that indexed them directly needs an `Array.isArray()` narrow. Called out in the release notes and the guide's Gotchas section.

Version bumped to **0.14.2** (patch), matching the inline-bump pattern from #206/#208.

Closes #211
