### PR TITLE
feat(ai-gateway): type workspace create/update responses from live shapes

### DIFF
--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## v0.17.0
+
+### Workspace write responses are now typed
+
+`workspaces.create()` returned the permissive `GatewayWriteResponse` placeholder, so `created.id` was `unknown` and every field needed a cast. Both write shapes have now been verified against a live tenant, and the *"Shape unverified against a live tenant"* markers are gone.
+
+`create()` returns the new `GatewayWorkspaceCreateResponse`: `{ id, name, slug, description, created_at, last_updated_at, scope_name, object }`, plus optional `defaults` and `users`.
+
+**Workspace create is the exception to this subsystem's "receipt, not record" pattern.** `configs.create()`, `guardrails.create()`, `providers.create()`, and `deployments.create()` each return a 4–5 field receipt; workspace create returns most of the record. It is still not the full detail shape — `status`, `is_default`, `icon`, `usage_limits`, `rate_limits`, and the settings blocks are absent — so call `get()` when you need those. Conversely `users` appears only here.
+
+`update()` keeps `GatewayWriteResponse`, because the API genuinely returns an empty object `{}`. The write does persist; re-read with `get()` to see it. Typing it as anything richer would misrepresent the API.
+
+### Two behaviours worth knowing before you build on this
+
+- **Archived workspaces are not retrievable by `get()`.** After `delete()` archives a workspace, `get()` answers `404 AB08` for both its UUID and its slug, on either plane — even though `list({ status: 'archived' })` still lists it. A 404 following a delete is expected, not an error; use the list filter to inspect archived workspaces.
+- **`status` disagrees between endpoints.** `list()` reports `'active'` for a workspace whose `get()` reports `null`. `GatewayWorkspaceDetail` now types `status` as nullable/optional so it is at least visible; prefer the list value, and read a `null` here as "unknown" rather than "inactive".
+
+### Also fixed
+
+The `update()` JSDoc previously described the `"No update fields provided"` error as unproven inference. It is now confirmed: that message is a **misleading not-found**, not a complaint about your payload. If you hit it, check the workspace ref before the body.
+
 ## v0.16.0
 
 ### Red Team custom target adapters

--- a/docs-site/docs/guides/ai-gateway-api.mdx
+++ b/docs-site/docs/guides/ai-gateway-api.mdx
@@ -320,7 +320,9 @@ const summary = audit.records.map((r) => `${r.timestamp} ${r.method} ${r.uri.spl
 
 - **Workspace refs may be a UUID or a slug.** `gw.workspaces.get('ws-produc-985697')` is as valid as passing the UUID. Reading a workspace you are not scoped to needs `{ plane: 'admin' }` — on the data plane it returns `403 AB03`, not `404`, so a permission problem can read like a missing record.
 
-- **`workspaces.delete()` archives; it does not destroy.** The row survives under `list({ status: 'archived' })`. This matches `deployments.delete()` and contradicts `configs`/`guardrails`/`providers`, which hard delete. There is no hard delete for workspaces.
+- **`workspaces.delete()` archives; it does not destroy.** The row survives under `list({ status: 'archived' })`. This matches `deployments.delete()` and contradicts `configs`/`guardrails`/`providers`, which hard delete. There is no hard delete for workspaces. Note that `list` is the only way to see an archived workspace — `get()` returns `404 AB08` for one, on either plane, so a 404 straight after a delete is expected rather than a bug.
+
+- **`workspaces.create()` returns most of the record, not a receipt.** It is the odd one out: the other AI Gateway creates hand back 4-5 field receipts. Even so it omits `status`, `is_default`, `icon`, `usage_limits`, `rate_limits`, and the settings blocks, so follow it with `get()` if you need those. `workspaces.update()` returns an empty `{}` — the write lands, but you must re-read to see it.
 
 - **`workspaces.create()` needs a `scope_name`.** It is the SCM role scope granting data-plane access to the new workspace, and it is not derived from `name`. Create one with a scope nobody holds and it simply will not appear in a data-plane `list()` — which is the most common way a freshly created workspace "goes missing".
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdot65/prisma-airs-sdk",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdot65/prisma-airs-sdk",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "TypeScript SDK for Palo Alto Networks Prisma AIRS — scanning, management, model security, and red teaming APIs",
   "author": "Calvin Remsburg <cremsburg.dev@gmail.com>",
   "license": "MIT",

--- a/src/ai-gateway/workspaces-client.ts
+++ b/src/ai-gateway/workspaces-client.ts
@@ -7,9 +7,11 @@ import {
   ListWorkspacesResponseSchema,
   GatewayWorkspaceDetailSchema,
   GatewayWriteResponseSchema,
+  GatewayWorkspaceCreateResponseSchema,
   type ListWorkspacesResponse,
   type GatewayWorkspaceDetail,
   type GatewayWriteResponse,
+  type GatewayWorkspaceCreateResponse,
 } from '../models/ai-gateway.js';
 import type {
   AIGatewayPlane,
@@ -125,6 +127,12 @@ export class AIGatewayWorkspacesClient {
    * @param workspaceRef - Workspace UUID **or** slug; the API accepts both.
    * @param options - Plane selection. A workspace outside your workspace scope answers `403 AB03`
    * on the data plane, not `404`; re-read it with `{ plane: 'admin' }`.
+   *
+   * **Archived workspaces are not retrievable here.** Once
+   * {@link AIGatewayWorkspacesClient.delete} has archived a workspace, this returns `404 AB08`
+   * for both its UUID and its slug, on either plane (verified live 2026-08-01) — even though the
+   * row is still listed by `list({ status: 'archived' })`. Treat a 404 after a delete as expected,
+   * and use the list filter to inspect archived workspaces.
    * @returns Workspace detail; list rows do not carry the settings blocks.
    * @example
    * ```ts
@@ -157,9 +165,10 @@ export class AIGatewayWorkspacesClient {
    * Create a workspace. **Admin plane** — needs a tenant-root admin role.
    *
    * @param body - `name` and `scope_name` are both required; the API rejects a body missing either.
-   * @returns The created workspace. **Shape unverified against a live tenant** — typed
-   * permissively, like the other unconfirmed AI Gateway writes. Call
-   * {@link AIGatewayWorkspacesClient.get} for a record you can rely on.
+   * @returns The created workspace. Unlike `configs`/`guardrails`/`providers`/`deployments`,
+   * which return short receipts, this returns most of the record — but not `status`,
+   * `is_default`, `icon`, `usage_limits`, `rate_limits`, or the settings blocks. Call
+   * {@link AIGatewayWorkspacesClient.get} when you need those.
    * @example
    * ```ts
    * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
@@ -174,7 +183,7 @@ export class AIGatewayWorkspacesClient {
    * });
    * ```
    */
-  async create(body: GatewayWorkspaceCreateRequest): Promise<GatewayWriteResponse> {
+  async create(body: GatewayWorkspaceCreateRequest): Promise<GatewayWorkspaceCreateResponse> {
     if (!body.name) {
       throw new AISecSDKException('Missing name', ErrorType.USER_REQUEST_PAYLOAD_ERROR);
     }
@@ -186,7 +195,7 @@ export class AIGatewayWorkspacesClient {
       baseUrl: this.adminBaseUrl,
       path: AI_GW_WORKSPACES_PATH,
       body,
-      responseSchema: GatewayWriteResponseSchema,
+      responseSchema: GatewayWorkspaceCreateResponseSchema,
       auth: this.auth,
       numRetries: this.numRetries,
     });
@@ -198,7 +207,9 @@ export class AIGatewayWorkspacesClient {
    * @param workspaceRef - Workspace UUID or slug.
    * @param body - At least one field. An empty patch is rejected locally, mirroring the API's own
    * "No update fields provided" rejection, so a typo'd caller fails without a round trip.
-   * @returns **Shape unverified against a live tenant.**
+   * @returns An **empty object** — the API acknowledges the write without echoing the record
+   * (verified live 2026-08-01). The change does persist; re-read with
+   * {@link AIGatewayWorkspacesClient.get} to see it.
    * @example
    * ```ts
    * import { AIGatewayClient } from '@cdot65/prisma-airs-sdk';
@@ -235,7 +246,9 @@ export class AIGatewayWorkspacesClient {
    * Delete a workspace. **Admin plane.**
    *
    * This is a **soft delete**: the workspace is archived, not destroyed. It vanishes from a default
-   * {@link AIGatewayWorkspacesClient.list} but stays retrievable via `list({ status: 'archived' })`.
+   * {@link AIGatewayWorkspacesClient.list} but stays visible via `list({ status: 'archived' })`.
+   * Note that `list` is the *only* way to see it afterwards —
+   * {@link AIGatewayWorkspacesClient.get} answers `404 AB08` for an archived workspace.
    * Same semantics as `deployments.delete()`, and the opposite of `configs`/`guardrails`/`providers`,
    * which hard delete. There is no hard delete for workspaces.
    *

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,7 +47,7 @@ export const MAX_NUMBER_OF_RETRIES = 5;
 export const HTTP_FORCE_RETRY_STATUS_CODES = [500, 502, 503, 504];
 
 // User-Agent (version injected at build time or read from package.json)
-export const SDK_VERSION = '0.16.0';
+export const SDK_VERSION = '0.17.0';
 export const USER_AGENT = `PAN-AIRS/${SDK_VERSION}-typescript-sdk`;
 
 // Management API defaults

--- a/src/models/ai-gateway.ts
+++ b/src/models/ai-gateway.ts
@@ -471,9 +471,43 @@ export const GatewayWorkspaceDetailSchema = z
     security_settings: z.record(z.boolean()).optional(),
     data_plane_security_settings: z.record(z.unknown()).optional(),
     settings: z.record(z.unknown()).optional(),
+    /**
+     * Lifecycle state. **Diverges from the list row**: `list()` reports `'active'` for a
+     * workspace whose `get()` reports `null` (observed live 2026-08-01). Prefer the list value,
+     * or treat a `null` here as "unknown", not as "inactive".
+     */
+    status: z.string().nullable().optional(),
   })
   .passthrough();
 export type GatewayWorkspaceDetail = z.infer<typeof GatewayWorkspaceDetailSchema>;
+
+/**
+ * `POST /ai_gw/admin/v2/workspaces` response — verified live 2026-08-01.
+ *
+ * **The exception to this subsystem's "receipt, not record" write pattern.** `configs.create()`,
+ * `guardrails.create()`, `providers.create()`, and `deployments.create()` each return a 4-5 field
+ * receipt; workspace create returns most of the record instead.
+ *
+ * It is still not the full detail shape — `status`, `is_default`, `icon`, `usage_limits`,
+ * `rate_limits`, and the settings blocks are all absent — so call `get()` when you need those.
+ * Conversely `users` appears here and nowhere else.
+ */
+export const GatewayWorkspaceCreateResponseSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string(),
+    description: z.string().nullable(),
+    created_at: z.string(),
+    last_updated_at: z.string(),
+    scope_name: z.string(),
+    object: z.string(),
+    defaults: z.record(z.unknown()).nullable().optional(),
+    /** Seeded workspace members. Present on create only. */
+    users: z.array(z.unknown()).optional(),
+  })
+  .passthrough();
+export type GatewayWorkspaceCreateResponse = z.infer<typeof GatewayWorkspaceCreateResponseSchema>;
 
 export const ListWorkspacesResponseSchema = aiGatewayList(GatewayWorkspaceSchema);
 export type ListWorkspacesResponse = z.infer<typeof ListWorkspacesResponseSchema>;

--- a/test/ai-gateway/workspaces-client.spec.ts
+++ b/test/ai-gateway/workspaces-client.spec.ts
@@ -87,6 +87,23 @@ describe('AIGatewayWorkspacesClient', () => {
     expect(res.data[0].description).toBeNull();
   });
 
+  // Observed live: list() reports status 'active' for a workspace whose get() reports
+  // status null. Both forms must parse off the detail schema. See #215.
+  it.each([
+    ['null', null],
+    ['a string', 'active'],
+  ])('parses a detail read with %s status', async (_label, status) => {
+    mockFetch({
+      ...sampleWorkspace,
+      defaults: null,
+      usage_limits: null,
+      rate_limits: null,
+      status,
+    });
+    const res = await client.get(wsId);
+    expect(res.status).toBe(status);
+  });
+
   describe('list filtering and plane selection', () => {
     it('serialises the status filter in lowercase', async () => {
       mockFetch({ object: 'list', total: 1, data: [sampleWorkspace] });
@@ -117,7 +134,16 @@ describe('AIGatewayWorkspacesClient', () => {
 
   describe('writes (admin plane)', () => {
     it('POSTs a create to the admin plane', async () => {
-      mockFetch({ id: wsId, slug: 'ws-new-000000', object: 'workspace' });
+      mockFetch({
+        id: wsId,
+        name: 'New',
+        slug: 'ws-new-000000',
+        description: 'x',
+        created_at: '2026-08-01T19:28:31.697Z',
+        last_updated_at: '2026-08-01T19:28:31.697Z',
+        scope_name: 'ws_new_000000',
+        object: 'workspace',
+      });
       await client.create({ name: 'New', scope_name: 'ws_new_000000', description: 'x' });
 
       expect(calledUrl()).toBe('https://admin.example.com/workspaces');
@@ -128,6 +154,48 @@ describe('AIGatewayWorkspacesClient', () => {
         scope_name: 'ws_new_000000',
         description: 'x',
       });
+    });
+
+    // Captured verbatim from a live create (TSG 1852583913, 2026-08-01). Workspaces are the
+    // exception to this subsystem's "receipt, not record" write pattern — configs, guardrails,
+    // providers, and deployments all return 4-5 field receipts; this returns most of the record.
+    it('parses the full observed create response', async () => {
+      mockFetch({
+        id: 'c3caae0a-1d18-44bf-8cf1-ada3d70de91e',
+        name: 'zz-sdk-probe',
+        slug: 'ws-zz-sdk-8bb9ca',
+        description: 'throwaway; validating SDK write paths',
+        created_at: '2026-08-01T19:28:31.697Z',
+        last_updated_at: '2026-08-01T19:28:31.697Z',
+        defaults: { metadata: { env: 'scratch' } },
+        users: [],
+        scope_name: 'ws_zzsdkprobe_tmp',
+        object: 'workspace',
+      });
+
+      const res = await client.create({ name: 'zz-sdk-probe', scope_name: 'ws_zzsdkprobe_tmp' });
+
+      // Typed access, no cast — this is the point of the named schema.
+      expect(res.id).toBe('c3caae0a-1d18-44bf-8cf1-ada3d70de91e');
+      expect(res.slug).toBe('ws-zz-sdk-8bb9ca');
+      expect(res.scope_name).toBe('ws_zzsdkprobe_tmp');
+      expect(res.users).toEqual([]);
+      expect(res.defaults).toEqual({ metadata: { env: 'scratch' } });
+    });
+
+    it('parses a create response with a null description', async () => {
+      mockFetch({
+        id: wsId,
+        name: 'n',
+        slug: 'ws-n-000000',
+        description: null,
+        created_at: '2026-08-01T19:28:31.697Z',
+        last_updated_at: '2026-08-01T19:28:31.697Z',
+        scope_name: 'ws_n_000000',
+        object: 'workspace',
+      });
+      const res = await client.create({ name: 'n', scope_name: 'ws_n_000000' });
+      expect(res.description).toBeNull();
     });
 
     it('requires name and scope_name before issuing a request', async () => {
@@ -149,6 +217,14 @@ describe('AIGatewayWorkspacesClient', () => {
       const init = calledInit();
       expect(init.method).toBe('PUT');
       expect(JSON.parse(init.body as string)).toEqual({ description: 'updated' });
+    });
+
+    // Verified live: update returns a literal empty object and the change persists (confirmed
+    // by a follow-up get). GatewayWriteResponse is the honest type for {}.
+    it('parses the empty-object update response', async () => {
+      mockFetch({});
+      const res = await client.update(wsId, { description: 'updated via SDK' });
+      expect(res).toEqual({});
     });
 
     // The API rejects an empty patch with AB01 "No update fields provided"; fail locally


### PR DESCRIPTION
## Summary

`workspaces.create()` returned the permissive `GatewayWriteResponse` placeholder, so `created.id` was `unknown` and every field needed a cast. Both write shapes are now observed live (full create → get → update → get → delete round-trip on TSG `1852583913`, 2026-08-01), so the *"Shape unverified against a live tenant"* markers are stale and the types can be real.

Motivated by the upcoming `prisma-airs-cli` work — a CLI building on this needs the create response typed, not `unknown`.

## Changes

**`create()` → new `GatewayWorkspaceCreateResponse`**

```
{ id, name, slug, description, created_at, last_updated_at, scope_name, object }
```

plus optional `defaults` and `users`. **Workspace create is the exception to this subsystem's "receipt, not record" pattern** — `configs`, `guardrails`, `providers`, and `deployments` each return 4–5 field receipts; this returns most of the record. It is still not the detail shape (`status`, `is_default`, `icon`, `usage_limits`, `rate_limits`, settings blocks are all absent), so `get()` is still needed for those. Conversely `users` appears only here.

**`update()` deliberately keeps `GatewayWriteResponse`.** The API returns a literal `{}`. `z.object({}).passthrough()` is the honest type; inventing a richer one would misrepresent the API. The write does persist — verified by a follow-up `get()` showing both `description` and nested `defaults.metadata` had taken.

## Two behaviours found while validating

- **Archived workspaces are unreachable via `get()`.** After `delete()` archives one, `get()` answers `404 AB08` for both UUID and slug, on either plane — while `list({ status: 'archived' })` still lists it. Reproduced against two separate archived workspaces, with an active workspace as control (resolves fine both ways). A 404 straight after a delete is expected, not a bug.
- **`status` disagrees between endpoints.** `list()` reports `'active'` for a workspace whose `get()` reports `null`. `GatewayWorkspaceDetail` now types `status` as nullable/optional so it is at least visible; the guide says prefer the list value and read `null` as "unknown", not "inactive".

Also promotes the `"No update fields provided"` note from inference to fact: it is a **misleading not-found**, confirmed by updating a real workspace with the same body shape that failed against a non-existent one.

## Testing

TDD. The meaningful red here was at the **type** level, not runtime — `GatewayWriteResponse` is passthrough, so `created.id` resolved fine at runtime while failing to typecheck:

```
error TS2322: Type 'unknown' is not assignable to type 'string'.
```

Green after the change, with no casts.

New tests use payloads captured verbatim from the live round-trip: the full create response, a create with `null` description, the empty-object update, and a parameterised case covering `status` as both `null` and a string. One pre-existing test used a minimal 3-field create mock that the now-stricter schema correctly rejects — given a realistic fixture, since its purpose is verb/URL/body assertion.

Full suite **1576 passed**. Lint, typecheck, format, and `docs:build` clean. Also re-parsed the real captured create payload through the new schema directly, not just fixtures.

Version bumped to **0.17.0** (minor — new exported type, no breaking change: `GatewayWorkspaceCreateResponse` is strictly more specific than what `create()` returned before).

Closes #215
