### PR TITLE
feat(ai-gateway): workspace create/update/delete, status filter, slug refs

### DIFF
--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -1,5 +1,38 @@
 # Release Notes
 
+## v0.15.0
+
+### Workspace management
+
+`gw.workspaces` gains `create()`, `update()`, and `delete()`, all on the admin plane (`/ai_gw/admin/v2/workspaces`). Workspace lifecycle was previously impossible through the SDK.
+
+`create()` requires `name` and `scope_name`. `scope_name` is specific to Prisma AIRS and has no upstream equivalent: it is the SCM role scope that grants data-plane access to the new workspace. It is **not** derived from `name`, and a workspace created with a scope nobody holds will not appear in a data-plane `list()`.
+
+`delete()` is a **soft delete** — the workspace is archived, not destroyed. It disappears from a default `list()` but remains under `list({ status: 'archived' })`. Same semantics as `deployments.delete()`, the opposite of `configs`/`guardrails`/`providers`. There is no hard delete.
+
+Create and update responses are typed permissively and marked *"Shape unverified against a live tenant"*, matching the other unconfirmed AI Gateway writes. Follow a write with `get()` rather than trusting the returned body.
+
+### Fixed: `list()` was hiding workspaces two different ways
+
+`workspaces.list()` now takes an options object, because both of its previous defaults silently omitted rows:
+
+- **Archived workspaces were invisible**, with no way to ask for them. `list({ status: 'archived' })` now works; `status` is `'active' | 'archived'`.
+- **Only workspaces you were scoped to were returned.** The data plane lists just those your service account holds a workspace-scope grant on. `list({ plane: 'admin' })` enumerates the whole tenant.
+
+`list()` with no arguments behaves exactly as before.
+
+### Fixed: `get()` rejected valid identifiers
+
+`get()` validated its argument as a UUID, but the API accepts a workspace **slug** too — upstream documents the path parameter as *"Workspace UUID. Workspace slug is also accepted for backward compatibility."* `get('ws-produc-985697')` now works. `get()` also accepts `{ plane: 'admin' }`, the only way to read a workspace outside your workspace scope; on the data plane those return `403 AB03`, not `404`.
+
+### Fixed: workspace `description` can be null
+
+`GatewayWorkspace.description` and `GatewayWorkspaceDetail.description` were typed non-nullable. A workspace created without a description returns `null`, which threw `AISEC_RESPONSE_VALIDATION`. Both are now nullable, matching the upstream contract.
+
+### Note for direct sub-client construction
+
+`AIGatewayWorkspacesClient` now takes `AIGatewayWorkspacesClientOptions`, which adds a required `adminBaseUrl`. This affects only code constructing the sub-client directly; `new AIGatewayClient()` wires it automatically.
+
 ## v0.14.2
 
 ### Fixed: workspace usage and rate limits are arrays, not objects

--- a/docs-site/docs/guides/ai-gateway-api.mdx
+++ b/docs-site/docs/guides/ai-gateway-api.mdx
@@ -308,6 +308,22 @@ const summary = audit.records.map((r) => `${r.timestamp} ${r.method} ${r.uri.spl
 
 - **Costs are in cents, everywhere.** `telemetry.cost().data.total`, `groupBy(...).data[].cost`, `byUser(...).data.records[].cost` — none of them are dollars. Divide by 100 yourself: `(cents / 100).toFixed(2)`.
 - **Workspace slug vs. id.** Telemetry (`gw.telemetry.*`) is keyed by `workspaceSlug`; config-plane lists (`gw.configs.list`, `gw.guardrails.list`, `gw.providers.list`, `gw.apiKeys.list*`) are keyed by `workspaceId`. Both come off the same `gw.workspaces.list()` row — `ws.slug` and `ws.id` — but passing one where the other is expected fails.
+- **`workspaces.list()` hides rows by default — twice over.** It returns *active* workspaces only, and only those your service account holds a workspace-scope grant on. Neither omission is visible in the response. To see everything in the tenant:
+
+  ```ts
+  const mine = await gw.workspaces.list(); // active + scoped to you
+  const all = await gw.workspaces.list({ plane: 'admin' }); // every active workspace
+  const archived = await gw.workspaces.list({ plane: 'admin', status: 'archived' });
+  ```
+
+  There is no single call for "active and archived" — the filter is one or the other, so merge two reads if you need both.
+
+- **Workspace refs may be a UUID or a slug.** `gw.workspaces.get('ws-produc-985697')` is as valid as passing the UUID. Reading a workspace you are not scoped to needs `{ plane: 'admin' }` — on the data plane it returns `403 AB03`, not `404`, so a permission problem can read like a missing record.
+
+- **`workspaces.delete()` archives; it does not destroy.** The row survives under `list({ status: 'archived' })`. This matches `deployments.delete()` and contradicts `configs`/`guardrails`/`providers`, which hard delete. There is no hard delete for workspaces.
+
+- **`workspaces.create()` needs a `scope_name`.** It is the SCM role scope granting data-plane access to the new workspace, and it is not derived from `name`. Create one with a scope nobody holds and it simply will not appear in a data-plane `list()` — which is the most common way a freshly created workspace "goes missing".
+
 - **`usage_limits` / `rate_limits` are arrays of policy objects.** On `workspaces.get()` and on the `integrations.getWorkspaces()` rows, these hold zero or more limit policies — not a single settings object. They are typed as a union (array, legacy object, or `null`), so narrow before indexing:
 
   ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/scripts/ai-gateway-workspaces.ts
+++ b/scripts/ai-gateway-workspaces.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env tsx
+/**
+ * @internal
+ * AI Gateway — workspace CRUD from the command line.
+ *
+ * A thin CLI over `gw.workspaces.*`. Every call goes through the shipped SDK surface; this script
+ * holds no endpoint knowledge of its own.
+ *
+ * Two things about workspaces that catch people out, both handled here:
+ *
+ * 1. **The default list hides rows twice over.** `list()` returns only *active* workspaces, and
+ *    only those your service account holds a workspace-scope grant on. `list --all` widens both
+ *    (admin plane, no status filter) by merging an active and an archived admin-plane read.
+ * 2. **Delete archives, it does not destroy.** The workspace disappears from the default list but
+ *    remains under `--status archived`. There is no hard delete.
+ *
+ * VERIFICATION STATUS (probed live 2026-08-01 against TSG 1852583913):
+ *   list / get      VERIFIED, including the status filter, admin-plane routing, and slug refs.
+ *   create/update/delete  Endpoints exist and their request contracts are confirmed, but no 2xx
+ *                   has been observed — the SDK types those responses permissively and marks them
+ *                   "Shape unverified against a live tenant". Use --dry-run first, and follow any
+ *                   write with `get` rather than trusting the returned body.
+ *
+ * Requires PANW_AI_GW_* in the environment, falling back to PANW_MGMT_*. Writes and `--plane admin`
+ * need a tenant-root admin role; a workspace-scoped role alone yields 403.
+ *
+ * Usage:
+ *   set -a && source .env && set +a
+ *   npx tsx scripts/ai-gateway-workspaces.ts --help
+ */
+import { parseArgs } from 'node:util';
+
+import { AIGatewayClient, AISecSDKException } from '../src/index.js';
+import type {
+  GatewayWorkspaceCreateRequest,
+  GatewayWorkspaceUpdateRequest,
+} from '../src/ai-gateway/workspaces-client.js';
+import type { GatewayWorkspace } from '../src/models/ai-gateway.js';
+
+let asJson = false;
+
+function emit(label: string, value: unknown): void {
+  if (asJson) {
+    console.log(JSON.stringify(value, null, 2));
+    return;
+  }
+  console.log(`\n${label}`);
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function table(rows: GatewayWorkspace[]): void {
+  if (asJson) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+  const w = (s: string, n: number): string => s.padEnd(n).slice(0, n);
+  console.log(
+    `\n${w('ID', 38)}${w('SLUG', 20)}${w('NAME', 24)}${w('STATUS', 10)}${w('DEFAULT', 9)}SCOPE_NAME`,
+  );
+  console.log('─'.repeat(130));
+  for (const r of rows) {
+    console.log(
+      `${w(r.id, 38)}${w(r.slug, 20)}${w(r.name, 24)}${w(r.status, 10)}${w(r.is_default ? 'yes' : '', 9)}${r.scope_name}`,
+    );
+  }
+  console.log(`\n${rows.length} workspace(s)`);
+}
+
+function die(msg: string): never {
+  console.error(`error: ${msg}`);
+  process.exit(1);
+}
+
+function parseJsonFlag(raw: string | undefined, flag: string): unknown {
+  if (raw === undefined) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    die(`${flag} must be valid JSON`);
+  }
+}
+
+/**
+ * Fields shared by create and update. Only keys actually passed are emitted, so update stays a
+ * true partial patch and create never sends stray nulls.
+ *
+ * `--metadata` is sugar for `defaults.metadata`, where the API really keeps it. Passing both
+ * `--defaults` and `--metadata` merges them, with `--metadata` winning on that key.
+ */
+function writableFields(values: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of ['name', 'description', 'icon'] as const) {
+    if (values[key] !== undefined) out[key] = values[key];
+  }
+
+  const defaults = parseJsonFlag(values.defaults as string | undefined, '--defaults');
+  const metadata = parseJsonFlag(values.metadata as string | undefined, '--metadata');
+  if (defaults !== undefined || metadata !== undefined) {
+    out.defaults = {
+      ...(typeof defaults === 'object' && defaults !== null ? defaults : {}),
+      ...(metadata !== undefined ? { metadata } : {}),
+    };
+  }
+
+  const usage = parseJsonFlag(values['usage-limits'] as string | undefined, '--usage-limits');
+  if (usage !== undefined) out.usage_limits = usage;
+  const rate = parseJsonFlag(values['rate-limits'] as string | undefined, '--rate-limits');
+  if (rate !== undefined) out.rate_limits = rate;
+
+  return out;
+}
+
+const USAGE = `
+AI Gateway workspace CRUD. <ref> is a workspace UUID or slug.
+
+  list    [--plane data|admin] [--status active|archived] [--all]
+  get     <ref> [--plane data|admin]
+  create  --name <n> --scope-name <s> [--description <d>] [--icon <i>] [--metadata <json>]
+                                      [--users <a,b>] [--usage-limits <json>] [--rate-limits <json>]
+  update  <ref>  at least one of      [--name <n>] [--description <d>] [--icon <i>]
+                                      [--metadata <json>] [--defaults <json>]
+                                      [--usage-limits <json>] [--rate-limits <json>]
+  delete  <ref> --yes                 archives; recover the row with --status archived
+
+Global: --json  --dry-run  --help
+
+Defaults hide rows: plain \`list\` shows only ACTIVE workspaces you are SCOPED to.
+\`list --all\` shows every workspace in the tenant, active and archived.
+
+Limits are ARRAYS of policy objects:
+  --usage-limits '[{"type":"cost","credit_limit":10000,"alert_threshold":8000,"periodic_reset":"weekly"}]'
+  --rate-limits  '[{"type":"requests","unit":"rpm","value":100}]'
+--metadata is sugar for defaults.metadata: --metadata '{"env":"production"}'
+`;
+
+async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(2),
+    allowPositionals: true,
+    options: {
+      plane: { type: 'string' },
+      status: { type: 'string' },
+      all: { type: 'boolean', default: false },
+      name: { type: 'string' },
+      'scope-name': { type: 'string' },
+      description: { type: 'string' },
+      icon: { type: 'string' },
+      defaults: { type: 'string' },
+      metadata: { type: 'string' },
+      users: { type: 'string' },
+      'usage-limits': { type: 'string' },
+      'rate-limits': { type: 'string' },
+      yes: { type: 'boolean', default: false },
+      json: { type: 'boolean', default: false },
+      'dry-run': { type: 'boolean', default: false },
+      help: { type: 'boolean', default: false },
+    },
+  });
+
+  asJson = values.json;
+  const dryRun = values['dry-run'];
+  const [command, ref] = positionals;
+
+  if (values.help || !command) {
+    console.log(USAGE);
+    return;
+  }
+
+  const plane = values.plane;
+  if (plane !== undefined && plane !== 'data' && plane !== 'admin') {
+    die('--plane must be `data` or `admin`');
+  }
+  const status = values.status;
+  if (status !== undefined && status !== 'active' && status !== 'archived') {
+    die('--status must be `active` or `archived`');
+  }
+
+  const gw = new AIGatewayClient();
+
+  switch (command) {
+    case 'list': {
+      if (values.all) {
+        // No single call returns both states: the API filters to active unless asked otherwise.
+        const [active, archived] = await Promise.all([
+          gw.workspaces.list({ plane: 'admin' }),
+          gw.workspaces.list({ plane: 'admin', status: 'archived' }),
+        ]);
+        table([...active.data, ...archived.data]);
+        break;
+      }
+      const res = await gw.workspaces.list({ plane, status });
+      table(res.data);
+      break;
+    }
+
+    case 'get': {
+      if (!ref) die('get needs a workspace ref');
+      emit(`workspace ${ref}`, await gw.workspaces.get(ref, { plane }));
+      break;
+    }
+
+    case 'create': {
+      if (!values.name) die('create needs --name');
+      if (!values['scope-name']) die('create needs --scope-name');
+      const body = {
+        name: values.name,
+        scope_name: values['scope-name'],
+        ...writableFields(values),
+      } as GatewayWorkspaceCreateRequest;
+      if (values.users !== undefined) {
+        body.users = values.users
+          .split(',')
+          .map((u) => u.trim())
+          .filter(Boolean);
+      }
+      if (dryRun) {
+        emit('DRY RUN — would create', body);
+        break;
+      }
+      emit('created (shape unverified — confirm with `get`)', await gw.workspaces.create(body));
+      break;
+    }
+
+    case 'update': {
+      if (!ref) die('update needs a workspace ref');
+      const body = writableFields(values) as GatewayWorkspaceUpdateRequest;
+      if (Object.keys(body).length === 0) {
+        die(
+          'update needs at least one of --name --description --icon --metadata --defaults ' +
+            '--usage-limits --rate-limits',
+        );
+      }
+      if (dryRun) {
+        emit(`DRY RUN — would update ${ref}`, body);
+        break;
+      }
+      emit(
+        'updated (shape unverified — confirm with `get`)',
+        await gw.workspaces.update(ref, body),
+      );
+      break;
+    }
+
+    case 'delete': {
+      if (!ref) die('delete needs a workspace ref');
+      if (!values.yes && !dryRun) die('delete is destructive — pass --yes (or --dry-run)');
+      if (dryRun) {
+        emit(`DRY RUN — would archive ${ref}`, { ref });
+        break;
+      }
+      await gw.workspaces.delete(ref);
+      emit('archived', { ref });
+      if (!asJson) {
+        console.log('this is a soft delete — the row is still there under --status archived');
+      }
+      break;
+    }
+
+    default:
+      die(`unknown command \`${command}\`${USAGE}`);
+  }
+}
+
+main().catch((err: unknown) => {
+  if (err instanceof AISecSDKException) {
+    console.error(
+      `\n${err.errorType}${err.statusCode ? ` ${err.statusCode}` : ''}: ${err.message}`,
+    );
+    if (err.statusCode === 403) {
+      console.error(
+        'A 403 here is a grant problem, and which grant depends on the plane:\n' +
+          '  errorCode AB03              -> missing workspace-scope grant (data plane, /ai_gw/v2)\n' +
+          '  header x-opa-decision:false -> missing tenant-root admin grant (admin plane)\n' +
+          'SCM Access Management edits the existing role row by default — use "Add Role" so you end\n' +
+          'up with two role rows on one service account, not one row moved.',
+      );
+    }
+    process.exit(1);
+  }
+  console.error('\nunexpected error:', err);
+  process.exit(1);
+});

--- a/src/ai-gateway/client.ts
+++ b/src/ai-gateway/client.ts
@@ -119,7 +119,8 @@ export class AIGatewayClient {
     const adminOpts = { baseUrl: adminEndpoint, auth, numRetries };
 
     this.telemetry = new AIGatewayTelemetryClient({ ...dataOpts, tsgId });
-    this.workspaces = new AIGatewayWorkspacesClient(dataOpts);
+    // The one sub-client needing both planes: reads default to data, writes are admin-only.
+    this.workspaces = new AIGatewayWorkspacesClient({ ...dataOpts, adminBaseUrl: adminEndpoint });
     this.configs = new AIGatewayConfigsClient(dataOpts);
     this.guardrails = new AIGatewayGuardrailsClient(dataOpts);
     this.providers = new AIGatewayProvidersClient(dataOpts);

--- a/src/ai-gateway/index.ts
+++ b/src/ai-gateway/index.ts
@@ -9,8 +9,16 @@ export { type AIGatewayWindowOptions } from './window.js';
 export {
   type AIGatewaySubClientOptions,
   type AIGatewayWorkspaceScopedListOptions,
+  type AIGatewayWorkspacesClientOptions,
+  type AIGatewayWorkspaceListOptions,
+  type AIGatewayWorkspaceGetOptions,
+  type AIGatewayPlane,
 } from './types.js';
-export { AIGatewayWorkspacesClient } from './workspaces-client.js';
+export {
+  AIGatewayWorkspacesClient,
+  type GatewayWorkspaceCreateRequest,
+  type GatewayWorkspaceUpdateRequest,
+} from './workspaces-client.js';
 export { AIGatewayConfigsClient, type GatewayConfigCreateRequest } from './configs-client.js';
 export {
   AIGatewayGuardrailsClient,

--- a/src/ai-gateway/types.ts
+++ b/src/ai-gateway/types.ts
@@ -13,6 +13,51 @@ export interface AIGatewaySubClientOptions {
 }
 
 /**
+ * @internal
+ * Construction options for `AIGatewayWorkspacesClient`, the one resource that spans both planes:
+ * reads work on either, writes are admin-only.
+ *
+ * Declared standalone rather than extending {@link AIGatewaySubClientOptions}, matching the
+ * precedent set by `AIGatewayTelemetryClientOptions` — sub-client option types in this subsystem
+ * stay separate even when near-identical.
+ */
+export interface AIGatewayWorkspacesClientOptions {
+  /** Data-plane base URL (`/ai_gw/v2`). Default for reads. */
+  baseUrl: string;
+  /** Admin-plane base URL (`/ai_gw/admin/v2`). Required for writes and tenant-wide reads. */
+  adminBaseUrl: string;
+  auth: AuthAdapter;
+  numRetries: number;
+}
+
+/**
+ * Which plane to route a workspace read through.
+ *
+ * - `data` (default) — `/ai_gw/v2`, returns only workspaces the caller holds a workspace-scope
+ *   grant on. A workspace outside that scope answers `403 AB03`, not `404`.
+ * - `admin` — `/ai_gw/admin/v2`, returns every workspace in the tenant. Needs a tenant-root
+ *   admin role.
+ */
+export type AIGatewayPlane = 'data' | 'admin';
+
+/** Options for `AIGatewayWorkspacesClient.list`. */
+export interface AIGatewayWorkspaceListOptions {
+  /**
+   * Filter by lifecycle state. **Omitting this returns active workspaces only** — archived
+   * workspaces are invisible unless asked for explicitly. Lowercase on the wire.
+   */
+  status?: 'active' | 'archived';
+  /** Defaults to `data`. Use `admin` to enumerate the whole tenant. */
+  plane?: AIGatewayPlane;
+}
+
+/** Options for `AIGatewayWorkspacesClient.get`. */
+export interface AIGatewayWorkspaceGetOptions {
+  /** Defaults to `data`. Use `admin` to read a workspace outside your workspace scope. */
+  plane?: AIGatewayPlane;
+}
+
+/**
  * Options for listing workspace-scoped resources. Shared by every sub-client whose `list`
  * (or list-alike) endpoint takes only a workspace UUID — guardrails, providers, api-keys,
  * and configs.

--- a/src/ai-gateway/workspaces-client.ts
+++ b/src/ai-gateway/workspaces-client.ts
@@ -1,44 +1,118 @@
 import { AI_GW_WORKSPACES_PATH } from '../constants.js';
+import { AISecSDKException, ErrorType } from '../errors.js';
 import { request } from '../http/request.js';
 import type { AuthAdapter } from '../http/types.js';
-import { assertUuid } from '../validators.js';
+import { assertWorkspaceRef } from '../validators.js';
 import {
   ListWorkspacesResponseSchema,
   GatewayWorkspaceDetailSchema,
+  GatewayWriteResponseSchema,
   type ListWorkspacesResponse,
   type GatewayWorkspaceDetail,
+  type GatewayWriteResponse,
 } from '../models/ai-gateway.js';
-import type { AIGatewaySubClientOptions } from './types.js';
+import type {
+  AIGatewayPlane,
+  AIGatewayWorkspaceGetOptions,
+  AIGatewayWorkspaceListOptions,
+  AIGatewayWorkspacesClientOptions,
+} from './types.js';
 
-/** Client for AI Gateway workspace reads (data plane). */
+/** Request body for {@link AIGatewayWorkspacesClient.create}. */
+export interface GatewayWorkspaceCreateRequest {
+  /** Display name. Required. */
+  name: string;
+  /**
+   * SCM role scope granting data-plane access to the new workspace, e.g. `ws_production_bx7qw0`.
+   * Required, and **specific to Prisma AIRS** — upstream Portkey has no such field.
+   *
+   * It is not derived from `name`. A workspace created with a scope nobody holds is invisible to
+   * `list()` on the data plane, though it still appears via `list({ plane: 'admin' })`.
+   */
+  scope_name: string;
+  description?: string;
+  icon?: string;
+  /** Workspace defaults; `metadata` is a flat string map applied to every request. */
+  defaults?: Record<string, unknown>;
+  /** User ids to seed the workspace with. */
+  users?: string[];
+  /** Usage-limit policies. An **array**, not a single object. */
+  usage_limits?: Array<Record<string, unknown>>;
+  /** Rate-limit policies. An **array**, not a single object. */
+  rate_limits?: Array<Record<string, unknown>>;
+}
+
+/**
+ * Request body for {@link AIGatewayWorkspacesClient.update}. Partial — send only what changes.
+ *
+ * The API enumerates the fields it accepts in its own rejection message: `name`, `description`,
+ * `icon`, `defaults`, `rate_limits`. `usage_limits` is accepted by upstream Portkey but missing
+ * from that message, so it is offered here and may be ignored server-side.
+ */
+export interface GatewayWorkspaceUpdateRequest {
+  name?: string;
+  description?: string;
+  icon?: string;
+  defaults?: Record<string, unknown>;
+  usage_limits?: Array<Record<string, unknown>>;
+  rate_limits?: Array<Record<string, unknown>>;
+}
+
+/**
+ * Client for AI Gateway workspaces.
+ *
+ * The only sub-client spanning **both planes**: reads default to the data plane but can be routed
+ * to the admin plane, and every write is admin-only. Each of the other eleven sub-clients is wired
+ * to exactly one plane.
+ */
 export class AIGatewayWorkspacesClient {
   private readonly baseUrl: string;
+  private readonly adminBaseUrl: string;
   private readonly auth: AuthAdapter;
   private readonly numRetries: number;
 
-  constructor(opts: AIGatewaySubClientOptions) {
+  constructor(opts: AIGatewayWorkspacesClientOptions) {
     this.baseUrl = opts.baseUrl;
+    this.adminBaseUrl = opts.adminBaseUrl;
     this.auth = opts.auth;
     this.numRetries = opts.numRetries;
   }
 
+  private urlFor(plane: AIGatewayPlane | undefined): string {
+    return plane === 'admin' ? this.adminBaseUrl : this.baseUrl;
+  }
+
   /**
-   * List workspaces visible to the caller.
-   * @returns All workspaces, each with the `scope_name` that grants data-plane access to it.
+   * List workspaces.
+   *
+   * Two defaults worth knowing, because each one hides rows:
+   *
+   * 1. **Active only.** Without `status`, archived workspaces are omitted. Pass
+   *    `{ status: 'archived' }` to see them — that is where {@link AIGatewayWorkspacesClient.delete}
+   *    leaves a workspace.
+   * 2. **Your scope only.** The data plane returns just the workspaces your service account holds a
+   *    workspace-scope grant on. Pass `{ plane: 'admin' }` to enumerate the whole tenant.
+   *
+   * @param options - Optional status filter and plane selection.
+   * @returns Workspaces, each with the `scope_name` that grants data-plane access to it.
    * @example
    * ```ts
    * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
    * const gw = new AIGatewayClient();
    *
-   * const ws = await gw.workspaces.list();
-   * // ws.data[0] => { slug: 'ws-main-a-349e0e', scope_name: 'main_airs_workspace_1852583913', ... }
+   * const mine = await gw.workspaces.list();
+   * // mine.data[0] => { slug: 'ws-main-a-349e0e', scope_name: 'main_airs_workspace_1852583913', ... }
+   *
+   * const everything = await gw.workspaces.list({ plane: 'admin' });
+   * const archived = await gw.workspaces.list({ plane: 'admin', status: 'archived' });
    * ```
    */
-  async list(): Promise<ListWorkspacesResponse> {
+  async list(options: AIGatewayWorkspaceListOptions = {}): Promise<ListWorkspacesResponse> {
     return request({
       method: 'GET',
-      baseUrl: this.baseUrl,
+      baseUrl: this.urlFor(options.plane),
       path: AI_GW_WORKSPACES_PATH,
+      params: options.status ? { status: options.status } : undefined,
       responseSchema: ListWorkspacesResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
@@ -47,7 +121,10 @@ export class AIGatewayWorkspacesClient {
 
   /**
    * Fetch one workspace, including its security and rate-limit settings.
-   * @param workspaceId - Workspace UUID.
+   *
+   * @param workspaceRef - Workspace UUID **or** slug; the API accepts both.
+   * @param options - Plane selection. A workspace outside your workspace scope answers `403 AB03`
+   * on the data plane, not `404`; re-read it with `{ plane: 'admin' }`.
    * @returns Workspace detail; list rows do not carry the settings blocks.
    * @example
    * ```ts
@@ -56,15 +133,133 @@ export class AIGatewayWorkspacesClient {
    *
    * const ws = await gw.workspaces.get('16f7e90d-382a-4e78-b577-1b01eb5f8297');
    * // ws.security_settings?.membersViewLogs => true
+   *
+   * // Slugs work too, and the admin plane reaches workspaces you aren't scoped to:
+   * const other = await gw.workspaces.get('ws-produc-985697', { plane: 'admin' });
    * ```
    */
-  async get(workspaceId: string): Promise<GatewayWorkspaceDetail> {
-    assertUuid(workspaceId, 'workspaceId');
+  async get(
+    workspaceRef: string,
+    options: AIGatewayWorkspaceGetOptions = {},
+  ): Promise<GatewayWorkspaceDetail> {
+    assertWorkspaceRef(workspaceRef, 'workspaceRef');
     return request({
       method: 'GET',
-      baseUrl: this.baseUrl,
-      path: `${AI_GW_WORKSPACES_PATH}/${workspaceId}`,
+      baseUrl: this.urlFor(options.plane),
+      path: `${AI_GW_WORKSPACES_PATH}/${workspaceRef}`,
       responseSchema: GatewayWorkspaceDetailSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Create a workspace. **Admin plane** — needs a tenant-root admin role.
+   *
+   * @param body - `name` and `scope_name` are both required; the API rejects a body missing either.
+   * @returns The created workspace. **Shape unverified against a live tenant** — typed
+   * permissively, like the other unconfirmed AI Gateway writes. Call
+   * {@link AIGatewayWorkspacesClient.get} for a record you can rely on.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * const created = await gw.workspaces.create({
+   *   name: 'Production',
+   *   scope_name: 'ws_production_bx7qw0', // the SCM scope, not derived from name
+   *   description: 'All production applications',
+   *   defaults: { metadata: { env: 'production' } },
+   *   rate_limits: [{ type: 'requests', unit: 'rpm', value: 100 }],
+   * });
+   * ```
+   */
+  async create(body: GatewayWorkspaceCreateRequest): Promise<GatewayWriteResponse> {
+    if (!body.name) {
+      throw new AISecSDKException('Missing name', ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+    }
+    if (!body.scope_name) {
+      throw new AISecSDKException('Missing scope_name', ErrorType.USER_REQUEST_PAYLOAD_ERROR);
+    }
+    return request({
+      method: 'POST',
+      baseUrl: this.adminBaseUrl,
+      path: AI_GW_WORKSPACES_PATH,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Update a workspace. **Admin plane.** Partial patch — send only the fields that change.
+   *
+   * @param workspaceRef - Workspace UUID or slug.
+   * @param body - At least one field. An empty patch is rejected locally, mirroring the API's own
+   * "No update fields provided" rejection, so a typo'd caller fails without a round trip.
+   * @returns **Shape unverified against a live tenant.**
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.workspaces.update('ws-produc-985697', {
+   *   description: 'Production workloads, us-east',
+   * });
+   * ```
+   */
+  async update(
+    workspaceRef: string,
+    body: GatewayWorkspaceUpdateRequest,
+  ): Promise<GatewayWriteResponse> {
+    assertWorkspaceRef(workspaceRef, 'workspaceRef');
+    if (Object.keys(body).length === 0) {
+      throw new AISecSDKException(
+        'Empty update: provide at least one of name, description, icon, defaults, usage_limits, rate_limits',
+        ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+      );
+    }
+    return request({
+      method: 'PUT',
+      baseUrl: this.adminBaseUrl,
+      path: `${AI_GW_WORKSPACES_PATH}/${workspaceRef}`,
+      body,
+      responseSchema: GatewayWriteResponseSchema,
+      auth: this.auth,
+      numRetries: this.numRetries,
+    });
+  }
+
+  /**
+   * Delete a workspace. **Admin plane.**
+   *
+   * This is a **soft delete**: the workspace is archived, not destroyed. It vanishes from a default
+   * {@link AIGatewayWorkspacesClient.list} but stays retrievable via `list({ status: 'archived' })`.
+   * Same semantics as `deployments.delete()`, and the opposite of `configs`/`guardrails`/`providers`,
+   * which hard delete. There is no hard delete for workspaces.
+   *
+   * Takes no query parameters — unlike `integrations.delete()` and `deployments.delete()`, which
+   * both require `organisation_id`.
+   *
+   * @param workspaceRef - Workspace UUID or slug.
+   * @example
+   * ```ts
+   * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
+   * const gw = new AIGatewayClient();
+   *
+   * await gw.workspaces.delete('ws-produc-985697');
+   *
+   * // Still there, archived:
+   * const gone = await gw.workspaces.list({ plane: 'admin', status: 'archived' });
+   * ```
+   */
+  async delete(workspaceRef: string): Promise<void> {
+    assertWorkspaceRef(workspaceRef, 'workspaceRef');
+    return request({
+      method: 'DELETE',
+      baseUrl: this.adminBaseUrl,
+      path: `${AI_GW_WORKSPACES_PATH}/${workspaceRef}`,
       auth: this.auth,
       numRetries: this.numRetries,
     });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.14.2';
+export const SDK_VERSION = '0.15.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/models/ai-gateway.ts
+++ b/src/models/ai-gateway.ts
@@ -440,7 +440,9 @@ export const GatewayWorkspaceSchema = z
     slug: z.string(),
     name: z.string(),
     icon: z.string().nullable(),
-    description: z.string(),
+    // Nullable: a workspace created without one returns null, and upstream declares it
+    // `nullable: true`. Observed on an archived workspace (#213).
+    description: z.string().nullable(),
     created_at: z.string(),
     last_updated_at: z.string(),
     is_default: z.number(),
@@ -456,7 +458,8 @@ export const GatewayWorkspaceDetailSchema = z
   .object({
     id: z.string(),
     name: z.string(),
-    description: z.string(),
+    /** Nullable — see `GatewayWorkspaceSchema.description`. */
+    description: z.string().nullable(),
     created_at: z.string(),
     last_updated_at: z.string(),
     is_default: z.number(),

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -30,6 +30,29 @@ export function assertLength(value: string, min: number, max: number, fieldName:
 
 /**
  * @internal
+ * Throw `AISecSDKException(USER_REQUEST_PAYLOAD_ERROR)` if `value` is neither a UUID nor a
+ * workspace slug.
+ *
+ * AI Gateway workspace endpoints accept **either** form: upstream documents the path parameter as
+ * "Workspace UUID. Workspace slug is also accepted for backward compatibility", and a well-formed
+ * but unknown slug returns `404` rather than `400`. `assertUuid` is therefore too strict for these
+ * paths — it rejects identifiers the API honours.
+ *
+ * The slug pattern stays deliberately loose (the server owns the real format) but still rejects
+ * anything containing `/` or `..`, so an attacker-supplied value cannot reshape a path built by
+ * string interpolation.
+ */
+export function assertWorkspaceRef(value: string, fieldName: string): void {
+  if (!isValidUuid(value) && !/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(value)) {
+    throw new AISecSDKException(
+      `Invalid ${fieldName}: ${value} (expected a workspace UUID or slug)`,
+      ErrorType.USER_REQUEST_PAYLOAD_ERROR,
+    );
+  }
+}
+
+/**
+ * @internal
  * Throw `AISecSDKException(USER_REQUEST_PAYLOAD_ERROR)` if `value` is not a plain numeric-string
  * id (`/^\d+$/`). Use for identifiers that are numeric but not UUIDs (e.g. AI Gateway's
  * `tsgId`/`organisationId`) — rejects `/` or `..` so the value can't reshape a path built by

--- a/test/ai-gateway/client.spec.ts
+++ b/test/ai-gateway/client.spec.ts
@@ -102,6 +102,15 @@ describe('AIGatewayClient', () => {
     it.each(cases)('$name is wired to $expectedOrigin', ({ accessor, expectedOrigin }) => {
       expect(baseUrlOf(accessor())).toBe(expectedOrigin);
     });
+
+    // workspaces is the only sub-client spanning both planes: reads default to data, while writes
+    // and tenant-wide reads go to admin. A missing adminBaseUrl would silently route
+    // create/update/delete at the data plane. See #213.
+    it('workspaces also carries the admin base URL for its write paths', () => {
+      const adminBaseUrlOf = (client: object): string =>
+        (client as unknown as { adminBaseUrl: string }).adminBaseUrl;
+      expect(adminBaseUrlOf(gw.workspaces)).toBe(ADMIN_ENDPOINT);
+    });
   });
 
   describe('x-tsg-id on the wire', () => {

--- a/test/ai-gateway/workspaces-client.spec.ts
+++ b/test/ai-gateway/workspaces-client.spec.ts
@@ -34,9 +34,15 @@ describe('AIGatewayWorkspacesClient', () => {
   const originalFetch = globalThis.fetch;
   let client: AIGatewayWorkspacesClient;
 
+  const calledUrl = (): string =>
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+  const calledInit = (): RequestInit =>
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+
   beforeEach(() => {
     client = new AIGatewayWorkspacesClient({
       baseUrl: 'https://gw.example.com',
+      adminBaseUrl: 'https://admin.example.com',
       auth: passthroughAuth(),
       numRetries: 0,
     });
@@ -50,14 +56,133 @@ describe('AIGatewayWorkspacesClient', () => {
     const res = await client.list();
 
     expect(res.data[0].slug).toBe('ws-main-a-349e0e');
-    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(url).toBe('https://gw.example.com/workspaces');
+    expect(calledUrl()).toBe('https://gw.example.com/workspaces');
   });
 
-  it('rejects a non-UUID id before issuing a request', async () => {
+  it('rejects a malformed workspace ref before issuing a request', async () => {
     globalThis.fetch = vi.fn();
-    await expect(client.get('not-a-uuid')).rejects.toThrow(AISecSDKException);
+    await expect(client.get('not a workspace!')).rejects.toThrow(AISecSDKException);
     expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  // The API accepts a slug wherever it accepts a UUID — upstream documents the path param as
+  // "Workspace UUID. Workspace slug is also accepted for backward compatibility", and a bogus
+  // slug returns 404 (recognised key form) rather than 400. See #213.
+  it('accepts a slug as well as a UUID', async () => {
+    mockFetch({ ...sampleWorkspace, defaults: null, usage_limits: null, rate_limits: null });
+    await client.get('ws-produc-985697');
+    expect(calledUrl()).toBe('https://gw.example.com/workspaces/ws-produc-985697');
+  });
+
+  // Found live: an archived workspace created without a description returns `description: null`,
+  // and upstream declares the field `nullable: true`. The list-row schema had it non-nullable,
+  // so list({ status: 'archived' }) threw. See #213.
+  it('parses a null description on list rows', async () => {
+    mockFetch({
+      object: 'list',
+      total: 1,
+      data: [{ ...sampleWorkspace, description: null, status: 'archived' }],
+    });
+    const res = await client.list({ status: 'archived' });
+    expect(res.data[0].description).toBeNull();
+  });
+
+  describe('list filtering and plane selection', () => {
+    it('serialises the status filter in lowercase', async () => {
+      mockFetch({ object: 'list', total: 1, data: [sampleWorkspace] });
+      await client.list({ status: 'archived' });
+      expect(calledUrl()).toBe('https://gw.example.com/workspaces?status=archived');
+    });
+
+    // The data plane returns only workspaces the caller holds a workspace-scope grant on;
+    // the admin plane returns every workspace in the tenant.
+    it('targets the admin plane when asked', async () => {
+      mockFetch({ object: 'list', total: 2, data: [sampleWorkspace] });
+      await client.list({ plane: 'admin' });
+      expect(calledUrl()).toBe('https://admin.example.com/workspaces');
+    });
+
+    it('combines plane and status', async () => {
+      mockFetch({ object: 'list', total: 1, data: [sampleWorkspace] });
+      await client.list({ plane: 'admin', status: 'active' });
+      expect(calledUrl()).toBe('https://admin.example.com/workspaces?status=active');
+    });
+
+    it('reads a workspace through the admin plane when asked', async () => {
+      mockFetch({ ...sampleWorkspace, defaults: null, usage_limits: null, rate_limits: null });
+      await client.get(wsId, { plane: 'admin' });
+      expect(calledUrl()).toBe(`https://admin.example.com/workspaces/${wsId}`);
+    });
+  });
+
+  describe('writes (admin plane)', () => {
+    it('POSTs a create to the admin plane', async () => {
+      mockFetch({ id: wsId, slug: 'ws-new-000000', object: 'workspace' });
+      await client.create({ name: 'New', scope_name: 'ws_new_000000', description: 'x' });
+
+      expect(calledUrl()).toBe('https://admin.example.com/workspaces');
+      const init = calledInit();
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body as string)).toEqual({
+        name: 'New',
+        scope_name: 'ws_new_000000',
+        description: 'x',
+      });
+    });
+
+    it('requires name and scope_name before issuing a request', async () => {
+      globalThis.fetch = vi.fn();
+      await expect(
+        client.create({ name: '', scope_name: 'ws_x' } as Parameters<typeof client.create>[0]),
+      ).rejects.toThrow(AISecSDKException);
+      await expect(
+        client.create({ name: 'x', scope_name: '' } as Parameters<typeof client.create>[0]),
+      ).rejects.toThrow(AISecSDKException);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('PUTs an update to the admin plane', async () => {
+      mockFetch({ ok: true });
+      await client.update(wsId, { description: 'updated' });
+
+      expect(calledUrl()).toBe(`https://admin.example.com/workspaces/${wsId}`);
+      const init = calledInit();
+      expect(init.method).toBe('PUT');
+      expect(JSON.parse(init.body as string)).toEqual({ description: 'updated' });
+    });
+
+    // The API rejects an empty patch with AB01 "No update fields provided"; fail locally
+    // instead of burning a round trip.
+    it('rejects an empty update before issuing a request', async () => {
+      globalThis.fetch = vi.fn();
+      await expect(client.update(wsId, {})).rejects.toThrow(AISecSDKException);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    // Soft delete: the row persists with status 'archived' and is retrievable via
+    // list({ status: 'archived' }). Same semantics as deployments.delete().
+    it('DELETEs against the admin plane with no query params', async () => {
+      mockFetch({});
+      await client.delete(wsId);
+
+      expect(calledUrl()).toBe(`https://admin.example.com/workspaces/${wsId}`);
+      expect(calledInit().method).toBe('DELETE');
+    });
+
+    it.each(['create', 'update', 'delete'] as const)(
+      '%s rejects a malformed ref/body before issuing a request',
+      async (method) => {
+        globalThis.fetch = vi.fn();
+        const call =
+          method === 'create'
+            ? client.create({ name: 'x', scope_name: '' } as Parameters<typeof client.create>[0])
+            : method === 'update'
+              ? client.update('not a ref!', { name: 'x' })
+              : client.delete('not a ref!');
+        await expect(call).rejects.toThrow(AISecSDKException);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+      },
+    );
   });
 
   // Regression: usage_limits / rate_limits are ARRAYS of policy objects, not objects.


### PR DESCRIPTION
## Summary

Workspace lifecycle was impossible through the SDK, and both read methods had shipped behaviour that hid or rejected valid data. Findings come from live probing against TSG `1852583913` (2026-08-01), cross-checked against the upstream Portkey Admin API spec — Prisma AIRS AI Gateway is Portkey, OEM'd.

## New: workspace writes

`create()`, `update()`, `delete()` on the admin plane.

`create()` requires `name` + `scope_name`. **`scope_name` is a Palo Alto addition with no upstream equivalent** — it's the SCM role scope granting data-plane access. It is not derived from `name`, and a workspace created with a scope nobody holds won't appear in a data-plane `list()`. That's the most common way a freshly created workspace appears to go missing, so it's called out in the guide.

**`delete()` is a soft delete** — archives, doesn't destroy. Evidence: `?status=archived` returns a real archived row on the probe tenant, and upstream defines a `status: [ACTIVE, ARCHIVED]` enum. Matches `deployments.delete()`; opposite of `configs`/`guardrails`/`providers`. No hard delete exists.

Create/update responses are typed permissively and marked *"Shape unverified against a live tenant"* — the existing convention here (`integrations`, `apiKeys`, `plugins`, `mcpIntegrations` all do this). I could not observe a 2xx: creating a workspace on the live tenant was outside what I was permitted to do. Request contracts *are* confirmed, from the API's own field-level rejections.

## Fixed: three read bugs

**1. `list()` hid archived workspaces** with no way to ask for them. On the probe tenant that meant a real workspace (`ws-test12-f67b79`) was unreachable. Now `list({ status: 'archived' })`, lowercase on the wire.

**2. `list()` returned only workspaces the caller was scoped to.** Data plane shows 1 row where admin shows 2 — the tenant was not enumerable. Now `list({ plane: 'admin' })`.

**3. `get()` rejected slugs.** It called `assertUuid`, but the API accepts either form — [Portkey-AI/openapi#142](https://github.com/Portkey-AI/openapi/pull/142) documents the param as *"Workspace UUID. Workspace slug is also accepted for backward compatibility"*, and a bogus slug returns 404 (recognised key form), not 400. New `assertWorkspaceRef` accepts both while still rejecting anything with `/` or `..`, so a caller-supplied value can't reshape an interpolated path.

`list()` with no arguments is unchanged.

## Also fixed: nullable `description`

Found while verifying the above — `list({ status: 'archived' })` threw, because the archived workspace has `description: null` and both workspace schemas typed it non-nullable. Upstream declares it `nullable: true`. Same class of bug as #211: derived from a tenant where the field happened to be populated.

## Design note

`AIGatewayWorkspacesClient` was wired to the data plane only and couldn't reach admin. It now takes its own `AIGatewayWorkspacesClientOptions` carrying both base URLs — standalone rather than extending `AIGatewaySubClientOptions`, following the `AIGatewayTelemetryClientOptions` precedent. It's the only sub-client spanning both planes, and there's a dedicated wiring test so a missing `adminBaseUrl` can't silently route writes at the data plane.

## Deliberately not done

[Portkey-AI/openapi#147](https://github.com/Portkey-AI/openapi/pull/147) describes a **newer API generation** — paths at `/workspaces` not `/admin/workspaces`, create keyed on `organisation_id` instead of `scope_name`, and a delete confirmation body `{name, force_delete}`. I tested that delete body against PAN's build: rejected, same 400 as a bare call. PAN tracks the older generation, having adopted the `status` filter but not the rest. Modelling on #147 would have broken things.

## Testing

TDD — 13 failing tests written first, then implementation.

19 tests on the workspaces client plus a plane-wiring regression. Full suite **1555 passed** (was 1540). Lint, typecheck, format, `docs:build` all clean.

**Live-verified:** `list()`, `list({plane:'admin'})`, `list({plane:'admin',status:'archived'})`, `get()` by UUID and by slug, and admin-plane `get()`. The three write paths are unit-tested for verb/URL/body/guards but have no live 2xx behind them — stated plainly in the JSDoc and release notes rather than implied as verified.

## Also included

`scripts/ai-gateway-workspaces.ts` — a CLI over the new surface, useful for exercising it against a real tenant. `list --all` merges the active and archived admin reads, since the API filter is one or the other.

Version bumped to **0.15.0** (minor — new surface, plus a constructor signature change on a sub-client users don't normally construct directly).

Closes #213

